### PR TITLE
[3.0] Base tests for define and redefine

### DIFF
--- a/concept/migration/data-validation.feature
+++ b/concept/migration/data-validation.feature
@@ -3766,3 +3766,92 @@ Feature: Data validation
     When relation $rel remove 2 players for role(role1[]): $ent1
     When relation $rel remove 1 players for role(role1[]): $ent2
     Then transaction commits
+
+
+  Scenario: Can reset owns with existing instances
+    Given create attribute type: attr0
+    Given attribute(attr0) set value type: string
+    Given attribute(attr0) set annotation: @abstract
+    Given create attribute type: attr1
+    Given attribute(attr1) set supertype: attr0
+    Given create attribute type: attr2
+    Given attribute(attr2) set supertype: attr0
+    Given create attribute type: attr3
+    Given attribute(attr3) set supertype: attr0
+    Given create attribute type: ref
+    Given attribute(ref) set supertype: attr0
+    Given create entity type: ent
+    Given entity(ent) set owns: ref
+    Given entity(ent) set owns: attr1
+    Given entity(ent) set owns: attr2
+    Given entity(ent) set owns: attr3
+    Given entity(ent) get owns(attr2) set annotation: @card(0..3)
+    Then entity(ent) get owns(ref) get cardinality: @card(0..1)
+    Then entity(ent) get owns(attr1) get cardinality: @card(0..1)
+    Then entity(ent) get owns(attr2) get cardinality: @card(0..3)
+    Then entity(ent) get owns(attr3) get cardinality: @card(0..1)
+    Given transaction commits
+    Given connection open write transaction for database: typedb
+    When $ent = entity(ent) create new instance with key(ref): ent
+    When $attr1_0 = attribute(attr1) put instance with value: "val0"
+    When $attr2_0 = attribute(attr2) put instance with value: "val0"
+    When $attr2_1 = attribute(attr2) put instance with value: "val1"
+    When $attr2_2 = attribute(attr2) put instance with value: "val2"
+    When entity $ent set has: $attr1_0
+    When entity $ent set has: $attr2_0
+    When entity $ent set has: $attr2_1
+    When entity $ent set has: $attr2_2
+    When transaction commits
+    When connection open schema transaction for database: typedb
+    Then entity(ent) set owns: ref
+    Then entity(ent) set owns: attr1
+    Then entity(ent) set owns: attr2
+    Then entity(ent) set owns: attr3
+    Then entity(ent) get owns(ref) get cardinality: @card(0..1)
+    Then entity(ent) get owns(attr1) get cardinality: @card(0..1)
+    Then entity(ent) get owns(attr2) get cardinality: @card(0..3)
+    Then entity(ent) get owns(attr3) get cardinality: @card(0..1)
+    Then transaction commits
+
+
+  Scenario: Can reset plays with existing instances
+    Given create attribute type: ref
+    Given attribute(ref) set value type: string
+    Given create relation type: rel1
+    Given relation(rel1) create role: role
+    Given relation(rel1) set owns: ref
+    Given create relation type: rel2
+    Given relation(rel2) create role: role
+    Given relation(rel2) set owns: ref
+    Given create relation type: rel3
+    Given relation(rel3) create role: role
+    Given relation(rel3) set owns: ref
+    Given create entity type: ent
+    Given entity(ent) set owns: ref
+    Given entity(ent) set plays: rel1:role
+    Given entity(ent) set plays: rel2:role
+    Given entity(ent) set plays: rel3:role
+    Given entity(ent) get plays(rel2:role) set annotation: @card(0..1)
+    Then entity(ent) get plays(rel1:role) get cardinality: @card(0..)
+    Then entity(ent) get plays(rel2:role) get cardinality: @card(0..1)
+    Then entity(ent) get plays(rel3:role) get cardinality: @card(0..)
+    Given transaction commits
+    Given connection open write transaction for database: typedb
+    When $ent = entity(ent) create new instance with key(ref): ent
+    When $rel1_0 = relation(rel1) create new instance with key(ref): rel0
+    When $rel1_1 = relation(rel1) create new instance with key(ref): rel1
+    When $rel1_2 = relation(rel1) create new instance with key(ref): rel2
+    When $rel2_0 = relation(rel2) create new instance with key(ref): rel0
+    When relation $rel1_0 add player for role(role): $ent
+    When relation $rel1_1 add player for role(role): $ent
+    When relation $rel1_2 add player for role(role): $ent
+    When relation $rel2_0 add player for role(role): $ent
+    When transaction commits
+    When connection open schema transaction for database: typedb
+    Then entity(ent) set plays: rel1:role
+    Then entity(ent) set plays: rel2:role
+    Then entity(ent) set plays: rel3:role
+    Then entity(ent) get plays(rel1:role) get cardinality: @card(0..)
+    Then entity(ent) get plays(rel2:role) get cardinality: @card(0..1)
+    Then entity(ent) get plays(rel3:role) get cardinality: @card(0..)
+    Then transaction commits

--- a/concept/type/attributetype.feature
+++ b/concept/type/attributetype.feature
@@ -684,7 +684,7 @@ Feature: Concept Attribute Type
     Then attribute(email) get value type is none
     Then attribute(birthday) get value type is none
 
-  Scenario: Attribute type cannot set value type if it already inherits it
+  Scenario: Attribute type cannot set value type without value type annotations specialization if it already inherits it
     When create attribute type: name
     When attribute(name) set value type: string
     When attribute(name) set annotation: @abstract
@@ -706,7 +706,63 @@ Feature: Concept Attribute Type
     When transaction commits
     When connection open read transaction for database: typedb
     Then attribute(name) get value type: string
+    Then attribute(name) get value type declared: string
     Then attribute(surname) get value type: string
+    Then attribute(surname) get value type declared is none
+
+  Scenario Outline: Attribute type cannot set value type without value type annotations specialization if it already inherits it (has <annotation> specialization)
+    When create attribute type: name
+    When attribute(name) set value type: string
+    When attribute(name) set annotation: @abstract
+    Then attribute(name) get annotations contain: @abstract
+    When transaction commits
+    When connection open schema transaction for database: typedb
+    When create attribute type: surname
+    When attribute(surname) set supertype: name
+    When attribute(surname) set annotation: @<annotation>
+    When attribute(surname) set value type: string
+    Then transaction commits; fails
+    When connection open schema transaction for database: typedb
+    When create attribute type: surname
+    When attribute(surname) set value type: string
+    When attribute(surname) set supertype: name
+    When attribute(surname) set annotation: @<annotation>
+    Then transaction commits; fails
+    Examples:
+      | annotation  |
+      | abstract    |
+      | independent |
+
+  Scenario Outline: Attribute type can set value type if it already inherits it with value type @<annotation> specialization
+    When create attribute type: name
+    When attribute(name) set value type: string
+    When attribute(name) set annotation: @abstract
+    Then attribute(name) get annotations contain: @abstract
+    When transaction commits
+    When connection open schema transaction for database: typedb
+    When create attribute type: surname
+    When attribute(surname) set supertype: name
+    When attribute(surname) set value type: string
+    When attribute(surname) set annotation: @<annotation>
+    Then transaction commits
+    When connection open schema transaction for database: typedb
+    When create attribute type: third-name
+    When attribute(third-name) set value type: string
+    When attribute(third-name) set annotation: @<annotation>
+    When attribute(third-name) set supertype: name
+    Then transaction commits
+    When connection open schema transaction for database: typedb
+    Then attribute(name) get value type: string
+    Then attribute(name) get value type declared: string
+    Then attribute(surname) get value type: string
+    Then attribute(surname) get value type declared: string
+    Then attribute(third-name) get value type: string
+    Then attribute(third-name) get value type declared: string
+    Examples:
+      | annotation      |
+      | regex("str")    |
+      | values("str")   |
+      | range("1".."2") |
 
   Scenario: Inherited attribute types without @abstract cannot be created without value type
     When create attribute type: name

--- a/concept/type/owns.feature
+++ b/concept/type/owns.feature
@@ -1805,3 +1805,24 @@ Feature: Concept Owns
       | root-type | supertype-name | subtype-name |
       | entity    | person         | customer     |
       | relation  | description    | registration |
+
+  Scenario Outline: <root-type> can't change supertype if override is lost even if it has another owns for the same attribute type
+    When <root-type>(<supertype-name-2>) unset supertype
+    When create attribute type: name
+    When attribute(name) set value type: <value-type>
+    When <root-type>(<supertype-name>) set owns: name
+    When <root-type>(<supertype-name>) get owns(name) set annotation: @card(0..7)
+    When <root-type>(<subtype-name>) set supertype: <supertype-name>
+    When <root-type>(<subtype-name>) set owns: name
+    When <root-type>(<subtype-name>) get owns(name) set override: name
+    When <root-type>(<subtype-name>) get owns(name) set annotation: @key
+    When <root-type>(<supertype-name-2>) set owns: name
+    Then <root-type>(<subtype-name>) set supertype: <supertype-name-2>; fails
+    When <root-type>(<subtype-name>) get owns(name) unset override
+    When <root-type>(<subtype-name>) set supertype: <supertype-name-2>
+    When <root-type>(<subtype-name>) get owns(name) set override: name
+    Then transaction commits
+    Examples:
+      | root-type | supertype-name | subtype-name | supertype-name-2 | value-type |
+      | entity    | person         | customer     | subscriber       | long       |
+      | relation  | description    | registration | profile          | date       |

--- a/concept/type/plays.feature
+++ b/concept/type/plays.feature
@@ -1142,6 +1142,26 @@ Feature: Concept Plays
       | entity    | person         | customer     |
       | relation  | description    | registration |
 
+  Scenario Outline: <root-type> can't change supertype if override is lost even if it has another plays for the same role type
+    When <root-type>(<supertype-name-2>) unset supertype
+    When create relation type: parentship
+    When relation(parentship) create role: parent
+    When <root-type>(<supertype-name>) set plays: parentship:parent
+    When <root-type>(<subtype-name>) set supertype: <supertype-name>
+    When <root-type>(<subtype-name>) set plays: parentship:parent
+    When <root-type>(<subtype-name>) get plays(parentship:parent) set override: parentship:parent
+    When <root-type>(<subtype-name>) get plays(parentship:parent) set annotation: @card(1..1)
+    When <root-type>(<supertype-name-2>) set plays: parentship:parent
+    Then <root-type>(<subtype-name>) set supertype: <supertype-name-2>; fails
+    When <root-type>(<subtype-name>) get plays(parentship:parent) unset override
+    When <root-type>(<subtype-name>) set supertype: <supertype-name-2>
+    When <root-type>(<subtype-name>) get plays(parentship:parent) set override: parentship:parent
+    Then transaction commits
+    Examples:
+      | root-type | supertype-name | subtype-name | supertype-name-2 |
+      | entity    | person         | customer     | subscriber       |
+      | relation  | description    | registration | profile          |
+
 ########################
 # plays from a list
 ########################

--- a/query/language/define.feature
+++ b/query/language/define.feature
@@ -336,6 +336,310 @@ Feature: TypeQL Define Query
       """
 
 
+  ###############
+  # ANNOTATIONS #
+  ###############
+
+  Scenario Outline: can set annotation @<annotation> to entity types
+    Then typeql define
+      """
+      define
+      entity player @<annotation>;
+      """
+    Then transaction commits
+    Examples:
+      | annotation |
+      | abstract   |
+
+
+  Scenario Outline: cannot set annotation @<annotation> to entity types
+    Then typeql define; fails
+      """
+      define
+      entity player @<annotation>;
+      """
+    Examples:
+      | annotation       |
+      | distinct         |
+      | independent      |
+      | unique           |
+      | key              |
+      | card(1..1)       |
+      | regex("val")     |
+      | cascade          |
+      | range("1".."2")  |
+      | values("1", "2") |
+
+
+  Scenario Outline: can set annotation @<annotation> to relation types
+    Then typeql define
+      """
+      define
+      relation parentship @<annotation>, relates parent;
+      """
+    Then transaction commits
+    Examples:
+      | annotation |
+      | abstract   |
+      | cascade    |
+
+
+  Scenario Outline: cannot set annotation @<annotation> to relation types
+    Then typeql define; fails
+      """
+      define
+      relation parentship @<annotation>, relates parent;
+      """
+    Examples:
+      | annotation       |
+      | distinct         |
+      | independent      |
+      | unique           |
+      | key              |
+      | card(1..1)       |
+      | regex("val")     |
+      | range("1".."2")  |
+      | values("1", "2") |
+
+
+  Scenario Outline: can set annotation @<annotation> to attribute types
+    Then typeql define
+      """
+      define
+      attribute description @<annotation>, value string;
+      """
+    Then transaction commits
+    Examples:
+      | annotation  |
+      | abstract    |
+      | independent |
+
+
+  Scenario Outline: cannot set annotation @<annotation> to attribute types
+    Then typeql define; fails
+      """
+      define
+      attribute description @<annotation>, value string;
+      """
+    Examples:
+      | annotation       |
+      | distinct         |
+      | unique           |
+      | key              |
+      | card(1..1)       |
+      | cascade          |
+      | regex("val")     |
+      | range("1".."2")  |
+      | values("1", "2") |
+
+
+  Scenario Outline: can set annotation @<annotation> to relates/role types
+    Then typeql define
+      """
+      define
+      relation parentship @abstract, relates parent @<annotation>;
+      """
+    Then transaction commits
+    Examples:
+      | annotation |
+      | abstract   |
+      | card(1..1) |
+
+
+  Scenario Outline: cannot set annotation @<annotation> to relates/role types
+    Then typeql define; fails
+      """
+      define
+      relation parentship @abstract, relates parent @<annotation>;
+      """
+    Examples:
+      | annotation       |
+      | distinct         |
+      | independent      |
+      | unique           |
+      | key              |
+      | cascade          |
+      | regex("val")     |
+      | range("1".."2")  |
+      | values("1", "2") |
+
+
+  Scenario Outline: can set annotation @<annotation> to relates/role types lists
+    Then typeql define
+      """
+      define
+      relation parentship @abstract, relates parent[] @<annotation>;
+      """
+    Then transaction commits
+    Examples:
+      | annotation |
+      | abstract   |
+      | card(1..1) |
+      | distinct   |
+
+
+  Scenario Outline: cannot set annotation @<annotation> to relates/role types lists
+    Then typeql define; fails
+      """
+      define
+      relation parentship @abstract, relates parent[] @<annotation>;
+      """
+    Examples:
+      | annotation       |
+      | independent      |
+      | unique           |
+      | key              |
+      | cascade          |
+      | regex("val")     |
+      | range("1".."2")  |
+      | values("1", "2") |
+
+
+  Scenario Outline: can set annotation @<annotation> to owns
+    Then typeql define
+      """
+      define
+      entity player owns name @<annotation>;
+      """
+    Then transaction commits
+    Examples:
+      | annotation       |
+      | card(1..1)       |
+      | unique           |
+      | key              |
+      | regex("val")     |
+      | range("1".."2")  |
+      | values("1", "2") |
+
+
+  Scenario Outline: cannot set annotation @<annotation> to owns
+    Then typeql define; fails
+      """
+      define
+      entity player owns name @<annotation>;
+      """
+    Examples:
+      | annotation  |
+      | abstract    |
+      | distinct    |
+      | independent |
+      | cascade     |
+
+
+  Scenario Outline: can set annotation @<annotation> to owns lists
+    Then typeql define
+      """
+      define
+      entity player owns name[] @<annotation>;
+      """
+    Then transaction commits
+    Examples:
+      | annotation       |
+      | distinct         |
+      | card(1..1)       |
+      | unique           |
+      | key              |
+      | regex("val")     |
+      | range("1".."2")  |
+      | values("1", "2") |
+
+
+  Scenario Outline: cannot set annotation @<annotation> to owns lists
+    Then typeql define; fails
+      """
+      define
+      entity player owns name[] @<annotation>;
+      """
+    Examples:
+      | annotation  |
+      | abstract    |
+      | independent |
+      | cascade     |
+
+
+  Scenario Outline: can set annotation @<annotation> to plays
+    Then typeql define
+      """
+      define
+      entity player plays employment:employee @<annotation>;
+      """
+    Then transaction commits
+    Examples:
+      | annotation |
+      | card(1..1) |
+
+
+  Scenario Outline: cannot set annotation @<annotation> to plays
+    Then typeql define; fails
+      """
+      define
+      entity player plays employment:employee @<annotation>;
+      """
+    Examples:
+      | annotation       |
+      | abstract         |
+      | distinct         |
+      | independent      |
+      | cascade          |
+      | unique           |
+      | key              |
+      | regex("val")     |
+      | range("1".."2")  |
+      | values("1", "2") |
+
+
+  Scenario Outline: can set annotation @<annotation> to value types
+    Then typeql define
+      """
+      define
+      attribute description value string @<annotation>;
+      """
+    Then transaction commits
+    Examples:
+      | annotation       |
+      | regex("val")     |
+      | range("1".."2")  |
+      | values("1", "2") |
+
+
+  Scenario Outline: cannot set annotation @<annotation> to value types
+    Then typeql define; fails
+      """
+      define
+      attribute description value string @<annotation>;
+      """
+    Examples:
+      | annotation  |
+      | abstract    |
+      | distinct    |
+      | independent |
+      | unique      |
+      | key         |
+      | card(1..1)  |
+      | cascade     |
+
+
+  Scenario Outline: cannot set annotation @<annotation> to subs
+    Then typeql define; fails
+      """
+      define
+      entity player sub person @<annotation>;
+      """
+    Examples:
+      | annotation       |
+      | abstract         |
+      | distinct         |
+      | independent      |
+      | unique           |
+      | key              |
+      | card(1..1)       |
+      | regex("val")     |
+      | cascade          |
+      | range("1".."2")  |
+      | values("1", "2") |
+
+    # TODO: Same "cannot set annotation" for alias?
+
 
   ##################
   # RELATION TYPES #
@@ -663,10 +967,18 @@ Feature: TypeQL Define Query
       | label:flight-attendant-employment |
 
 
-  Scenario: a relation type can be defined with no roleplayers when it is marked as @abstract
+  Scenario: a relation type cannot be defined with no roleplayers even if it is marked as @abstract
     When typeql define
       """
       define relation connection @abstract;
+      """
+    Then transaction commits; fails
+
+
+  Scenario: an abstract relation type can be defined with both abstract and concrete role types
+    When typeql define
+      """
+      define relation connection @abstract, relates from, relates to @abstract;
       """
     Then transaction commits
 
@@ -678,6 +990,28 @@ Feature: TypeQL Define Query
     Then uniquely identify answer concepts
       | x                |
       | label:connection |
+
+
+  Scenario: a concrete relation type cannot be defined with abstract role types
+    When typeql define
+      """
+      define relation connection relates from, relates to @abstract;
+      """
+    Then transaction commits; fails
+
+    When connection open schema transaction for database: typedb
+    When typeql define
+      """
+      define relation connection @abstract, relates to @abstract;
+      """
+    Then transaction commits; fails
+
+    When connection open schema transaction for database: typedb
+    When typeql define
+      """
+      define relation connection, relates from;
+      """
+    Then transaction commits
 
 
   Scenario: when defining a relation type, duplicate 'relates' are idempotent
@@ -735,7 +1069,7 @@ Feature: TypeQL Define Query
       """
       match
         $x type <label>;
-        $x sub attribute;
+        attribute $x;
       get;
       """
     Then answer size is: 1
@@ -750,10 +1084,19 @@ Feature: TypeQL Define Query
 
 
   Scenario: defining an attribute type throws if you don't specify a value type
-    Then typeql define; fails
+    When typeql define
       """
-      define colour sub attribute;
+      define attribute colour;
       """
+    Then transaction commits; fails
+
+
+  Scenario: defining an abstract attribute type does not throw if you don't specify a value type
+    When typeql define
+      """
+      define attribute colour @abstract;
+      """
+    Then transaction commits
 
 
   Scenario: defining an attribute type throws if the specified value type is not a recognised value type
@@ -808,14 +1151,27 @@ Feature: TypeQL Define Query
       define attribute code-name sub name, value long;
       """
 
+    When typeql define
+      """
+      define attribute code-name sub name; attribute code-name-2 value long;
+      """
 
+    Then typeql define; fails
+      """
+      define attribute code-name, value long;
+      """
+
+    Then typeql define; fails
+      """
+      define attribute code-name-2 sub name;
+      """
 
   # TODO: re-enable when fixed (currently gives wrong answer)
   @ignore
   Scenario: a regex constraint can be defined on a 'string' attribute type
     Given typeql define
       """
-      define attribute response value string, @regex("^(yes|no|maybe)$");
+      define attribute response @regex("^(yes|no|maybe)$"), value string;
       """
     Given transaction commits
 
@@ -832,7 +1188,7 @@ Feature: TypeQL Define Query
   Scenario: a regex constraint cannot be defined on an attribute type whose value type is anything other than 'string'
     Then typeql define; fails
       """
-      define attribute name-in-binary value long, @regex("^(0|1)+$");
+      define attribute name-in-binary @regex("^(0|1)+$"), value long;
       """
 
 
@@ -1150,9 +1506,9 @@ Feature: TypeQL Define Query
       match $t owns $a @unique; get;
       """
     Then uniquely identify answer concepts
-      | t             | a               |
-      | label:person  | label:phone-nr  |
-      | label:child   | label:phone-nr  |
+      | t            | a              |
+      | label:person | label:phone-nr |
+      | label:child  | label:phone-nr |
 
 
   Scenario: redefining inherited annotations throws
@@ -1185,9 +1541,9 @@ Feature: TypeQL Define Query
       match $t owns $a @unique; get;
       """
     Then uniquely identify answer concepts
-      | t             | a               |
-      | label:person  | label:phone-nr  |
-      | label:child   | label:mobile    |
+      | t            | a              |
+      | label:person | label:phone-nr |
+      | label:child  | label:mobile   |
     Given typeql define
       """
       define
@@ -1203,10 +1559,10 @@ Feature: TypeQL Define Query
       match $t owns $a @unique; get;
       """
     Then uniquely identify answer concepts
-      | t             | a                   |
-      | label:person  | label:phone-nr      |
-      | label:child   | label:mobile        |
-      | label:infant  | label:baby-phone-nr |
+      | t            | a                   |
+      | label:person | label:phone-nr      |
+      | label:child  | label:mobile        |
+      | label:infant | label:baby-phone-nr |
 
 
   Scenario: redefining inherited annotations on overrides throws
@@ -1230,7 +1586,7 @@ Feature: TypeQL Define Query
   Scenario: defining a less strict annotation on an inherited ownership throws
     Then typeql define; fails
       """
-      define child, owns email @unique;
+      define entity child, owns email @unique;
       """
 
 
@@ -1451,7 +1807,7 @@ Feature: TypeQL Define Query
     Given connection open schema transaction for database: typedb
     When typeql define
       """
-      define name value string @regex("^A.*$");
+      define name @regex("^A.*$"), value string;
       """
     Then transaction commits
 
@@ -1492,7 +1848,7 @@ Feature: TypeQL Define Query
     Given connection open schema transaction for database: typedb
     Then typeql define; fails
       """
-      define house-number @regex("^A.*$)";
+      define house-number @regex("^A.*$");
       """
 
 
@@ -1562,7 +1918,11 @@ Feature: TypeQL Define Query
 
 
   Scenario: defining a uniqueness on existing ownership is possible if data conforms to uniqueness requirements
-    Given transaction closes
+    Given typeql define
+      """
+      define person owns name @card(0..);
+      """
+    Given transaction commits
     Given connection open write transaction for database: typedb
     When typeql insert
       """
@@ -1604,41 +1964,41 @@ Feature: TypeQL Define Query
       define person owns name @unique;
       """
 
-
-  Scenario: a key ownership can be converted to a unique ownership
-    Given transaction closes
-    Given connection open write transaction for database: typedb
-    Given typeql insert
-      """
-      insert
-      $x isa person, has email "jane@gmail.com";
-      $y isa person, has email "john@gmail.com";
-      """
-    Given transaction commits
-    Given connection open schema transaction for database: typedb
-    Given typeql define
-      """
-      define person owns email @unique;
-      """
-    Then transaction commits
-    Given connection open write transaction for database: typedb
-    When get answers of typeql get
-      """
-      match $x owns $y @unique; get;
-      """
-    Then uniquely identify answer concepts
-      | x            | y              |
-      | label:person | label:email    |
-      | label:person | label:phone-nr |
-    When get answers of typeql get
-      """
-      match person owns $y @key; get;
-      """
-    Then answer size is: 0
-    Given typeql insert; fails
-      """
-      insert $x isa person, has email "jane@gmail.com";
-      """
+## TODO: Move to redefine!
+#  Scenario: a key ownership can be converted to a unique ownership
+#    Given transaction closes
+#    Given connection open write transaction for database: typedb
+#    Given typeql insert
+#      """
+#      insert
+#      $x isa person, has email "jane@gmail.com";
+#      $y isa person, has email "john@gmail.com";
+#      """
+#    Given transaction commits
+#    Given connection open schema transaction for database: typedb
+#    Given typeql define
+#      """
+#      define person owns email @unique;
+#      """
+#    Then transaction commits
+#    Given connection open write transaction for database: typedb
+#    When get answers of typeql get
+#      """
+#      match $x owns $y @unique; get;
+#      """
+#    Then uniquely identify answer concepts
+#      | x            | y              |
+#      | label:person | label:email    |
+#      | label:person | label:phone-nr |
+#    When get answers of typeql get
+#      """
+#      match person owns $y @key; get;
+#      """
+#    Then answer size is: 0
+#    Given typeql insert; fails
+#      """
+#      insert $x isa person, has email "jane@gmail.com";
+#      """
 
 
   Scenario: ownership uniqueness can be removed
@@ -1656,45 +2016,46 @@ Feature: TypeQL Define Query
       """
     Given transaction commits
 
-
-  Scenario: converting unique to key is possible if the data conforms to key requirements
-    Given transaction closes
-    Given connection open write transaction for database: typedb
-    Given typeql insert
-      """
-      insert
-      $x isa person, has phone-nr "123", has email "abc@gmail.com";
-      $y isa person, has phone-nr "456", has email "xyz@gmail.com";
-      """
-    Given transaction commits
-    Given connection open schema transaction for database: typedb
-    Given typeql define
-      """
-      define
-      person owns phone-nr @key;
-      """
-    Then transaction commits
-    Given connection open write transaction for database: typedb
-    Then typeql insert; fails
-      """
-      insert $x isa person, has phone-nr "9999", has phone-nr "8888", has email "pqr@gmail.com";
-      """
-
-
-  Scenario: converting unique to key fails if the data does not conform to key requirements
-    Given transaction closes
-    Given connection open write transaction for database: typedb
-    Given typeql insert
-      """
-      insert $x isa person, has phone-nr "123", has phone-nr "456", has email "abc@gmail.com";
-      """
-    Given transaction commits
-    Given connection open schema transaction for database: typedb
-    Then typeql define; fails
-      """
-      define
-      person owns phone-nr @key;
-      """
+#
+## TODO: Move to redefine!
+#  Scenario: converting unique to key is possible if the data conforms to key requirements
+#    Given transaction closes
+#    Given connection open write transaction for database: typedb
+#    Given typeql insert
+#      """
+#      insert
+#      $x isa person, has phone-nr "123", has email "abc@gmail.com";
+#      $y isa person, has phone-nr "456", has email "xyz@gmail.com";
+#      """
+#    Given transaction commits
+#    Given connection open schema transaction for database: typedb
+#    Given typeql define
+#      """
+#      define
+#      person owns phone-nr @key;
+#      """
+#    Then transaction commits
+#    Given connection open write transaction for database: typedb
+#    Then typeql insert; fails
+#      """
+#      insert $x isa person, has phone-nr "9999", has phone-nr "8888", has email "pqr@gmail.com";
+#      """
+#
+## TODO: Move to redefine!
+#  Scenario: converting unique to key fails if the data does not conform to key requirements
+#    Given transaction closes
+#    Given connection open write transaction for database: typedb
+#    Given typeql insert
+#      """
+#      insert $x isa person, has phone-nr "123", has phone-nr "456", has email "abc@gmail.com";
+#      """
+#    Given transaction commits
+#    Given connection open schema transaction for database: typedb
+#    Then typeql define; fails
+#      """
+#      define
+#      person owns phone-nr @key;
+#      """
 
 
   #############################
@@ -1864,7 +2225,7 @@ Feature: TypeQL Define Query
     Given typeql define
       """
       define
-      attribute measure value double @abstract;
+      attribute measure @abstract, value double;
       attribute shoe-size sub measure;
       entity shoe owns shoe-size;
       """
@@ -1884,6 +2245,7 @@ Feature: TypeQL Define Query
       attribute size value double @abstract;
       attribute shoe-size sub size;
       """
+    # TODO: This will probably fail because of the value type redundancy. Move this test to redefine/undefine?
     Then transaction commits
 
     When connection open read transaction for database: typedb
@@ -2099,11 +2461,11 @@ Feature: TypeQL Define Query
       match $x type child, owns $y; get;
       """
     Then uniquely identify answer concepts
-      | x           | y                  |
-      | label:child | label:name         |
-      | label:child | label:mobile       |
-      | label:child | label:email        |
-      | label:child | label:phone-nr     |
+      | x           | y              |
+      | label:child | label:name     |
+      | label:child | label:mobile   |
+      | label:child | label:email    |
+      | label:child | label:phone-nr |
 
 
   Scenario: when adding a key ownership to an existing type, the change is propagated to its subtypes
@@ -2156,12 +2518,14 @@ Feature: TypeQL Define Query
       """
       define entity dog;
       """
+    # TODO: The current framework doesn't support another transaction from the same client without closing the
+    # already existing one. It might contradict the test!
+    Given transaction closes
     Given connection open read transaction for database: typedb
     Then typeql get; fails
       """
       match $x type dog; get;
       """
-
 
 
   ########################
@@ -2222,44 +2586,44 @@ Feature: TypeQL Define Query
       """
       define
 
-      relation apple @abstract, plays huge-apple:grows-from;
+      relation apple @abstract, relates source @abstract, plays huge-apple:grows-from;
       relation big-apple @abstract, sub apple;
-      relation huge-apple sub big-apple, relates tree, relates grows-from;
+      relation huge-apple sub big-apple, relates tree as source, relates grows-from;
 
-      relation banana @abstract, plays huge-banana:grows-from;
+      relation banana @abstract, relates source @abstract, plays huge-banana:grows-from;
       relation big-banana @abstract, sub banana;
-      relation huge-banana sub big-banana, relates tree, relates grows-from;
+      relation huge-banana sub big-banana, relates tree as source, relates grows-from;
 
-      relation orange @abstract, plays huge-orange:grows-from;
+      relation orange @abstract, relates source @abstract, plays huge-orange:grows-from;
       relation big-orange @abstract, sub orange;
-      relation huge-orange sub big-orange, relates tree, relates grows-from;
+      relation huge-orange sub big-orange, relates tree as source, relates grows-from;
 
-      relation pear @abstract, plays huge-pear:grows-from;
+      relation pear @abstract, relates source @abstract, plays huge-pear:grows-from;
       relation big-pear @abstract, sub pear;
-      relation huge-pear sub big-pear, relates tree, relates grows-from;
+      relation huge-pear sub big-pear, relates tree as source, relates grows-from;
 
-      relation tomato @abstract, plays huge-tomato:grows-from;
+      relation tomato @abstract, relates source @abstract, plays huge-tomato:grows-from;
       relation big-tomato @abstract, sub tomato;
-      relation huge-tomato sub big-tomato, relates tree, relates grows-from;
+      relation huge-tomato sub big-tomato, relates tree as source, relates grows-from;
 
-      relation watermelon @abstract, plays huge-watermelon:grows-from;
+      relation watermelon @abstract, relates source @abstract, plays huge-watermelon:grows-from;
       relation big-watermelon @abstract, sub watermelon;
-      relation huge-watermelon sub big-watermelon, relates tree, relates grows-from;
+      relation huge-watermelon sub big-watermelon, relates tree as source, relates grows-from;
 
-      relation lemon @abstract, plays huge-lemon:grows-from;
+      relation lemon @abstract, relates source @abstract, plays huge-lemon:grows-from;
       relation big-lemon @abstract, sub lemon;
-      relation huge-lemon sub big-lemon, relates tree, relates grows-from;
+      relation huge-lemon sub big-lemon, relates tree as source, relates grows-from;
 
-      relation lime @abstract, plays huge-lime:grows-from;
+      relation lime @abstract, relates source @abstract, plays huge-lime:grows-from;
       relation big-lime @abstract, sub lime;
-      relation huge-lime sub big-lime, relates tree, relates grows-from;
+      relation huge-lime sub big-lime, relates tree as source, relates grows-from;
 
-      relation mango @abstract, plays huge-mango:grows-from;
+      relation mango @abstract, relates source @abstract, plays huge-mango:grows-from;
       relation big-mango @abstract, sub mango;
-      relation huge-mango sub big-mango, relates tree, relates grows-from;
+      relation huge-mango sub big-mango, relates tree as source, relates grows-from;
 
-      relation pineapple @abstract, plays huge-pineapple:grows-from;
+      relation pineapple @abstract, relates source @abstract, plays huge-pineapple:grows-from;
       relation big-pineapple @abstract, sub pineapple;
-      relation huge-pineapple sub big-pineapple, relates tree, relates grows-from;
+      relation huge-pineapple sub big-pineapple, relates tree as source, relates grows-from;
       """
     Then transaction commits

--- a/query/language/define.feature
+++ b/query/language/define.feature
@@ -550,7 +550,7 @@ Feature: TypeQL Define Query
       | role scoped label | locates:located |
 
 
-  Scenario Outline: types should be able to define roles they play with an override using <mode>
+  Scenario Outline: types should not be able to define roles they play with an incorrect override of <mode>
     Then typeql define<failure>
       """
         define
@@ -563,7 +563,6 @@ Feature: TypeQL Define Query
     Examples:
       | mode                     | as-label                              | failure         |
       | builtin kind             | entity                                | ; parsing fails |
-    # TODO: Parser allows builtin types here for simplicity, it would be cleaner to accept only label and scoped_label
       | builtin type             | string                                | ; fails         |
       | name:name without scope  | locates:locates                       | ; fails         |
       | scope:scope without name | located:located                       | ; fails         |

--- a/query/language/define.feature
+++ b/query/language/define.feature
@@ -2673,3 +2673,6 @@ Feature: TypeQL Define Query
       relation huge-pineapple sub big-pineapple, relates tree as source, relates grows-from;
       """
     Then transaction commits
+
+    # TODO 3.0: Add tests for structs
+    # TODO 3.0: Add tests for functions

--- a/query/language/define.feature
+++ b/query/language/define.feature
@@ -10,8 +10,6 @@ Feature: TypeQL Define Query
     Given connection opens with default authentication
     Given connection has been opened
     Given connection reset database: typedb
-#    Given connection does not have any database
-#    Given connection create database: typedb
     Given connection open schema transaction for database: typedb
 
     Given typeql define
@@ -336,311 +334,6 @@ Feature: TypeQL Define Query
       """
 
 
-  ###############
-  # ANNOTATIONS #
-  ###############
-
-  Scenario Outline: can set annotation @<annotation> to entity types
-    Then typeql define
-      """
-      define
-      entity player @<annotation>;
-      """
-    Then transaction commits
-    Examples:
-      | annotation |
-      | abstract   |
-
-
-  Scenario Outline: cannot set annotation @<annotation> to entity types
-    Then typeql define; fails
-      """
-      define
-      entity player @<annotation>;
-      """
-    Examples:
-      | annotation       |
-      | distinct         |
-      | independent      |
-      | unique           |
-      | key              |
-      | card(1..1)       |
-      | regex("val")     |
-      | cascade          |
-      | range("1".."2")  |
-      | values("1", "2") |
-
-
-  Scenario Outline: can set annotation @<annotation> to relation types
-    Then typeql define
-      """
-      define
-      relation parentship @<annotation>, relates parent;
-      """
-    Then transaction commits
-    Examples:
-      | annotation |
-      | abstract   |
-      | cascade    |
-
-
-  Scenario Outline: cannot set annotation @<annotation> to relation types
-    Then typeql define; fails
-      """
-      define
-      relation parentship @<annotation>, relates parent;
-      """
-    Examples:
-      | annotation       |
-      | distinct         |
-      | independent      |
-      | unique           |
-      | key              |
-      | card(1..1)       |
-      | regex("val")     |
-      | range("1".."2")  |
-      | values("1", "2") |
-
-
-  Scenario Outline: can set annotation @<annotation> to attribute types
-    Then typeql define
-      """
-      define
-      attribute description @<annotation>, value string;
-      """
-    Then transaction commits
-    Examples:
-      | annotation  |
-      | abstract    |
-      | independent |
-
-
-  Scenario Outline: cannot set annotation @<annotation> to attribute types
-    Then typeql define; fails
-      """
-      define
-      attribute description @<annotation>, value string;
-      """
-    Examples:
-      | annotation       |
-      | distinct         |
-      | unique           |
-      | key              |
-      | card(1..1)       |
-      | cascade          |
-      | regex("val")     |
-      | range("1".."2")  |
-      | values("1", "2") |
-
-
-  Scenario Outline: can set annotation @<annotation> to relates/role types
-    Then typeql define
-      """
-      define
-      relation parentship @abstract, relates parent @<annotation>;
-      """
-    Then transaction commits
-    Examples:
-      | annotation |
-      | abstract   |
-      | card(1..1) |
-
-
-  Scenario Outline: cannot set annotation @<annotation> to relates/role types
-    Then typeql define; fails
-      """
-      define
-      relation parentship @abstract, relates parent @<annotation>;
-      """
-    Examples:
-      | annotation       |
-      | distinct         |
-      | independent      |
-      | unique           |
-      | key              |
-      | cascade          |
-      | regex("val")     |
-      | range("1".."2")  |
-      | values("1", "2") |
-
-
-  Scenario Outline: can set annotation @<annotation> to relates/role types lists
-    Then typeql define
-      """
-      define
-      relation parentship @abstract, relates parent[] @<annotation>;
-      """
-    Then transaction commits
-    Examples:
-      | annotation |
-      | abstract   |
-      | card(1..1) |
-      | distinct   |
-
-
-  Scenario Outline: cannot set annotation @<annotation> to relates/role types lists
-    Then typeql define; fails
-      """
-      define
-      relation parentship @abstract, relates parent[] @<annotation>;
-      """
-    Examples:
-      | annotation       |
-      | independent      |
-      | unique           |
-      | key              |
-      | cascade          |
-      | regex("val")     |
-      | range("1".."2")  |
-      | values("1", "2") |
-
-
-  Scenario Outline: can set annotation @<annotation> to owns
-    Then typeql define
-      """
-      define
-      entity player owns name @<annotation>;
-      """
-    Then transaction commits
-    Examples:
-      | annotation       |
-      | card(1..1)       |
-      | unique           |
-      | key              |
-      | regex("val")     |
-      | range("1".."2")  |
-      | values("1", "2") |
-
-
-  Scenario Outline: cannot set annotation @<annotation> to owns
-    Then typeql define; fails
-      """
-      define
-      entity player owns name @<annotation>;
-      """
-    Examples:
-      | annotation  |
-      | abstract    |
-      | distinct    |
-      | independent |
-      | cascade     |
-
-
-  Scenario Outline: can set annotation @<annotation> to owns lists
-    Then typeql define
-      """
-      define
-      entity player owns name[] @<annotation>;
-      """
-    Then transaction commits
-    Examples:
-      | annotation       |
-      | distinct         |
-      | card(1..1)       |
-      | unique           |
-      | key              |
-      | regex("val")     |
-      | range("1".."2")  |
-      | values("1", "2") |
-
-
-  Scenario Outline: cannot set annotation @<annotation> to owns lists
-    Then typeql define; fails
-      """
-      define
-      entity player owns name[] @<annotation>;
-      """
-    Examples:
-      | annotation  |
-      | abstract    |
-      | independent |
-      | cascade     |
-
-
-  Scenario Outline: can set annotation @<annotation> to plays
-    Then typeql define
-      """
-      define
-      entity player plays employment:employee @<annotation>;
-      """
-    Then transaction commits
-    Examples:
-      | annotation |
-      | card(1..1) |
-
-
-  Scenario Outline: cannot set annotation @<annotation> to plays
-    Then typeql define; fails
-      """
-      define
-      entity player plays employment:employee @<annotation>;
-      """
-    Examples:
-      | annotation       |
-      | abstract         |
-      | distinct         |
-      | independent      |
-      | cascade          |
-      | unique           |
-      | key              |
-      | regex("val")     |
-      | range("1".."2")  |
-      | values("1", "2") |
-
-
-  Scenario Outline: can set annotation @<annotation> to value types
-    Then typeql define
-      """
-      define
-      attribute description value string @<annotation>;
-      """
-    Then transaction commits
-    Examples:
-      | annotation       |
-      | regex("val")     |
-      | range("1".."2")  |
-      | values("1", "2") |
-
-
-  Scenario Outline: cannot set annotation @<annotation> to value types
-    Then typeql define; fails
-      """
-      define
-      attribute description value string @<annotation>;
-      """
-    Examples:
-      | annotation  |
-      | abstract    |
-      | distinct    |
-      | independent |
-      | unique      |
-      | key         |
-      | card(1..1)  |
-      | cascade     |
-
-
-  Scenario Outline: cannot set annotation @<annotation> to subs
-    Then typeql define; fails
-      """
-      define
-      entity player sub person @<annotation>;
-      """
-    Examples:
-      | annotation       |
-      | abstract         |
-      | distinct         |
-      | independent      |
-      | unique           |
-      | key              |
-      | card(1..1)       |
-      | regex("val")     |
-      | cascade          |
-      | range("1".."2")  |
-      | values("1", "2") |
-
-    # TODO: Same "cannot set annotation" for alias?
-
-
   ##################
   # RELATION TYPES #
   ##################
@@ -705,8 +398,39 @@ Feature: TypeQL Define Query
       | label:employment           |
       | label:part-time-employment |
 
-  # TODO: Why does this have no body?
   Scenario: a newly defined relation subtype inherits roles from all of its supertypes
+    Given typeql define
+      """
+      define relation part-time-employment sub employment, relates shift;
+      define relation student-part-time-employment sub part-time-employment, relates student-document;
+      """
+    Given transaction commits
+
+    Given connection open read transaction for database: typedb
+    When get answers of typeql get
+      """
+      match $x relates employee; get;
+      """
+    Then uniquely identify answer concepts
+      | x                                  |
+      | label:employment                   |
+      | label:part-time-employment         |
+      | label:student-part-time-employment |
+    When get answers of typeql get
+      """
+      match $x relates shift; get;
+      """
+    Then uniquely identify answer concepts
+      | x                                  |
+      | label:part-time-employment         |
+      | label:student-part-time-employment |
+    When get answers of typeql get
+      """
+      match $x relates student-document; get;
+      """
+    Then uniquely identify answer concepts
+      | x                                  |
+      | label:student-part-time-employment |
 
 
   Scenario: a relation type's role can be overridden in a child relation type using 'as'
@@ -1261,6 +985,311 @@ Feature: TypeQL Define Query
 #  Scenario Outline: a type can own a '<value_type>' attribute type as a key
 #
 #  Scenario Outline: a '<value_type>' attribute type is not allowed to be a key
+
+
+  ###############
+  # ANNOTATIONS #
+  ###############
+
+  Scenario Outline: can set annotation @<annotation> to entity types
+    Then typeql define
+      """
+      define
+      entity player @<annotation>;
+      """
+    Then transaction commits
+    Examples:
+      | annotation |
+      | abstract   |
+
+
+  Scenario Outline: cannot set annotation @<annotation> to entity types
+    Then typeql define; fails
+      """
+      define
+      entity player @<annotation>;
+      """
+    Examples:
+      | annotation       |
+      | distinct         |
+      | independent      |
+      | unique           |
+      | key              |
+      | card(1..1)       |
+      | regex("val")     |
+      | cascade          |
+      | range("1".."2")  |
+      | values("1", "2") |
+
+
+  Scenario Outline: can set annotation @<annotation> to relation types
+    Then typeql define
+      """
+      define
+      relation parentship @<annotation>, relates parent;
+      """
+    Then transaction commits
+    Examples:
+      | annotation |
+      | abstract   |
+      | cascade    |
+
+
+  Scenario Outline: cannot set annotation @<annotation> to relation types
+    Then typeql define; fails
+      """
+      define
+      relation parentship @<annotation>, relates parent;
+      """
+    Examples:
+      | annotation       |
+      | distinct         |
+      | independent      |
+      | unique           |
+      | key              |
+      | card(1..1)       |
+      | regex("val")     |
+      | range("1".."2")  |
+      | values("1", "2") |
+
+
+  Scenario Outline: can set annotation @<annotation> to attribute types
+    Then typeql define
+      """
+      define
+      attribute description @<annotation>, value string;
+      """
+    Then transaction commits
+    Examples:
+      | annotation  |
+      | abstract    |
+      | independent |
+
+
+  Scenario Outline: cannot set annotation @<annotation> to attribute types
+    Then typeql define; fails
+      """
+      define
+      attribute description @<annotation>, value string;
+      """
+    Examples:
+      | annotation       |
+      | distinct         |
+      | unique           |
+      | key              |
+      | card(1..1)       |
+      | cascade          |
+      | regex("val")     |
+      | range("1".."2")  |
+      | values("1", "2") |
+
+
+  Scenario Outline: can set annotation @<annotation> to relates/role types
+    Then typeql define
+      """
+      define
+      relation parentship @abstract, relates parent @<annotation>;
+      """
+    Then transaction commits
+    Examples:
+      | annotation |
+      | abstract   |
+      | card(1..1) |
+
+
+  Scenario Outline: cannot set annotation @<annotation> to relates/role types
+    Then typeql define; fails
+      """
+      define
+      relation parentship @abstract, relates parent @<annotation>;
+      """
+    Examples:
+      | annotation       |
+      | distinct         |
+      | independent      |
+      | unique           |
+      | key              |
+      | cascade          |
+      | regex("val")     |
+      | range("1".."2")  |
+      | values("1", "2") |
+
+
+  Scenario Outline: can set annotation @<annotation> to relates/role types lists
+    Then typeql define
+      """
+      define
+      relation parentship @abstract, relates parent[] @<annotation>;
+      """
+    Then transaction commits
+    Examples:
+      | annotation |
+      | abstract   |
+      | card(1..1) |
+      | distinct   |
+
+
+  Scenario Outline: cannot set annotation @<annotation> to relates/role types lists
+    Then typeql define; fails
+      """
+      define
+      relation parentship @abstract, relates parent[] @<annotation>;
+      """
+    Examples:
+      | annotation       |
+      | independent      |
+      | unique           |
+      | key              |
+      | cascade          |
+      | regex("val")     |
+      | range("1".."2")  |
+      | values("1", "2") |
+
+
+  Scenario Outline: can set annotation @<annotation> to owns
+    Then typeql define
+      """
+      define
+      entity player owns name @<annotation>;
+      """
+    Then transaction commits
+    Examples:
+      | annotation       |
+      | card(1..1)       |
+      | unique           |
+      | key              |
+      | regex("val")     |
+      | range("1".."2")  |
+      | values("1", "2") |
+
+
+  Scenario Outline: cannot set annotation @<annotation> to owns
+    Then typeql define; fails
+      """
+      define
+      entity player owns name @<annotation>;
+      """
+    Examples:
+      | annotation  |
+      | abstract    |
+      | distinct    |
+      | independent |
+      | cascade     |
+
+
+  Scenario Outline: can set annotation @<annotation> to owns lists
+    Then typeql define
+      """
+      define
+      entity player owns name[] @<annotation>;
+      """
+    Then transaction commits
+    Examples:
+      | annotation       |
+      | distinct         |
+      | card(1..1)       |
+      | unique           |
+      | key              |
+      | regex("val")     |
+      | range("1".."2")  |
+      | values("1", "2") |
+
+
+  Scenario Outline: cannot set annotation @<annotation> to owns lists
+    Then typeql define; fails
+      """
+      define
+      entity player owns name[] @<annotation>;
+      """
+    Examples:
+      | annotation  |
+      | abstract    |
+      | independent |
+      | cascade     |
+
+
+  Scenario Outline: can set annotation @<annotation> to plays
+    Then typeql define
+      """
+      define
+      entity player plays employment:employee @<annotation>;
+      """
+    Then transaction commits
+    Examples:
+      | annotation |
+      | card(1..1) |
+
+
+  Scenario Outline: cannot set annotation @<annotation> to plays
+    Then typeql define; fails
+      """
+      define
+      entity player plays employment:employee @<annotation>;
+      """
+    Examples:
+      | annotation       |
+      | abstract         |
+      | distinct         |
+      | independent      |
+      | cascade          |
+      | unique           |
+      | key              |
+      | regex("val")     |
+      | range("1".."2")  |
+      | values("1", "2") |
+
+
+  Scenario Outline: can set annotation @<annotation> to value types
+    Then typeql define
+      """
+      define
+      attribute description value string @<annotation>;
+      """
+    Then transaction commits
+    Examples:
+      | annotation       |
+      | regex("val")     |
+      | range("1".."2")  |
+      | values("1", "2") |
+
+
+  Scenario Outline: cannot set annotation @<annotation> to value types
+    Then typeql define; fails
+      """
+      define
+      attribute description value string @<annotation>;
+      """
+    Examples:
+      | annotation  |
+      | abstract    |
+      | distinct    |
+      | independent |
+      | unique      |
+      | key         |
+      | card(1..1)  |
+      | cascade     |
+
+
+  Scenario Outline: cannot set annotation @<annotation> to subs
+    Then typeql define; fails
+      """
+      define
+      entity player sub person @<annotation>;
+      """
+    Examples:
+      | annotation       |
+      | abstract         |
+      | distinct         |
+      | independent      |
+      | unique           |
+      | key              |
+      | card(1..1)       |
+      | regex("val")     |
+      | cascade          |
+      | range("1".."2")  |
+      | values("1", "2") |
+
+    # TODO: Same "cannot set annotation" for alias when aliases are implemented?
 
 
   ##################
@@ -1885,7 +1914,6 @@ Feature: TypeQL Define Query
       """
 
 
-    # TODO: Write a successful test with redefine!
   Scenario: the value type of an existing attribute type is not modifiable through define
     Then typeql define; fails
       """
@@ -1984,42 +2012,6 @@ Feature: TypeQL Define Query
       define person owns name @unique;
       """
 
-## TODO: Move to redefine!
-#  Scenario: a key ownership can be converted to a unique ownership
-#    Given transaction closes
-#    Given connection open write transaction for database: typedb
-#    Given typeql insert
-#      """
-#      insert
-#      $x isa person, has email "jane@gmail.com";
-#      $y isa person, has email "john@gmail.com";
-#      """
-#    Given transaction commits
-#    Given connection open schema transaction for database: typedb
-#    Given typeql define
-#      """
-#      define person owns email @unique;
-#      """
-#    Then transaction commits
-#    Given connection open write transaction for database: typedb
-#    When get answers of typeql get
-#      """
-#      match $x owns $y @unique; get;
-#      """
-#    Then uniquely identify answer concepts
-#      | x            | y              |
-#      | label:person | label:email    |
-#      | label:person | label:phone-nr |
-#    When get answers of typeql get
-#      """
-#      match person owns $y @key; get;
-#      """
-#    Then answer size is: 0
-#    Given typeql insert; fails
-#      """
-#      insert $x isa person, has email "jane@gmail.com";
-#      """
-
 
   Scenario: ownership uniqueness can be removed
     Given typeql define
@@ -2035,47 +2027,6 @@ Feature: TypeQL Define Query
       $y isa person, has phone-nr "456", has email "xyz@gmail.com";
       """
     Given transaction commits
-
-#
-## TODO: Move to redefine!
-#  Scenario: converting unique to key is possible if the data conforms to key requirements
-#    Given transaction closes
-#    Given connection open write transaction for database: typedb
-#    Given typeql insert
-#      """
-#      insert
-#      $x isa person, has phone-nr "123", has email "abc@gmail.com";
-#      $y isa person, has phone-nr "456", has email "xyz@gmail.com";
-#      """
-#    Given transaction commits
-#    Given connection open schema transaction for database: typedb
-#    Given typeql define
-#      """
-#      define
-#      person owns phone-nr @key;
-#      """
-#    Then transaction commits
-#    Given connection open write transaction for database: typedb
-#    Then typeql insert; fails
-#      """
-#      insert $x isa person, has phone-nr "9999", has phone-nr "8888", has email "pqr@gmail.com";
-#      """
-#
-## TODO: Move to redefine!
-#  Scenario: converting unique to key fails if the data does not conform to key requirements
-#    Given transaction closes
-#    Given connection open write transaction for database: typedb
-#    Given typeql insert
-#      """
-#      insert $x isa person, has phone-nr "123", has phone-nr "456", has email "abc@gmail.com";
-#      """
-#    Given transaction commits
-#    Given connection open schema transaction for database: typedb
-#    Then typeql define; fails
-#      """
-#      define
-#      person owns phone-nr @key;
-#      """
 
 
   #############################
@@ -2210,34 +2161,6 @@ Feature: TypeQL Define Query
   # HIERARCHY MUTATION #
   ######################
 
-  # TODO: Move to redefine
-#  Scenario: an existing entity type can be switched to a new supertype
-#    Given typeql define
-#      """
-#      define
-#      entity apple-product;
-#      entity genius sub person;
-#      """
-#    Given transaction commits
-#
-#    Given connection open schema transaction for database: typedb
-#    When typeql define
-#      """
-#      define
-#      entity genius sub apple-product;
-#      """
-#    Then transaction commits
-#
-#    Given connection open read transaction for database: typedb
-#    When get answers of typeql get
-#      """
-#      match $x sub apple-product; get;
-#      """
-#    Then uniquely identify answer concepts
-#      | x                   |
-#      | label:apple-product |
-#      | label:genius        |
-
 
   Scenario: an existing entity type cannot be switched to a new supertype through define
     Given typeql define
@@ -2254,35 +2177,6 @@ Feature: TypeQL Define Query
       define
       entity genius sub apple-product;
       """
-
-
-  # TODO: Move to redefine
-#  Scenario: an existing relation type can be switched to a new supertype
-#    Given typeql define
-#      """
-#      define
-#      relation sabbatical sub employment;
-#      relation vacation relates employee;
-#      """
-#    Given transaction commits
-#
-#    Given connection open schema transaction for database: typedb
-#    When typeql define
-#      """
-#      define
-#      relation sabbatical sub vacation;
-#      """
-#    Then transaction commits
-#
-#    Given connection open read transaction for database: typedb
-#    When get answers of typeql get
-#      """
-#      match $x sub vacation; get;
-#      """
-#    Then uniquely identify answer concepts
-#      | x                |
-#      | label:vacation   |
-#      | label:sabbatical |
 
 
   Scenario: an existing relation type cannot be switched to a new supertype through define
@@ -2370,150 +2264,6 @@ Feature: TypeQL Define Query
       | label:organism |
       | label:person   |
       | label:child    |
-
-
-    # TODO: Move to redefine
-#  Scenario: assigning a supertype while having another supertype succeeds even if they have different attributes + roles, if there are no instances
-#    Given typeql define
-#      """
-#      define
-#      entity person sub species;
-#      entity species owns name, plays species-membership:species;
-#      relation species-membership relates species, relates member;
-#      attribute lifespan value double;
-#      entity organism owns lifespan, plays species-membership:member;
-#      entity child sub person;
-#      """
-#    Given transaction commits
-#
-#    Given connection open schema transaction for database: typedb
-#    When typeql define
-#      """
-#      define
-#      entity person sub organism;
-#      """
-#    Then transaction commits
-#
-#    Given connection open read transaction for database: typedb
-#    When get answers of typeql get
-#      """
-#      match $x sub organism; get;
-#      """
-#    Then uniquely identify answer concepts
-#      | x              |
-#      | label:organism |
-#      | label:person   |
-#      | label:child    |
-
-
-  # TODO: Move to redefine
-#  Scenario: assigning a new supertype when having other sub succeeds even with existing data if the supertypes have no properties
-#    Given typeql define
-#      """
-#      define
-#      entity bird;
-#      entity pigeon sub bird;
-#      """
-#    Given transaction commits
-#
-#    Given connection open write transaction for database: typedb
-#    Given typeql insert
-#      """
-#      insert $p isa pigeon;
-#      """
-#    Given transaction commits
-#
-#    Given connection open schema transaction for database: typedb
-#    When typeql define
-#      """
-#      define
-#      entity animal;
-#      entity pigeon sub animal;
-#      """
-#    Then transaction commits
-#
-#    Given connection open read transaction for database: typedb
-#    When get answers of typeql get
-#      """
-#      match $x sub pigeon; get;
-#      """
-#    Then uniquely identify answer concepts
-#      | x            |
-#      | label:pigeon |
-
-
-    # TODO: Move to redefine!
-#  Scenario: assigning a new supertype when having other sub succeeds with existing data if the supertypes play the same roles
-#    Given typeql define
-#      """
-#      define
-#      entity bird plays flying:flier;
-#      entity pigeon sub bird;
-#      relation flying relates flier;
-#      """
-#    Given transaction commits
-#
-#    Given connection open write transaction for database: typedb
-#    Given typeql insert
-#      """
-#      insert $p isa pigeon;
-#      """
-#    Given transaction commits
-#
-#    Given connection open schema transaction for database: typedb
-#    When typeql define
-#      """
-#      define
-#      entity animal plays flying:flier;
-#      entity pigeon sub animal;
-#      """
-#    Then transaction commits
-#
-#    Given connection open read transaction for database: typedb
-#    When get answers of typeql get
-#      """
-#      match $x sub pigeon; get;
-#      """
-#    Then uniquely identify answer concepts
-#      | x            |
-#      | label:pigeon |
-
-
-    # TODO: Move to redefine!
-#  Scenario: assigning a new supertype when having other sub succeeds with existing data if the supertypes have the same attributes
-#    Given typeql define
-#      """
-#      define
-#      attribute name value string;
-#      entity bird owns name;
-#      entity pigeon sub bird;
-#      """
-#    Given transaction commits
-#
-#    Given connection open write transaction for database: typedb
-#    Given typeql insert
-#      """
-#      insert $p isa pigeon;
-#      """
-#    Given transaction commits
-#
-#    Given connection open schema transaction for database: typedb
-#    When typeql define
-#      """
-#      define
-#      entity animal owns name;
-#      entity pigeon sub animal;
-#      """
-#    Then transaction commits
-#
-#    Given connection open read transaction for database: typedb
-#    When get answers of typeql get
-#      """
-#      match $x sub pigeon; get;
-#      """
-#    Then uniquely identify answer concepts
-#      | x            |
-#      | label:pigeon |
 
 
   Scenario: assigning a new supertype when having another supertype through define fails without preceding redefine/undefine

--- a/query/language/define.feature
+++ b/query/language/define.feature
@@ -1172,25 +1172,33 @@ Feature: TypeQL Define Query
 
   Scenario: defining an attribute subtype throws if it is given a different value type to what its parent has
     When typeql define
-    """
-    define attribute name @abstract;
-    """
+      """
+      define attribute name @abstract; entity person @abstract;
+      """
+    When transaction commits
 
+    When connection open schema transaction for database: typedb
     Then typeql define; fails
       """
       define attribute code-name sub name, value long;
       """
+    When transaction closes
 
+    When connection open schema transaction for database: typedb
     When typeql define
       """
       define attribute code-name sub name; attribute code-name-2 value long;
       """
+    When transaction commits
 
+    When connection open schema transaction for database: typedb
     Then typeql define; fails
       """
       define attribute code-name value long;
       """
+    When transaction closes
 
+    When connection open schema transaction for database: typedb
     Then typeql define; fails
       """
       define attribute code-name-2 sub name;

--- a/query/language/define.feature
+++ b/query/language/define.feature
@@ -100,7 +100,7 @@ Feature: TypeQL Define Query
 
 
   Scenario: types cannot play entity types
-    Then typeql define; fails
+    Then typeql define; parsing fails
       """
       define entity parrot plays person;
       """
@@ -316,21 +316,21 @@ Feature: TypeQL Define Query
 
 
   Scenario: defining a thing with 'isa' is not possible in a 'define' query
-    Then typeql define; fails
+    Then typeql define; parsing fails
       """
       define $p isa person;
       """
 
 
   Scenario: adding an attribute instance to a thing is not possible in a 'define' query
-    Then typeql define; fails
+    Then typeql define; parsing fails
       """
       define $p has name "Loch Ness Monster";
       """
 
 
   Scenario: writing a variable in a 'define' is not allowed
-    Then typeql define; fails
+    Then typeql define; parsing fails
       """
       define entity $x;
       """
@@ -1568,12 +1568,12 @@ Feature: TypeQL Define Query
     Then transaction commits; fails
 
 
-    # TODO: Check why it worked in typedb 2.x...
   Scenario: defining a less strict annotation on an inherited ownership throws
-    Then typeql define; fails
+    When typeql define
       """
-      define entity child owns email @unique;
+      define entity child sub person, owns email @unique;
       """
+    Then transaction commits; fails
 
 
   ###################

--- a/query/language/redefine.feature
+++ b/query/language/redefine.feature
@@ -1,0 +1,2839 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#noinspection CucumberUndefinedStep
+Feature: TypeQL Redefine Query
+
+  Background: Open connection and create a simple extensible schema
+    Given typedb starts
+    Given connection opens with default authentication
+    Given connection has been opened
+    Given connection reset database: typedb
+#    Given connection does not have any database
+#    Given connection create database: typedb
+    Given connection open schema transaction for database: typedb
+
+    Given typeql define
+      """
+      define
+      entity person plays employment:employee, plays income:earner, owns name, owns email @key, owns phone-nr @unique;
+      relation employment relates employee, plays income:source, owns start-date, owns employment-reference-code @key;
+      relation income relates earner, relates source;
+
+      attribute name value string;
+      attribute email value string;
+      attribute start-date value datetime;
+      attribute employment-reference-code value string;
+      attribute phone-nr value string;
+      """
+    Given transaction commits
+
+    Given connection open schema transaction for database: typedb
+
+
+  ################
+  # ENTITY TYPES #
+  ################
+
+  Scenario: entity types cannot be redefined
+    When typeql define; fails
+      """
+      redefine entity person;
+      """
+    Then transaction commits
+
+    When connection open schema transaction for database: typedb
+    When get answers of typeql get
+      """
+      match $x type dog; get;
+      """
+    Then uniquely identify answer concepts
+      | x         |
+      | label:dog |
+
+
+  Scenario: a new entity type can be defined as a subtype, creating a new child of its parent type
+    When typeql define
+      """
+      define entity child sub person;
+      """
+    Then transaction commits
+
+    When connection open read transaction for database: typedb
+    When get answers of typeql get
+      """
+      match $x sub person; get;
+      """
+    Then uniquely identify answer concepts
+      | x            |
+      | label:person |
+      | label:child  |
+
+
+  Scenario: when defining that a type owns a non-existent thing, an error is thrown
+    Then typeql define; fails
+      """
+      define entity book owns pages;
+      """
+
+
+  Scenario: types cannot own entity types
+    Then typeql define; fails
+      """
+      define entity house owns person;
+      """
+
+
+  Scenario: types cannot own relation types
+    Then typeql define; fails
+      """
+      define entity company owns employment;
+      """
+
+
+  Scenario: when defining that a type plays a non-existent role, an error is thrown
+    Then typeql define; fails
+      """
+      define entity house plays constructed:something;
+      """
+
+
+  Scenario: types cannot play entity types
+    Then typeql define; parsing fails
+      """
+      define entity parrot plays person;
+      """
+
+
+  Scenario: types can not own entity types as keys
+    Then typeql define; fails
+      """
+      define entity passport owns person @key;
+      """
+
+
+  Scenario: a newly defined entity subtype inherits playable roles from its parent type
+    Given typeql define
+      """
+      define entity child sub person;
+      """
+    Given transaction commits
+
+    Given connection open read transaction for database: typedb
+    When get answers of typeql get
+      """
+      match $x plays employment:employee; get;
+      """
+    Then uniquely identify answer concepts
+      | x            |
+      | label:person |
+      | label:child  |
+
+
+  Scenario: a newly defined entity subtype inherits playable roles from all of its supertypes
+    Given typeql define
+      """
+      define
+      entity athlete sub person;
+      entity runner sub athlete;
+      entity sprinter sub runner;
+      """
+    Given transaction commits
+
+    Given connection open read transaction for database: typedb
+    When get answers of typeql get
+      """
+      match $x plays employment:employee; get;
+      """
+    Then uniquely identify answer concepts
+      | x              |
+      | label:person   |
+      | label:athlete  |
+      | label:runner   |
+      | label:sprinter |
+
+
+  Scenario: a newly defined entity subtype inherits attribute ownerships from its parent type
+    Given typeql define
+      """
+      define entity child sub person;
+      """
+    Given transaction commits
+
+    Given connection open read transaction for database: typedb
+    When get answers of typeql get
+      """
+      match $x owns name; get;
+      """
+    Then uniquely identify answer concepts
+      | x            |
+      | label:person |
+      | label:child  |
+
+
+  Scenario: a newly defined entity subtype inherits attribute ownerships from all of its supertypes
+    Given typeql define
+      """
+      define
+      entity athlete sub person;
+      entity runner sub athlete;
+      entity sprinter sub runner;
+      """
+    Given transaction commits
+
+    Given connection open read transaction for database: typedb
+    When get answers of typeql get
+      """
+      match $x owns name; get;
+      """
+    Then uniquely identify answer concepts
+      | x              |
+      | label:person   |
+      | label:athlete  |
+      | label:runner   |
+      | label:sprinter |
+
+
+  Scenario: a newly defined entity subtype inherits keys from its parent type
+    Given typeql define
+      """
+      define entity child sub person;
+      """
+    Given transaction commits
+
+    Given connection open read transaction for database: typedb
+    When get answers of typeql get
+      """
+      match $x owns email @key; get;
+      """
+    Then uniquely identify answer concepts
+      | x            |
+      | label:person |
+      | label:child  |
+
+
+  Scenario: a newly defined entity subtype inherits keys from all of its supertypes
+    Given typeql define
+      """
+      define
+      entity athlete sub person;
+      entity runner sub athlete;
+      entity sprinter sub runner;
+      """
+    Given transaction commits
+
+    Given connection open read transaction for database: typedb
+    When get answers of typeql get
+      """
+      match $x owns email @key; get;
+      """
+    Then uniquely identify answer concepts
+      | x              |
+      | label:person   |
+      | label:athlete  |
+      | label:runner   |
+      | label:sprinter |
+
+
+  Scenario: defining a playable role is idempotent
+    Given typeql define
+      """
+      define
+      entity house plays home-ownership:home, plays home-ownership:home, plays home-ownership:home;
+      relation home-ownership relates home, relates owner;
+      person plays home-ownership:owner;
+      """
+    Given transaction commits
+
+    Given connection open read transaction for database: typedb
+    When get answers of typeql get
+      """
+      match $x plays home-ownership:home; get;
+      """
+    Then uniquely identify answer concepts
+      | x           |
+      | label:house |
+
+
+  Scenario: defining an attribute ownership is idempotent
+    Given typeql define
+      """
+      define
+      attribute price value double;
+      entity house owns price, owns price, owns price;
+      """
+    Given transaction commits
+
+    Given connection open read transaction for database: typedb
+    When get answers of typeql get
+      """
+      match $x owns price; get;
+      """
+    Then uniquely identify answer concepts
+      | x           |
+      | label:house |
+
+
+  Scenario: defining a key ownership is idempotent
+    Given typeql define
+      """
+      define
+      attribute address value string;
+      entity house owns address @key, owns address @key, owns address @key;
+      """
+    Given transaction commits
+
+    Given connection open read transaction for database: typedb
+    When get answers of typeql get
+      """
+      match $x owns address @key; get;
+      """
+    Then uniquely identify answer concepts
+      | x           |
+      | label:house |
+
+
+  Scenario: defining a type without a kind throws
+    Then typeql define; fails
+      """
+      define flying-spaghetti-monster;
+      """
+
+
+  Scenario: a type definition must specify a kind
+    Then typeql define; fails
+      """
+      define column;
+      """
+
+
+  Scenario: an entity type can not have a value type defined
+    Then typeql define; fails
+      """
+      define entity cream value double;
+      """
+
+
+  Scenario: defining a thing with 'isa' is not possible in a 'define' query
+    Then typeql define; parsing fails
+      """
+      define $p isa person;
+      """
+
+
+  Scenario: adding an attribute instance to a thing is not possible in a 'define' query
+    Then typeql define; parsing fails
+      """
+      define $p has name "Loch Ness Monster";
+      """
+
+
+  Scenario: writing a variable in a 'define' is not allowed
+    Then typeql define; parsing fails
+      """
+      define entity $x;
+      """
+
+
+  ###############
+  # ANNOTATIONS #
+  ###############
+
+  Scenario Outline: can set annotation @<annotation> to entity types
+    Then typeql define
+      """
+      define
+      entity player @<annotation>;
+      """
+    Then transaction commits
+    Examples:
+      | annotation |
+      | abstract   |
+
+
+  Scenario Outline: cannot set annotation @<annotation> to entity types
+    Then typeql define; fails
+      """
+      define
+      entity player @<annotation>;
+      """
+    Examples:
+      | annotation       |
+      | distinct         |
+      | independent      |
+      | unique           |
+      | key              |
+      | card(1..1)       |
+      | regex("val")     |
+      | cascade          |
+      | range("1".."2")  |
+      | values("1", "2") |
+
+
+  Scenario Outline: can set annotation @<annotation> to relation types
+    Then typeql define
+      """
+      define
+      relation parentship @<annotation>, relates parent;
+      """
+    Then transaction commits
+    Examples:
+      | annotation |
+      | abstract   |
+      | cascade    |
+
+
+  Scenario Outline: cannot set annotation @<annotation> to relation types
+    Then typeql define; fails
+      """
+      define
+      relation parentship @<annotation>, relates parent;
+      """
+    Examples:
+      | annotation       |
+      | distinct         |
+      | independent      |
+      | unique           |
+      | key              |
+      | card(1..1)       |
+      | regex("val")     |
+      | range("1".."2")  |
+      | values("1", "2") |
+
+
+  Scenario Outline: can set annotation @<annotation> to attribute types
+    Then typeql define
+      """
+      define
+      attribute description @<annotation>, value string;
+      """
+    Then transaction commits
+    Examples:
+      | annotation  |
+      | abstract    |
+      | independent |
+
+
+  Scenario Outline: cannot set annotation @<annotation> to attribute types
+    Then typeql define; fails
+      """
+      define
+      attribute description @<annotation>, value string;
+      """
+    Examples:
+      | annotation       |
+      | distinct         |
+      | unique           |
+      | key              |
+      | card(1..1)       |
+      | cascade          |
+      | regex("val")     |
+      | range("1".."2")  |
+      | values("1", "2") |
+
+
+  Scenario Outline: can set annotation @<annotation> to relates/role types
+    Then typeql define
+      """
+      define
+      relation parentship @abstract, relates parent @<annotation>;
+      """
+    Then transaction commits
+    Examples:
+      | annotation |
+      | abstract   |
+      | card(1..1) |
+
+
+  Scenario Outline: cannot set annotation @<annotation> to relates/role types
+    Then typeql define; fails
+      """
+      define
+      relation parentship @abstract, relates parent @<annotation>;
+      """
+    Examples:
+      | annotation       |
+      | distinct         |
+      | independent      |
+      | unique           |
+      | key              |
+      | cascade          |
+      | regex("val")     |
+      | range("1".."2")  |
+      | values("1", "2") |
+
+
+  Scenario Outline: can set annotation @<annotation> to relates/role types lists
+    Then typeql define
+      """
+      define
+      relation parentship @abstract, relates parent[] @<annotation>;
+      """
+    Then transaction commits
+    Examples:
+      | annotation |
+      | abstract   |
+      | card(1..1) |
+      | distinct   |
+
+
+  Scenario Outline: cannot set annotation @<annotation> to relates/role types lists
+    Then typeql define; fails
+      """
+      define
+      relation parentship @abstract, relates parent[] @<annotation>;
+      """
+    Examples:
+      | annotation       |
+      | independent      |
+      | unique           |
+      | key              |
+      | cascade          |
+      | regex("val")     |
+      | range("1".."2")  |
+      | values("1", "2") |
+
+
+  Scenario Outline: can set annotation @<annotation> to owns
+    Then typeql define
+      """
+      define
+      entity player owns name @<annotation>;
+      """
+    Then transaction commits
+    Examples:
+      | annotation       |
+      | card(1..1)       |
+      | unique           |
+      | key              |
+      | regex("val")     |
+      | range("1".."2")  |
+      | values("1", "2") |
+
+
+  Scenario Outline: cannot set annotation @<annotation> to owns
+    Then typeql define; fails
+      """
+      define
+      entity player owns name @<annotation>;
+      """
+    Examples:
+      | annotation  |
+      | abstract    |
+      | distinct    |
+      | independent |
+      | cascade     |
+
+
+  Scenario Outline: can set annotation @<annotation> to owns lists
+    Then typeql define
+      """
+      define
+      entity player owns name[] @<annotation>;
+      """
+    Then transaction commits
+    Examples:
+      | annotation       |
+      | distinct         |
+      | card(1..1)       |
+      | unique           |
+      | key              |
+      | regex("val")     |
+      | range("1".."2")  |
+      | values("1", "2") |
+
+
+  Scenario Outline: cannot set annotation @<annotation> to owns lists
+    Then typeql define; fails
+      """
+      define
+      entity player owns name[] @<annotation>;
+      """
+    Examples:
+      | annotation  |
+      | abstract    |
+      | independent |
+      | cascade     |
+
+
+  Scenario Outline: can set annotation @<annotation> to plays
+    Then typeql define
+      """
+      define
+      entity player plays employment:employee @<annotation>;
+      """
+    Then transaction commits
+    Examples:
+      | annotation |
+      | card(1..1) |
+
+
+  Scenario Outline: cannot set annotation @<annotation> to plays
+    Then typeql define; fails
+      """
+      define
+      entity player plays employment:employee @<annotation>;
+      """
+    Examples:
+      | annotation       |
+      | abstract         |
+      | distinct         |
+      | independent      |
+      | cascade          |
+      | unique           |
+      | key              |
+      | regex("val")     |
+      | range("1".."2")  |
+      | values("1", "2") |
+
+
+  Scenario Outline: can set annotation @<annotation> to value types
+    Then typeql define
+      """
+      define
+      attribute description value string @<annotation>;
+      """
+    Then transaction commits
+    Examples:
+      | annotation       |
+      | regex("val")     |
+      | range("1".."2")  |
+      | values("1", "2") |
+
+
+  Scenario Outline: cannot set annotation @<annotation> to value types
+    Then typeql define; fails
+      """
+      define
+      attribute description value string @<annotation>;
+      """
+    Examples:
+      | annotation  |
+      | abstract    |
+      | distinct    |
+      | independent |
+      | unique      |
+      | key         |
+      | card(1..1)  |
+      | cascade     |
+
+
+  Scenario Outline: cannot set annotation @<annotation> to subs
+    Then typeql define; fails
+      """
+      define
+      entity player sub person @<annotation>;
+      """
+    Examples:
+      | annotation       |
+      | abstract         |
+      | distinct         |
+      | independent      |
+      | unique           |
+      | key              |
+      | card(1..1)       |
+      | regex("val")     |
+      | cascade          |
+      | range("1".."2")  |
+      | values("1", "2") |
+
+    # TODO: Same "cannot set annotation" for alias?
+
+
+  ##################
+  # RELATION TYPES #
+  ##################
+
+  Scenario: new relation types can be defined
+    When typeql define
+      """
+      define relation pet-ownership relates pet-owner, relates owned-pet;
+      """
+    Then transaction commits
+
+    When connection open read transaction for database: typedb
+    When get answers of typeql get
+      """
+      match $x type pet-ownership; get;
+      """
+    Then uniquely identify answer concepts
+      | x                   |
+      | label:pet-ownership |
+
+
+  Scenario: a new relation type can be defined as a subtype, creating a new child of its parent type
+    When typeql define
+      """
+      define relation fun-employment sub employment, relates employee-having-fun as employee;
+      """
+    Then transaction commits
+
+    When connection open read transaction for database: typedb
+    When get answers of typeql get
+      """
+      match $x sub employment; get;
+      """
+    Then uniquely identify answer concepts
+      | x                    |
+      | label:employment     |
+      | label:fun-employment |
+
+
+  Scenario: defining a relation type throws on commit if it has no roleplayers and is not abstract
+    Then typeql define
+      """
+      define relation useless-relation;
+      """
+    Then transaction commits; fails
+
+
+  Scenario: a newly defined relation subtype inherits roles from its supertype
+    Given typeql define
+      """
+      define relation part-time-employment sub employment;
+      """
+    Given transaction commits
+
+    Given connection open read transaction for database: typedb
+    When get answers of typeql get
+      """
+      match $x relates employee; get;
+      """
+    Then uniquely identify answer concepts
+      | x                          |
+      | label:employment           |
+      | label:part-time-employment |
+
+  # TODO: Why does this have no body?
+  Scenario: a newly defined relation subtype inherits roles from all of its supertypes
+
+
+  Scenario: a relation type's role can be overridden in a child relation type using 'as'
+    When typeql define
+      """
+      define
+        relation parenthood relates parent, relates child;
+        relation father-sonhood sub parenthood, relates father as parent, relates son as child;
+      """
+    Then transaction commits
+
+    When connection open read transaction for database: typedb
+    When get answers of typeql get
+      """
+      match
+        $x relates parent;
+        $x relates child;
+      get;
+      """
+    Then uniquely identify answer concepts
+      | x                |
+      | label:parenthood |
+    When get answers of typeql get
+      """
+      match
+        $x relates father;
+        $x relates son;
+      get;
+      """
+    Then uniquely identify answer concepts
+      | x                    |
+      | label:father-sonhood |
+
+
+  Scenario: when a relation type's role is overridden, it creates a sub-role of the parent role type
+    When typeql define
+      """
+      define
+      relation parenthood relates parent, relates child;
+      relation father-sonhood sub parenthood, relates father as parent, relates son as child;
+      """
+    Then transaction commits
+
+    When connection open read transaction for database: typedb
+    When get answers of typeql get
+      """
+      match
+      $x sub parenthood:parent; $y sub parenthood:child; get $x, $y;
+      """
+    Then uniquely identify answer concepts
+      | x                           | y                        |
+      | label:parenthood:parent     | label:parenthood:child   |
+      | label:father-sonhood:father | label:parenthood:child   |
+      | label:parenthood:parent     | label:father-sonhood:son |
+      | label:father-sonhood:father | label:father-sonhood:son |
+
+
+  Scenario: an overridden role is no longer associated with the relation type that overrides it
+    Given typeql define
+      """
+      define relation part-time-employment sub employment, relates part-timer as employee;
+      """
+    Given transaction commits
+
+    Given connection open read transaction for database: typedb
+    When get answers of typeql get
+      """
+      match $x relates employee; get;
+      """
+    Then uniquely identify answer concepts
+      | x                |
+      | label:employment |
+
+
+  Scenario: when overriding a role that doesn't exist on the parent relation, an error is thrown
+    Then typeql define; fails
+      """
+      define
+      relation close-friendship relates close-friend as friend;
+      """
+
+
+  Scenario: relation subtypes can have roles that their supertypes don't have
+    Given typeql define
+      """
+      define
+      entity plane plays pilot-employment:preferred-plane;
+      relation pilot-employment sub employment, relates pilot as employee, relates preferred-plane;
+      person plays pilot-employment:pilot;
+      """
+    Given transaction commits
+
+    Given connection open read transaction for database: typedb
+    When get answers of typeql get
+      """
+      match $x relates preferred-plane; get;
+      """
+    Then uniquely identify answer concepts
+      | x                      |
+      | label:pilot-employment |
+
+
+  Scenario Outline: types should be able to define roles they play with an override using <mode>
+    Then typeql define
+      """
+        define
+        relation locates relates located;
+        relation contractor-locates sub locates, relates contractor-located as located;
+
+        relation employment relates employee, plays locates:located;
+        relation contractor-employment sub employment, plays contractor-locates:contractor-located as <as-label>;
+      """
+    Examples:
+      | mode              | as-label        |
+      | role name         | located         |
+      | role scoped label | locates:located |
+
+
+  Scenario Outline: types should be able to define roles they play with an override using <mode>
+    Then typeql define<failure>
+      """
+        define
+        relation locates relates located;
+        relation contractor-locates sub locates, relates contractor-located as located;
+
+        relation employment relates employee, plays locates:located;
+        relation contractor-employment sub employment, plays contractor-locates:contractor-located as <as-label>;
+      """
+    Examples:
+      | mode                     | as-label                              | failure         |
+      | builtin kind             | entity                                | ; parsing fails |
+    # TODO: Parser allows builtin types here for simplicity, it would be cleaner to accept only label and scoped_label
+      | builtin type             | string                                | ; fails         |
+      | name:name without scope  | locates:locates                       | ; fails         |
+      | scope:scope without name | located:located                       | ; fails         |
+      | incorrect scope          | contractor-locates:located            | ; fails         |
+      | same role                | contractor-locates:contractor-located | ; fails         |
+
+
+  Scenario: already shadowed types should not be overrideable
+    Then typeql define; fails
+      """
+        define
+        relation locates relates located;
+        relation contractor-locates sub locates, relates contractor-located as located;
+        relation software-contractor-locates sub contractor-locates, relates software-contractor-located as contractor-located;
+
+        employment relates employee, plays locates:located;
+        relation contractor-employment sub employment, plays contractor-locates:contractor-located as located;
+        relation software-contractor-employment sub contractor-employment, plays software-contractor-locates:software-contractor-located as located;
+      """
+
+
+  Scenario: a newly defined relation subtype inherits playable roles from its parent type
+    Given typeql define
+      """
+      define relation contract-employment sub employment, relates contractor as employee;
+      """
+    Given transaction commits
+
+    Given connection open read transaction for database: typedb
+    When get answers of typeql get
+      """
+      match $x plays income:source; get;
+      """
+    Then uniquely identify answer concepts
+      | x                         |
+      | label:employment          |
+      | label:contract-employment |
+
+
+  Scenario: a newly defined relation subtype inherits playable roles from all of its supertypes
+    Given typeql define
+      """
+      define
+      relation transport-employment sub employment, relates transport-worker as employee;
+      relation aviation-employment sub transport-employment, relates aviation-worker as transport-worker;
+      relation flight-attendant-employment sub aviation-employment, relates flight-attendant as aviation-worker;
+      """
+    Given transaction commits
+
+    Given connection open read transaction for database: typedb
+    When get answers of typeql get
+      """
+      match $x plays income:source; get;
+      """
+    Then uniquely identify answer concepts
+      | x                                 |
+      | label:employment                  |
+      | label:transport-employment        |
+      | label:aviation-employment         |
+      | label:flight-attendant-employment |
+
+
+  Scenario: inherited role types cannot be played via role type aliases
+    Given typeql define; fails
+      """
+      define
+      relation part-time-employment sub employment;
+      person plays part-time-employment:employee;
+      """
+
+
+  Scenario: a newly defined relation subtype inherits attribute ownerships from its parent type
+    Given typeql define
+      """
+      define relation contract-employment sub employment, relates contractor as employee;
+      """
+    Given transaction commits
+
+    Given connection open read transaction for database: typedb
+    When get answers of typeql get
+      """
+      match $x owns start-date; get;
+      """
+    Then uniquely identify answer concepts
+      | x                         |
+      | label:employment          |
+      | label:contract-employment |
+
+
+  Scenario: a newly defined relation subtype inherits attribute ownerships from all of its supertypes
+    Given typeql define
+      """
+      define
+      relation transport-employment sub employment, relates transport-worker as employee;
+      relation aviation-employment sub transport-employment, relates aviation-worker as transport-worker;
+      relation flight-attendant-employment sub aviation-employment, relates flight-attendant as aviation-worker;
+      """
+    Given transaction commits
+
+    Given connection open read transaction for database: typedb
+    When get answers of typeql get
+      """
+      match $x owns start-date; get;
+      """
+    Then uniquely identify answer concepts
+      | x                                 |
+      | label:employment                  |
+      | label:transport-employment        |
+      | label:aviation-employment         |
+      | label:flight-attendant-employment |
+
+
+  Scenario: a newly defined relation subtype inherits keys from its parent type
+    Given typeql define
+      """
+      define relation contract-employment sub employment, relates contractor as employee;
+      """
+    Given transaction commits
+
+    Given connection open read transaction for database: typedb
+    When get answers of typeql get
+      """
+      match $x owns employment-reference-code @key; get;
+      """
+    Then uniquely identify answer concepts
+      | x                         |
+      | label:employment          |
+      | label:contract-employment |
+
+
+  Scenario: a newly defined relation subtype inherits keys from all of its supertypes
+    Given typeql define
+      """
+      define
+      relation transport-employment sub employment, relates transport-worker as employee;
+      relation aviation-employment sub transport-employment, relates aviation-worker as transport-worker;
+      relation flight-attendant-employment sub aviation-employment, relates flight-attendant as aviation-worker;
+      """
+    Given transaction commits
+
+    Given connection open read transaction for database: typedb
+    When get answers of typeql get
+      """
+      match $x owns employment-reference-code @key; get;
+      """
+    Then uniquely identify answer concepts
+      | x                                 |
+      | label:employment                  |
+      | label:transport-employment        |
+      | label:aviation-employment         |
+      | label:flight-attendant-employment |
+
+
+  Scenario: a relation type cannot be defined with no roleplayers even if it is marked as @abstract
+    When typeql define
+      """
+      define relation connection @abstract;
+      """
+    Then transaction commits; fails
+
+
+  Scenario: an abstract relation type can be defined with both abstract and concrete role types
+    When typeql define
+      """
+      define relation connection @abstract, relates from, relates to @abstract;
+      """
+    Then transaction commits
+
+    When connection open read transaction for database: typedb
+    When get answers of typeql get
+      """
+      match $x type connection; get;
+      """
+    Then uniquely identify answer concepts
+      | x                |
+      | label:connection |
+
+
+  Scenario: a concrete relation type cannot be defined with abstract role types
+    When typeql define; fails
+      """
+      define relation connection relates from, relates to @abstract;
+      """
+    When transaction closes
+
+    When connection open schema transaction for database: typedb
+    When typeql define; fails
+      """
+      define relation connection relates to @abstract;
+      """
+    When transaction closes
+
+    When connection open schema transaction for database: typedb
+    When typeql define
+      """
+      define relation connection relates from;
+      """
+    Then transaction commits
+
+
+  Scenario: when defining a relation type, duplicate 'relates' are idempotent
+    Given typeql define
+      """
+      define
+      relation parenthood relates parent, relates child, relates child, relates parent, relates child;
+      person plays parenthood:parent, plays parenthood:child;
+      """
+    Given transaction commits
+
+    Given connection open read transaction for database: typedb
+    When get answers of typeql get
+      """
+      match $x relates parent; $x relates child; get;
+      """
+    Then uniquely identify answer concepts
+      | x                |
+      | label:parenthood |
+
+
+  Scenario: unrelated relations are allowed to have roles with the same name
+    When typeql define
+      """
+      define
+      relation ownership relates owner;
+      relation loan relates owner;
+      """
+    Then transaction commits
+
+    When connection open read transaction for database: typedb
+    When get answers of typeql get
+      """
+      match $x relates owner; get;
+      """
+    Then uniquely identify answer concepts
+      | x               |
+      | label:ownership |
+      | label:loan      |
+
+
+  ###################
+  # ATTRIBUTE TYPES #
+  ###################
+
+  Scenario Outline: a '<value_type>' attribute type can be defined
+    Given typeql define
+      """
+      define attribute <label> value <value_type>;
+      """
+    Given transaction commits
+
+    Given connection open read transaction for database: typedb
+    When get answers of typeql get
+      """
+      match
+        $x type <label>;
+        attribute $x;
+      get;
+      """
+    Then answer size is: 1
+
+    Examples:
+      | value_type | label          |
+      | boolean    | can-fly        |
+      | long       | number-of-cows |
+      | double     | density        |
+      | string     | favourite-food |
+      | datetime   | flight-date    |
+
+
+  Scenario: defining an attribute type throws if you don't specify a value type
+    When typeql define
+      """
+      define attribute colour;
+      """
+    Then transaction commits; fails
+
+
+  Scenario: defining an abstract attribute type does not throw if you don't specify a value type
+    When typeql define
+      """
+      define attribute colour @abstract;
+      """
+    Then transaction commits
+
+
+  Scenario: defining an attribute type throws if the specified value type is not a recognised value type
+    Then typeql define; fails
+      """
+      define attribute colour value rgba;
+      """
+
+
+  Scenario: a new attribute type can be defined as a subtype of an abstract attribute type
+    When typeql define
+      """
+      define
+      attribute code @abstract, value string ;
+      attribute door-code sub code;
+      """
+    Then transaction commits
+
+    Given connection open read transaction for database: typedb
+    When get answers of typeql get
+      """
+      match $x sub code; get;
+      """
+    Then uniquely identify answer concepts
+      | x               |
+      | label:code      |
+      | label:door-code |
+
+
+  Scenario: a newly defined attribute subtype inherits the value type of its parent
+    When typeql define
+      """
+      define
+      attribute code @abstract, value string;
+      attribute door-code sub code;
+      """
+    Then transaction commits
+
+    Given connection open read transaction for database: typedb
+    When get answers of typeql get
+      """
+      match $x type door-code, value string; get;
+      """
+    Then uniquely identify answer concepts
+      | x               |
+      | label:door-code |
+
+
+  Scenario: defining an attribute subtype throws if it is given a different value type to what its parent has
+    When typeql define
+      """
+      define attribute name @abstract; entity person @abstract;
+      """
+    When transaction commits
+
+    When connection open schema transaction for database: typedb
+    Then typeql define; fails
+      """
+      define attribute code-name sub name, value long;
+      """
+    When transaction closes
+
+    When connection open schema transaction for database: typedb
+    When typeql define
+      """
+      define attribute code-name sub name; attribute code-name-2 value long;
+      """
+    When transaction commits
+
+    When connection open schema transaction for database: typedb
+    Then typeql define; fails
+      """
+      define attribute code-name value long;
+      """
+    When transaction closes
+
+    When connection open schema transaction for database: typedb
+    Then typeql define; fails
+      """
+      define attribute code-name-2 sub name;
+      """
+
+  # TODO: re-enable when fixed (currently gives wrong answer)
+  @ignore
+  Scenario: a regex constraint can be defined on a 'string' attribute type
+    Given typeql define
+      """
+      define attribute response @regex("^(yes|no|maybe)$"), value string;
+      """
+    Given transaction commits
+
+    Given connection open read transaction for database: typedb
+    When get answers of typeql get
+      """
+      match $x @regex("^(yes|no|maybe)$"); get;
+      """
+    Then uniquely identify answer concepts
+      | x              |
+      | label:resource |
+
+
+  Scenario: a regex constraint cannot be defined on an attribute type whose value type is anything other than 'string'
+    Then typeql define; fails
+      """
+      define attribute name-in-binary @regex("^(0|1)+$"), value long;
+      """
+
+
+  Scenario Outline: a type can own a '<value_type>' attribute type
+    When typeql define
+      """
+      define
+      attribute <label> value <value_type>;
+      person owns <label>;
+      """
+    Then transaction commits
+
+    Given connection open read transaction for database: typedb
+    When get answers of typeql get
+      """
+      match $x owns <label>; get;
+      """
+    Then uniquely identify answer concepts
+      | x            |
+      | label:person |
+
+    Examples:
+      | value_type | label             |
+      | boolean    | is-sleeping       |
+      | long       | number-of-fingers |
+      | double     | height            |
+      | string     | first-word        |
+      | datetime   | graduation-date   |
+
+
+  # TODO
+#  Scenario Outline: a type can own a '<value_type>' attribute type as a key
+#
+#  Scenario Outline: a '<value_type>' attribute type is not allowed to be a key
+
+
+  ##################
+  # ABSTRACT TYPES #
+  ##################
+
+  Scenario: an abstract entity type can be defined
+    When typeql define
+      """
+      define entity animal @abstract;
+      """
+    Then transaction commits
+
+    Given connection open read transaction for database: typedb
+    When get answers of typeql get
+      """
+      match $x type animal; $x @abstract; get;
+      """
+    Then uniquely identify answer concepts
+      | x            |
+      | label:animal |
+
+
+  Scenario: a concrete entity type can be defined as a subtype of an abstract entity type
+    When typeql define
+      """
+      define
+      entity animal @abstract;
+      entity horse sub animal;
+      """
+    Then transaction commits
+
+    Given connection open read transaction for database: typedb
+    When get answers of typeql get
+      """
+      match $x sub animal; get;
+      """
+    Then uniquely identify answer concepts
+      | x            |
+      | label:animal |
+      | label:horse  |
+
+
+  Scenario: an abstract entity type can be defined as a subtype of another abstract entity type
+    When typeql define
+      """
+      define
+      entity animal @abstract;
+      entity fish @abstract, sub animal;
+      """
+    Then transaction commits
+
+    Given connection open read transaction for database: typedb
+    When get answers of typeql get
+      """
+      match $x sub animal; $x @abstract; get;
+      """
+    Then uniquely identify answer concepts
+      | x            |
+      | label:animal |
+      | label:fish   |
+
+
+  Scenario: an abstract entity type cannot be defined as a subtype of a concrete entity type
+    Then typeql define; fails
+      """
+      define
+      entity exception;
+      entity typedb-exception @abstract, sub exception;
+      """
+
+
+  Scenario: an abstract relation type can be defined
+    When typeql define
+      """
+      define relation membership @abstract, relates member;
+      """
+    Then transaction commits
+
+    Given connection open read transaction for database: typedb
+    When get answers of typeql get
+      """
+      match $x type membership; $x @abstract; get;
+      """
+    Then uniquely identify answer concepts
+      | x                |
+      | label:membership |
+
+
+  Scenario: a concrete relation type can be defined as a subtype of an abstract relation type
+    When typeql define
+      """
+      define
+      relation membership @abstract, relates member;
+      relation gym-membership sub membership, relates gym-with-members, relates gym-member as member;
+      """
+    Then transaction commits
+
+    When connection open read transaction for database: typedb
+    When get answers of typeql get
+      """
+      match $x sub membership; get;
+      """
+    Then uniquely identify answer concepts
+      | x                    |
+      | label:membership     |
+      | label:gym-membership |
+
+
+  Scenario: an abstract relation type can be defined as a subtype of another abstract relation type
+    When typeql define
+      """
+      define
+      relation requirement @abstract, relates prerequisite, relates outcome;
+      relation tool-requirement @abstract, sub requirement, relates required-tool as prerequisite;
+      """
+    Then transaction commits
+
+    When connection open read transaction for database: typedb
+    When get answers of typeql get
+      """
+      match $x sub requirement; $x @abstract; get;
+      """
+    Then uniquely identify answer concepts
+      | x                      |
+      | label:requirement      |
+      | label:tool-requirement |
+
+
+  Scenario: an abstract relation type cannot be defined as a subtype of a concrete relation type
+    Then typeql define; fails
+      """
+      define
+      relation requirement relates prerequisite, relates outcome;
+      relation tech-requirement @abstract, sub requirement, relates required-tech as prerequisite;
+      """
+
+
+  Scenario: an abstract attribute type can be defined
+    When typeql define
+      """
+      define attribute number-of-limbs @abstract, value long;
+      """
+    Then transaction commits
+
+    Given connection open read transaction for database: typedb
+    When get answers of typeql get
+      """
+      match $x type number-of-limbs; $x @abstract; get;
+      """
+    Then uniquely identify answer concepts
+      | x                     |
+      | label:number-of-limbs |
+
+
+  Scenario: a concrete attribute type can be defined as a subtype of an abstract attribute type
+    When typeql define
+      """
+      define
+      attribute number-of-limbs @abstract, value long;
+      attribute number-of-legs sub number-of-limbs;
+      """
+    Then transaction commits
+
+    When connection open read transaction for database: typedb
+    When get answers of typeql get
+      """
+      match $x sub number-of-limbs; get;
+      """
+    Then uniquely identify answer concepts
+      | x                     |
+      | label:number-of-limbs |
+      | label:number-of-legs  |
+
+
+  Scenario: an abstract attribute type can be defined as a subtype of another abstract attribute type
+    When typeql define
+      """
+      define
+      attribute number-of-limbs @abstract, value long;
+      attribute number-of-artificial-limbs @abstract, sub number-of-limbs;
+      """
+    Then transaction commits
+
+    Given connection open read transaction for database: typedb
+    When get answers of typeql get
+      """
+      match $x sub number-of-limbs; $x @abstract; get;
+      """
+    Then uniquely identify answer concepts
+      | x                                |
+      | label:number-of-limbs            |
+      | label:number-of-artificial-limbs |
+
+
+  Scenario: defining attribute type hierarchies is idempotent
+    When typeql define
+      """
+      define attribute super-name @abstract, value string; attribute location-name sub super-name;
+      """
+    Then transaction commits
+    Then connection open schema transaction for database: typedb
+    Then typeql define
+      """
+      define attribute super-name @abstract, value string; attribute location-name sub super-name;
+      """
+    Then transaction commits
+    Then connection open read transaction for database: typedb
+    When get answers of typeql get
+      """
+      match
+      $name type super-name @abstract;
+      $location type location-name, sub super-name;
+      get;
+      """
+    Then uniquely identify answer concepts
+      | name             | location            |
+      | label:super-name | label:location-name |
+
+  # TODO: Reenable this scenario after closing https://github.com/vaticle/typeql/issues/281
+  @ignore
+  @ignore-typedb-driver-rust
+  Scenario: repeating the term 'abstract' when defining a type causes an error to be thrown
+    Given typeql define; fails
+      """
+      define entity animal @abstract @abstract @abstract;
+      """
+
+  ##############
+  # Annotation #
+  ##############
+
+  Scenario: annotations can be added on subtypes
+    Given typeql define
+      """
+      define
+      entity child sub person, owns school-id @unique;
+      attribute school-id value string;
+      """
+    Then transaction commits
+
+
+  Scenario: annotations are inherited
+    Given typeql define
+      """
+      define entity child sub person;
+      """
+    Given transaction commits
+    Then connection open read transaction for database: typedb
+    When get answers of typeql get
+      """
+      match $t owns $a @key; get;
+      """
+    Then uniquely identify answer concepts
+      | t                | a                               |
+      | label:person     | label:email                     |
+      | label:child      | label:email                     |
+      | label:employment | label:employment-reference-code |
+    When get answers of typeql get
+      """
+      match $t owns $a @unique; get;
+      """
+    Then uniquely identify answer concepts
+      | t            | a              |
+      | label:person | label:phone-nr |
+      | label:child  | label:phone-nr |
+
+
+  Scenario: redefining inherited annotations throws
+    Then typeql define
+      """
+      define entity child sub person, owns email @key;
+      """
+    Then transaction commits; fails
+    Then connection open schema transaction for database: typedb
+    Then typeql define
+      """
+      define entity child sub person, owns phone-nr @unique;
+      """
+    Then transaction commits; fails
+
+
+  Scenario: annotations are inherited through overrides
+    Given typeql define
+      """
+      define
+      entity person @abstract;
+      attribute phone-nr @abstract;
+      entity child sub person, owns mobile as phone-nr;
+      attribute mobile sub phone-nr;
+      """
+    Given transaction commits
+    Then connection open schema transaction for database: typedb
+    When get answers of typeql get
+      """
+      match $t owns $a @unique; get;
+      """
+    Then uniquely identify answer concepts
+      | t            | a              |
+      | label:person | label:phone-nr |
+      | label:child  | label:mobile   |
+    Given typeql define
+      """
+      define
+      entity child @abstract;
+      attribute mobile @abstract;
+      entity infant sub child, owns baby-phone-nr as mobile;
+      attribute baby-phone-nr sub mobile;
+      """
+    Given transaction commits
+    Then connection open read transaction for database: typedb
+    When get answers of typeql get
+      """
+      match $t owns $a @unique; get;
+      """
+    Then uniquely identify answer concepts
+      | t            | a                   |
+      | label:person | label:phone-nr      |
+      | label:child  | label:mobile        |
+      | label:infant | label:baby-phone-nr |
+
+
+  Scenario: redefining inherited annotations on overrides throws
+    Given typeql define
+      """
+      define
+      entity person @abstract;
+      attribute phone-nr @abstract;
+      entity child sub person, owns mobile as phone-nr;
+      attribute mobile sub phone-nr;
+      """
+    Then transaction commits
+    Given connection open schema transaction for database: typedb
+    Then typeql define
+      """
+      define entity child owns mobile as phone-nr @unique;
+      """
+    Then transaction commits; fails
+
+
+  Scenario: defining a less strict annotation on an inherited ownership throws
+    When typeql define
+      """
+      define entity child sub person, owns email @unique;
+      """
+    Then transaction commits; fails
+
+
+  ###################
+  # SCHEMA MUTATION #
+  ###################
+
+  Scenario: an existing type can be repeatedly redefined, and it is a no-op
+    When typeql define
+      """
+      define
+      entity person owns name;
+      entity person owns name;
+      entity person owns name;
+      """
+    Then transaction commits
+
+    When connection open read transaction for database: typedb
+    When get answers of typeql get
+      """
+      match $x type person, owns name; get;
+      """
+    Then answer size is: 1
+
+
+  Scenario: an entity type cannot be changed into a relation type
+    Then typeql define; fails
+      """
+      define
+      relation person relates body-part;
+      entity arm plays person:body-part;
+      """
+
+
+  Scenario: a relation type cannot be changed into an attribute type
+    Then typeql define; fails
+      """
+      define attribute employment value string;
+      """
+
+
+  Scenario: an attribute type cannot be changed into an entity type
+    Then typeql define; fails
+      """
+      define entity name;
+      """
+
+
+  Scenario: a new attribute ownership can be defined on an existing type
+    When typeql define
+      """
+      define employment owns name;
+      """
+    Then transaction commits
+
+    When connection open read transaction for database: typedb
+    When get answers of typeql get
+      """
+      match $x owns name; get;
+      """
+    Then uniquely identify answer concepts
+      | x                |
+      | label:person     |
+      | label:employment |
+
+
+  Scenario: a new playable role can be defined on an existing type
+    When typeql define
+      """
+      define employment plays employment:employee;
+      """
+    Then transaction commits
+
+    When connection open read transaction for database: typedb
+    When get answers of typeql get
+      """
+      match $x plays employment:employee; get;
+      """
+    Then uniquely identify answer concepts
+      | x                |
+      | label:person     |
+      | label:employment |
+
+
+  Scenario: defining a key on an existing ownership is possible if data already conforms to key requirements
+    Given typeql define
+      """
+      define
+      attribute barcode value string;
+      entity product owns name, owns barcode;
+      """
+    Given transaction commits
+
+    Given connection open write transaction for database: typedb
+    Given typeql insert
+      """
+      insert
+      $x isa product, has name "Cheese", has barcode "10001";
+      $y isa product, has name "Ham", has barcode "10011";
+      $a "Milk" isa name;
+      $b "11111" isa barcode;
+      """
+    Given transaction commits
+
+    Given connection open schema transaction for database: typedb
+    When typeql define
+      """
+      define
+      product owns barcode @key;
+      """
+    Then transaction commits
+
+    Given connection open read transaction for database: typedb
+    When get answers of typeql get
+      """
+      match $x owns barcode @key; get;
+      """
+    Then uniquely identify answer concepts
+      | x             |
+      | label:product |
+
+
+  Scenario: defining a key on a type throws if existing instances don't have that key
+    Given typeql define
+      """
+      define
+      attribute barcode value string;
+      entity product owns name;
+      """
+    Given transaction commits
+
+    Given connection open write transaction for database: typedb
+    Given typeql insert
+      """
+      insert
+      $x isa product, has name "Cheese";
+      $y isa product, has name "Ham";
+      """
+    Given transaction commits
+
+    Given connection open schema transaction for database: typedb
+    Then typeql define; fails
+      """
+      define
+      product owns barcode @key;
+      """
+
+
+  Scenario: defining a key on a type throws if there is a key collision between two existing instances
+    Given typeql define
+      """
+      define
+      attribute barcode value string;
+      entity product owns name, owns barcode;
+      """
+    Given transaction commits
+
+    Given connection open write transaction for database: typedb
+    Given typeql insert
+      """
+      insert
+      $x isa product, has name "Cheese", has barcode "10000";
+      $y isa product, has name "Ham", has barcode "10000";
+      """
+    Given transaction commits
+
+    Given connection open schema transaction for database: typedb
+    Then typeql define; fails
+      """
+      define
+      product owns barcode @key;
+      """
+
+
+  Scenario: a new role can be defined on an existing relation type
+    When typeql define
+      """
+      define
+      entity company plays employment:employer;
+      employment relates employer;
+      """
+    Then transaction commits
+
+    Given connection open read transaction for database: typedb
+    When get answers of typeql get
+      """
+      match $x relates employer; get;
+      """
+    Then uniquely identify answer concepts
+      | x                |
+      | label:employment |
+
+
+  Scenario: Redefining an attribute type succeeds if and only if the value type remains unchanged
+    Then typeql define; fails
+      """
+      define attribute name value long;
+      """
+    Given transaction closes
+    Given connection open schema transaction for database: typedb
+    When typeql define
+      """
+      define attribute name value string;
+      """
+    Then transaction commits
+
+
+  Scenario: a regex constraint can be added to an existing attribute type if all its instances satisfy it
+    Given transaction closes
+    Given connection open write transaction for database: typedb
+    Given typeql insert
+      """
+      insert
+      $x isa person, has name "Alice", has email "alice@vaticle.com";
+      """
+    Given transaction commits
+
+    Given connection open schema transaction for database: typedb
+    When typeql define
+      """
+      define name value string @regex("^A.*$");
+      """
+    Then transaction commits
+
+    Given connection open read transaction for database: typedb
+    Then get answers of typeql get
+      """
+      match $x @regex("^A.*$"); get;
+      """
+    Then uniquely identify answer concepts
+      | x          |
+      | label:name |
+
+
+  Scenario: a regex cannot be added to an existing attribute type if there is an instance that doesn't satisfy it
+    Given transaction closes
+    Given connection open write transaction for database: typedb
+    Given typeql insert
+      """
+      insert
+      $x isa person, has name "Maria", has email "maria@vaticle.com";
+      """
+    Given transaction commits
+
+    Given connection open schema transaction for database: typedb
+    Then typeql define; fails
+      """
+      define name @regex("^A.*$");
+      """
+
+
+  Scenario: a regex constraint can not be added to an existing attribute type whose value type isn't 'string'
+    Given typeql define
+      """
+      define attribute house-number value long;
+      """
+    Given transaction commits
+
+    Given connection open schema transaction for database: typedb
+    Then typeql define; fails
+      """
+      define house-number @regex("^A.*$");
+      """
+
+
+  Scenario: related roles cannot be added to existing entity types
+    Then typeql define; fails
+      """
+      define person relates employee;
+      """
+
+
+  Scenario: related roles cannot be added to existing attribute types
+    Then typeql define; fails
+      """
+      define name relates employee;
+      """
+
+
+  Scenario: the value type of an existing attribute type is modifiable through redefine
+    Then typeql redefine
+      """
+      redefine name value long;
+      """
+    Then transaction commits
+    Given connection open schema transaction for database: typedb
+    Then typeql redefine
+      """
+      redefine attribute name value long;
+      """
+    Then transaction commits
+
+
+  Scenario: an attribute ownership can be converted to a key ownership
+    When typeql define
+      """
+      define person owns name @key;
+      """
+    Then transaction commits
+
+    Given connection open read transaction for database: typedb
+    When get answers of typeql get
+      """
+      match $x owns name @key; get;
+      """
+    Then uniquely identify answer concepts
+      | x            |
+      | label:person |
+
+
+  Scenario: an attribute key ownership can be converted to a regular ownership
+    When typeql define
+      """
+      define person owns email;
+      """
+    Then transaction commits
+
+    Given connection open read transaction for database: typedb
+    When get answers of typeql get
+      """
+      match $x owns email; get;
+      """
+    Then uniquely identify answer concepts
+      | x            |
+      | label:person |
+    When get answers of typeql get
+      """
+      match $x owns email @key; get;
+      """
+    Then answer size is: 0
+
+
+  Scenario: defining a uniqueness on existing ownership is possible if data conforms to uniqueness requirements
+    Given typeql define
+      """
+      define person owns name @card(0..);
+      """
+    Given transaction commits
+    Given connection open write transaction for database: typedb
+    When typeql insert
+      """
+      insert $x isa person, has name "Bob", has email "bob@gmail.com";
+      """
+    Then typeql insert
+      """
+      insert $x isa person, has name "Jane", has name "Doe", has email "janedoe@gmail.com";
+      """
+    Given transaction commits
+    Given connection open schema transaction for database: typedb
+    Given typeql define
+      """
+      define person owns name @unique;
+      """
+    Then transaction commits
+    Given connection open write transaction for database: typedb
+    Given typeql insert; fails
+      """
+      insert $x isa person, has name "Bob", has email "bob2@gmail.com";
+      """
+
+
+  Scenario: defining a uniqueness on existing ownership fail if data does not conform to uniqueness requirements
+    Given transaction closes
+    Given connection open write transaction for database: typedb
+    When typeql insert
+      """
+      insert $x isa person, has name "Bob", has email "bob@gmail.com";
+      """
+    Then typeql insert
+      """
+      insert $x isa person, has name "Bob", has email "bob2@gmail.com";
+      """
+    Given transaction commits
+    Given connection open schema transaction for database: typedb
+    Given typeql define; fails
+      """
+      define person owns name @unique;
+      """
+
+
+  Scenario: a key ownership can be converted to a unique ownership
+    Given transaction closes
+    Given connection open write transaction for database: typedb
+    Given typeql insert
+      """
+      insert
+      $x isa person, has email "jane@gmail.com";
+      $y isa person, has email "john@gmail.com";
+      """
+    Given transaction commits
+    Given connection open schema transaction for database: typedb
+    Given typeql redefine
+      """
+      redefine person owns email @unique;
+      """
+    Then transaction commits
+    Given connection open write transaction for database: typedb
+    When get answers of typeql get
+      """
+      match $x owns $y @unique; get;
+      """
+    Then uniquely identify answer concepts
+      | x            | y              |
+      | label:person | label:email    |
+      | label:person | label:phone-nr |
+    When get answers of typeql get
+      """
+      match person owns $y @key; get;
+      """
+    Then answer size is: 0
+    Given typeql insert; fails
+      """
+      insert $x isa person, has email "jane@gmail.com";
+      """
+
+
+  Scenario: ownership uniqueness can be removed
+    Given typeql define
+      """
+      define person owns phone-nr;
+      """
+    Given transaction commits
+    Given connection open write transaction for database: typedb
+    Given typeql insert
+      """
+      insert
+      $x isa person, has phone-nr "123", has email "abc@gmail.com";
+      $y isa person, has phone-nr "456", has email "xyz@gmail.com";
+      """
+    Given transaction commits
+
+
+  Scenario: converting unique to key is possible if the data conforms to key requirements
+    Given transaction closes
+    Given connection open write transaction for database: typedb
+    Given typeql insert
+      """
+      insert
+      $x isa person, has phone-nr "123", has email "abc@gmail.com";
+      $y isa person, has phone-nr "456", has email "xyz@gmail.com";
+      """
+    Given transaction commits
+    Given connection open schema transaction for database: typedb
+    Given typeql redefine
+      """
+      redefine
+      person owns phone-nr @key;
+      """
+    Then transaction commits
+    Given connection open write transaction for database: typedb
+    Then typeql insert; fails
+      """
+      insert $x isa person, has phone-nr "9999", has phone-nr "8888", has email "pqr@gmail.com";
+      """
+
+
+  Scenario: converting unique to key fails if the data does not conform to key requirements
+    Given transaction closes
+    Given connection open write transaction for database: typedb
+    Given typeql insert
+      """
+      insert $x isa person, has phone-nr "123", has phone-nr "456", has email "abc@gmail.com";
+      """
+    Given transaction commits
+    Given connection open schema transaction for database: typedb
+    Then typeql redefine; fails
+      """
+      redefine
+      person owns phone-nr @key;
+      """
+
+
+  #############################
+  # SCHEMA MUTATION: ABSTRACT #
+  #############################
+
+  Scenario: a concrete entity type can be converted to an abstract entity type
+    When typeql define
+      """
+      define person @abstract;
+      """
+    Then transaction commits
+
+    When connection open read transaction for database: typedb
+    When get answers of typeql get
+      """
+      match $x sub person; $x @abstract; get;
+      """
+    Then uniquely identify answer concepts
+      | x            |
+      | label:person |
+
+
+  Scenario: a concrete relation type can be converted to an abstract relation type
+    When typeql define
+      """
+      define relation friendship relates friend;
+      """
+    Then transaction commits
+    Given connection open schema transaction for database: typedb
+    When typeql define
+      """
+      define friendship @abstract;
+      """
+    Then transaction commits
+
+    Given connection open read transaction for database: typedb
+    When get answers of typeql get
+      """
+      match $x sub friendship @abstract; get;
+      """
+    Then uniquely identify answer concepts
+      | x                |
+      | label:friendship |
+
+
+  Scenario: a concrete attribute type can be converted to an abstract attribute type
+    When typeql define
+      """
+      define attribute age value long;
+      """
+    Then transaction commits
+    Given connection open schema transaction for database: typedb
+    When typeql define
+      """
+      define age @abstract;
+      """
+    Then transaction commits
+    Given connection open read transaction for database: typedb
+    When get answers of typeql get
+      """
+      match $x sub age @abstract; get;
+      """
+    Then uniquely identify answer concepts
+      | x         |
+      | label:age |
+
+
+  Scenario: an existing entity type cannot be converted to abstract if it has existing instances
+    Given transaction closes
+    Given connection open write transaction for database: typedb
+    Given typeql insert
+      """
+      insert
+      $x isa person, has name "Jeremy", has email "jeremy@vaticle.com";
+      """
+    Given transaction commits
+
+    Given connection open schema transaction for database: typedb
+    Then typeql define; fails
+      """
+      define person @abstract;
+      """
+
+
+  Scenario: an existing relation type cannot be converted to abstract if it has existing instances
+    Given transaction closes
+    Given connection open write transaction for database: typedb
+    Given typeql insert
+      """
+      insert
+      $x isa person, has name "Jeremy", has email "jeremy@vaticle.com";
+      $r isa employment, links (employee: $x), has employment-reference-code "J123123";
+      """
+    Given transaction commits
+
+    Given connection open schema transaction for database: typedb
+    Then typeql define; fails
+      """
+      define employment @abstract;
+      """
+
+
+  Scenario: an existing attribute type cannot be converted to abstract if it has existing instances
+    Given transaction closes
+    Given connection open write transaction for database: typedb
+    Given typeql insert
+      """
+      insert
+      $x isa person, has name "Jeremy", has email "jeremy@vaticle.com";
+      """
+    Given transaction commits
+
+    Given connection open schema transaction for database: typedb
+    Then typeql define; fails
+      """
+      define name @abstract;
+      """
+
+
+  Scenario: changing a concrete type to abstract throws on commit if it has a concrete supertype
+
+  @ignore
+  # TODO: re-enable when rules are indexed
+  Scenario: changing a concrete relation type to abstract throws on commit if it appears in the conclusion of any rule
+
+#  @ignore
+#  # TODO: re-enable when rules are indexed
+#  Scenario: changing a concrete attribute type to abstract throws on commit if it appears in the conclusion of any rule
+
+  ######################
+  # HIERARCHY MUTATION #
+  ######################
+
+  Scenario: an existing entity type can be switched to a new supertype
+    Given typeql define
+      """
+      define
+      entity apple-product;
+      entity genius sub person;
+      """
+    Given transaction commits
+
+    Given connection open schema transaction for database: typedb
+    When typeql redefine
+      """
+      redefine
+      entity genius sub apple-product;
+      """
+    Then transaction commits
+
+    Given connection open read transaction for database: typedb
+    When get answers of typeql get
+      """
+      match $x sub apple-product; get;
+      """
+    Then uniquely identify answer concepts
+      | x                   |
+      | label:apple-product |
+      | label:genius        |
+
+
+  Scenario: an existing entity type cannot be switched to a new supertype through define
+    Given typeql define
+      """
+      define
+      entity apple-product;
+      entity genius sub person;
+      """
+    Given transaction commits
+
+    Given connection open schema transaction for database: typedb
+    Then typeql define; fails
+      """
+      define
+      entity genius sub apple-product;
+      """
+
+
+  Scenario: an existing relation type can be switched to a new supertype
+    Given typeql define
+      """
+      define
+      relation sabbatical sub employment;
+      relation vacation relates employee;
+      """
+    Given transaction commits
+
+    Given connection open schema transaction for database: typedb
+    When typeql redefine
+      """
+      redefine
+      relation sabbatical sub vacation;
+      """
+    Then transaction commits
+
+    Given connection open read transaction for database: typedb
+    When get answers of typeql get
+      """
+      match $x sub vacation; get;
+      """
+    Then uniquely identify answer concepts
+      | x                |
+      | label:vacation   |
+      | label:sabbatical |
+
+
+  Scenario: an existing relation type cannot be switched to a new supertype through define
+    Given typeql define
+      """
+      define
+      relation sabbatical sub employment;
+      relation vacation relates employee;
+      """
+    Given transaction commits
+
+    Given connection open schema transaction for database: typedb
+    Then typeql define; fails
+      """
+      define
+      relation sabbatical sub vacation;
+      """
+
+
+  Scenario: an existing attribute type can be switched to a new supertype with a matching value type
+    Given typeql define
+      """
+      define
+      attribute measure @abstract, value double;
+      attribute shoe-size sub measure;
+      entity shoe owns shoe-size;
+      """
+    Given transaction commits
+
+    Given connection open write transaction for database: typedb
+    # TODO: 9 is considered long, while it should be transformed into double before thing_manager
+    Given typeql insert
+      """
+      insert $s isa shoe, has shoe-size 9;
+      """
+    Given transaction commits
+
+    Given connection open schema transaction for database: typedb
+    When typeql define
+      """
+      define
+      attribute size value double @abstract;
+      attribute shoe-size sub size;
+      """
+    # TODO: This will probably fail because of the value type redundancy. Move this test to redefine/undefine?
+    Then transaction commits
+
+    When connection open read transaction for database: typedb
+    When get answers of typeql get
+      """
+      match $x sub shoe-size; get;
+      """
+    Then uniquely identify answer concepts
+      | x               |
+      | label:shoe-size |
+
+
+  Scenario: assigning a supertype without previous supertype succeeds even if they have different attributes + roles, if there are no instances
+    Given typeql define
+      """
+      define
+      entity species owns name, plays species-membership:species;
+      relation species-membership relates species, relates member;
+      attribute lifespan value double;
+      entity organism owns lifespan, plays species-membership:member;
+      entity child sub person;
+      """
+    Given transaction commits
+
+    Given connection open schema transaction for database: typedb
+    When typeql define
+      """
+      define
+      entity person sub organism;
+      """
+    Then transaction commits
+
+    Given connection open read transaction for database: typedb
+    When get answers of typeql get
+      """
+      match $x sub organism; get;
+      """
+    Then uniquely identify answer concepts
+      | x              |
+      | label:organism |
+      | label:person   |
+      | label:child    |
+
+
+  Scenario: assigning a supertype while having another supertype succeeds even if they have different attributes + roles, if there are no instances
+    Given typeql define
+      """
+      define
+      entity person sub species;
+      entity species owns name, plays species-membership:species;
+      relation species-membership relates species, relates member;
+      attribute lifespan value double;
+      entity organism owns lifespan, plays species-membership:member;
+      entity child sub person;
+      """
+    Given transaction commits
+
+    Given connection open schema transaction for database: typedb
+    When typeql define
+      """
+      redefine
+      entity person sub organism;
+      """
+    Then transaction commits
+
+    Given connection open read transaction for database: typedb
+    When get answers of typeql get
+      """
+      match $x sub organism; get;
+      """
+    Then uniquely identify answer concepts
+      | x              |
+      | label:organism |
+      | label:person   |
+      | label:child    |
+
+
+  Scenario: assigning a new supertype when having other sub succeeds even with existing data if the supertypes have no properties
+    Given typeql define
+      """
+      define
+      entity bird;
+      entity pigeon sub bird;
+      """
+    Given transaction commits
+
+    Given connection open write transaction for database: typedb
+    Given typeql insert
+      """
+      insert $p isa pigeon;
+      """
+    Given transaction commits
+
+    Given connection open schema transaction for database: typedb
+    When typeql define
+      """
+      define
+      entity animal;
+      """
+    When typeql redefine
+      """
+      redefine
+      entity pigeon sub animal;
+      """
+    Then transaction commits
+
+    Given connection open read transaction for database: typedb
+    When get answers of typeql get
+      """
+      match $x sub pigeon; get;
+      """
+    Then uniquely identify answer concepts
+      | x            |
+      | label:pigeon |
+
+
+  Scenario: assigning a new supertype when having other sub succeeds with existing data if the supertypes play the same roles
+    Given typeql define
+      """
+      define
+      entity bird plays flying:flier;
+      entity pigeon sub bird;
+      relation flying relates flier;
+      """
+    Given transaction commits
+
+    Given connection open write transaction for database: typedb
+    Given typeql insert
+      """
+      insert $p isa pigeon;
+      """
+    Given transaction commits
+
+    Given connection open schema transaction for database: typedb
+    When typeql redefine
+      """
+      redefine
+      entity animal plays flying:flier;
+      entity pigeon sub animal;
+      """
+    Then transaction commits
+
+    Given connection open read transaction for database: typedb
+    When get answers of typeql get
+      """
+      match $x sub pigeon; get;
+      """
+    Then uniquely identify answer concepts
+      | x            |
+      | label:pigeon |
+
+
+  Scenario: assigning a new supertype when having other sub succeeds with existing data if the supertypes have the same attributes
+    Given typeql define
+      """
+      define
+      attribute name value string;
+      entity bird owns name;
+      entity pigeon sub bird;
+      """
+    Given transaction commits
+
+    Given connection open write transaction for database: typedb
+    Given typeql insert
+      """
+      insert $p isa pigeon;
+      """
+    Given transaction commits
+
+    Given connection open schema transaction for database: typedb
+    When typeql redefine
+      """
+      redefine
+      entity animal owns name;
+      entity pigeon sub animal;
+      """
+    Then transaction commits
+
+    Given connection open read transaction for database: typedb
+    When get answers of typeql get
+      """
+      match $x sub pigeon; get;
+      """
+    Then uniquely identify answer concepts
+      | x            |
+      | label:pigeon |
+
+
+  Scenario: assigning a new supertype when having another supertype through define fails without preceding redefine/undefine
+    Given typeql define
+      """
+      define
+      entity bird;
+      entity pigeon sub bird;
+      """
+    Given transaction commits
+
+    Given connection open write transaction for database: typedb
+    Given typeql insert
+      """
+      insert $p isa pigeon;
+      """
+    Given transaction commits
+
+    Given connection open schema transaction for database: typedb
+    Then typeql define; fails
+      """
+      define
+      entity animal;
+      entity pigeon sub animal;
+      """
+
+    Given typeql define
+      """
+      define
+      attribute name value string;
+      entity bird2 owns name;
+      entity pigeon2 sub bird2;
+      """
+    Given transaction commits
+
+    Given connection open write transaction for database: typedb
+    Given typeql insert
+      """
+      insert $p isa pigeon2;
+      """
+    Given transaction commits
+
+    Given connection open schema transaction for database: typedb
+    Then typeql define; fails
+      """
+      define
+      entity animal owns name;
+      entity pigeon2 sub animal;
+      """
+
+    Given typeql define
+      """
+      define
+      entity bird3 plays flying:flier;
+      entity pigeon3 sub bird3;
+      relation flying relates flier;
+      """
+    Given transaction commits
+
+    Given connection open write transaction for database: typedb
+    Given typeql insert
+      """
+      insert $p isa pigeon3;
+      """
+    Given transaction commits
+
+    Given connection open schema transaction for database: typedb
+    Then typeql define; fails
+      """
+      define
+      entity animal plays flying:flier;
+      entity pigeon3 sub animal;
+      """
+
+  Scenario: assigning a supertype while having another supertype through define fails even if there are no instances
+    Given typeql define
+      """
+      define
+      entity person sub organism;
+      entity species owns name, plays species-membership:species;
+      relation species-membership relates species, relates member;
+      attribute lifespan value double;
+      entity organism owns lifespan, plays species-membership:member;
+      entity child sub person;
+      """
+    Given transaction commits
+
+    Given connection open schema transaction for database: typedb
+    Then typeql define; fails
+      """
+      define
+      entity person sub species;
+      """
+
+
+  # TODO: write this once 'assign new supertype .. with existing data' succeeds if the supertypes have the same attributes
+  Scenario: assigning a new supertype throws if existing data has attributes not present on the new supertype
+
+  # TODO: write this once 'assign new supertype .. with existing data' succeeds if the supertypes play the same roles
+  Scenario: assigning a new supertype throws if existing data plays a role that it can't with the new supertype
+
+  # TODO: write this once 'assign new supertype throws if .. data has attributes not present on the new supertype' is written
+  Scenario: assigning a new supertype throws if that supertype has a has not @key present in the existing data (?)
+
+  # TODO: write this once 'define new 'sub' on relation type changes its supertype' is written
+  Scenario: assigning a new super-relation throws if existing data has roleplayers not present on the new supertype (?)
+
+  # TODO: write this once 'define new 'sub' on attribute type changes its supertype' passes
+  Scenario: assigning a new super-attribute throws if it has a different value type (?)
+
+  # TODO: write this if 'assign new super-attribute throws if it has a different value type ..' turns out to not throw
+  Scenario: assigning a new super-attribute throws if it has existing data and a different value type (?)
+
+  # TODO: write this once 'define new 'sub' on attribute type changes its supertype' passes
+  Scenario: assigning a new super-attribute throws if the new supertype has a regex and existing data doesn't match it (?)
+
+  ###############################
+  # SCHEMA MUTATION INHERITANCE #
+  ###############################
+
+
+  Scenario: when adding a playable role to an existing type, the change is propagated to its subtypes
+    Given typeql define
+      """
+      define
+      relation employment relates employer;
+      entity child sub person;
+      entity person plays employment:employer;
+      """
+    Given transaction commits
+
+    Given connection open read transaction for database: typedb
+    When get answers of typeql get
+      """
+      match $x type child, plays $r; get;
+      """
+    Then uniquely identify answer concepts
+      | x           | r                         |
+      | label:child | label:employment:employee |
+      | label:child | label:employment:employer |
+      | label:child | label:income:earner       |
+
+
+  Scenario: when adding an attribute ownership to an existing type, the change is propagated to its subtypes
+    Given typeql define
+    """
+       define
+       entity person owns mobile;
+       attribute mobile value long;
+       entity child sub person;
+      """
+    Given transaction commits
+
+    Given connection open read transaction for database: typedb
+    When get answers of typeql get
+      """
+      match $x type child, owns $y; get;
+      """
+    Then uniquely identify answer concepts
+      | x           | y              |
+      | label:child | label:name     |
+      | label:child | label:mobile   |
+      | label:child | label:email    |
+      | label:child | label:phone-nr |
+
+
+  Scenario: when adding a key ownership to an existing type, the change is propagated to its subtypes
+    Given typeql define
+      """
+      define
+      entity child sub person;
+      attribute phone-number value long;
+      entity person owns phone-number @key;
+      """
+    Given transaction commits
+
+    Given connection open read transaction for database: typedb
+    When get answers of typeql get
+      """
+      match $x type child, owns $y @key; get;
+      """
+    Then uniquely identify answer concepts
+      | x           | y                  |
+      | label:child | label:email        |
+      | label:child | label:phone-number |
+
+
+  Scenario: when adding a related role to an existing relation type, the change is propagated to all its subtypes
+    Given typeql define
+      """
+      define
+      relation part-time-employment sub employment;
+      relation employment relates employer;
+      """
+    Given transaction commits
+
+    Given connection open read transaction for database: typedb
+    When get answers of typeql get
+      """
+      match $x type part-time-employment, relates $r; get;
+      """
+    Then uniquely identify answer concepts
+      | x                          | r                         |
+      | label:part-time-employment | label:employment:employee |
+      | label:part-time-employment | label:employment:employer |
+
+
+  ####################
+  # TRANSACTIONALITY #
+  ####################
+
+  Scenario: uncommitted transaction writes are not persisted
+    When typeql define
+      """
+      define entity dog;
+      """
+    # TODO: The current framework doesn't support another transaction from the same client without closing the
+    # already existing one. It might contradict the test!
+    Given transaction closes
+    Given connection open read transaction for database: typedb
+    Then typeql get; fails
+      """
+      match $x type dog; get;
+      """
+
+
+  ########################
+  # CYCLIC SCHEMA GRAPHS #
+  ########################
+
+  Scenario: a type cannot be a subtype of itself
+    Then typeql define; fails
+      """
+      define dog sub dog;
+      """
+
+
+  Scenario: a cyclic type hierarchy is not allowed
+    Then typeql define; fails
+      """
+      define
+      entity giant sub person;
+      entity green-giant sub giant;
+      entity person sub green-giant;
+      """
+
+
+  Scenario: a relation type can relate to a role that it plays itself
+    When typeql define
+      """
+      define
+      relation recursive-function relates function, plays recursive-function:function;
+      """
+    Then transaction commits
+
+    Given connection open read transaction for database: typedb
+    When get answers of typeql get
+      """
+      match $x relates function; $x plays recursive-function:function; get;
+      """
+    Then uniquely identify answer concepts
+      | x                        |
+      | label:recursive-function |
+
+
+  Scenario: two relation types in a type hierarchy can play each other's roles
+    When typeql define
+      """
+      define
+      relation apple @abstract, relates role1, plays big-apple:role2;
+      relation big-apple sub apple, plays apple:role1, relates role2;
+      """
+
+
+  Scenario: relation types that play roles in their transitive subtypes can be reliably defined
+
+  Variables from a 'define' query are selected for defining in an arbitrary order. When these variables
+  depend on each other, creating a dependency graph, they should all define successfully regardless of
+  which variable was picked as the start vertex (#131)
+
+    When typeql define
+      """
+      define
+
+      relation apple @abstract, relates source @abstract, plays huge-apple:grows-from;
+      relation big-apple @abstract, sub apple;
+      relation huge-apple sub big-apple, relates tree as source, relates grows-from;
+
+      relation banana @abstract, relates source @abstract, plays huge-banana:grows-from;
+      relation big-banana @abstract, sub banana;
+      relation huge-banana sub big-banana, relates tree as source, relates grows-from;
+
+      relation orange @abstract, relates source @abstract, plays huge-orange:grows-from;
+      relation big-orange @abstract, sub orange;
+      relation huge-orange sub big-orange, relates tree as source, relates grows-from;
+
+      relation pear @abstract, relates source @abstract, plays huge-pear:grows-from;
+      relation big-pear @abstract, sub pear;
+      relation huge-pear sub big-pear, relates tree as source, relates grows-from;
+
+      relation tomato @abstract, relates source @abstract, plays huge-tomato:grows-from;
+      relation big-tomato @abstract, sub tomato;
+      relation huge-tomato sub big-tomato, relates tree as source, relates grows-from;
+
+      relation watermelon @abstract, relates source @abstract, plays huge-watermelon:grows-from;
+      relation big-watermelon @abstract, sub watermelon;
+      relation huge-watermelon sub big-watermelon, relates tree as source, relates grows-from;
+
+      relation lemon @abstract, relates source @abstract, plays huge-lemon:grows-from;
+      relation big-lemon @abstract, sub lemon;
+      relation huge-lemon sub big-lemon, relates tree as source, relates grows-from;
+
+      relation lime @abstract, relates source @abstract, plays huge-lime:grows-from;
+      relation big-lime @abstract, sub lime;
+      relation huge-lime sub big-lime, relates tree as source, relates grows-from;
+
+      relation mango @abstract, relates source @abstract, plays huge-mango:grows-from;
+      relation big-mango @abstract, sub mango;
+      relation huge-mango sub big-mango, relates tree as source, relates grows-from;
+
+      relation pineapple @abstract, relates source @abstract, plays huge-pineapple:grows-from;
+      relation big-pineapple @abstract, sub pineapple;
+      relation huge-pineapple sub big-pineapple, relates tree as source, relates grows-from;
+      """
+    Then transaction commits

--- a/query/language/redefine.feature
+++ b/query/language/redefine.feature
@@ -113,6 +113,58 @@ Feature: TypeQL Redefine Query
       | label:child  |
 
 
+  Scenario: cannot redefine entity types' relates
+    Then typeql redefine; fails
+      """
+      redefine entity child relates employee;
+      """
+    Then typeql redefine; fails
+      """
+      redefine entity child relates employee[];
+      """
+
+
+  Scenario: can redefine entity type's owns ordering
+    Then typeql define; fails
+      """
+      define entity person owns name[];
+      """
+    When transaction closes
+
+    When connection open schema transaction for database: typedb
+    When typeql redefine
+      """
+      redefine entity person owns name[];
+      """
+    Then transaction commits
+
+    When connection open read transaction for database: typedb
+    When get answers of typeql get
+      """
+      match $x owns name[]; get;
+      """
+    Then uniquely identify answer concepts
+      | x            |
+      | label:person |
+    When transaction closes
+
+    When connection open schema transaction for database: typedb
+    When typeql redefine
+      """
+      redefine entity person owns name;
+      """
+    Then transaction commits
+
+    When connection open read transaction for database: typedb
+    When get answers of typeql get
+      """
+      match $x owns name; get;
+      """
+    Then uniquely identify answer concepts
+      | x            |
+      | label:person |
+
+
   Scenario: redefining an entity type without a kind is acceptable
     When typeql define
       """
@@ -236,6 +288,88 @@ Feature: TypeQL Redefine Query
       | x                          |
       | label:employment           |
       | label:part-time-employment |
+
+
+  Scenario: can redefine relation type's relates ordering
+    Then typeql define; fails
+      """
+      define relation employment relates employee[];
+      """
+    When transaction closes
+
+    When connection open schema transaction for database: typedb
+    When typeql redefine
+      """
+      redefine relation employment relates employee[];
+      """
+    Then transaction commits
+
+    When connection open read transaction for database: typedb
+    When get answers of typeql get
+      """
+      match $x relates employee[]; get;
+      """
+    Then uniquely identify answer concepts
+      | x                |
+      | label:employment |
+    When transaction closes
+
+    When connection open schema transaction for database: typedb
+    When typeql redefine
+      """
+      redefine relation employment relates employee;
+      """
+    Then transaction commits
+
+    When connection open read transaction for database: typedb
+    When get answers of typeql get
+      """
+      match $x relates employee; get;
+      """
+    Then uniquely identify answer concepts
+      | x                |
+      | label:employment |
+
+
+  Scenario: can redefine relation type's owns ordering
+    Then typeql define; fails
+      """
+      define relation employment owns start-date[];
+      """
+    When transaction closes
+
+    When connection open schema transaction for database: typedb
+    When typeql redefine
+      """
+      redefine relation employment owns start-date[];
+      """
+    Then transaction commits
+
+    When connection open read transaction for database: typedb
+    When get answers of typeql get
+      """
+      match $x owns start-date[]; get;
+      """
+    Then uniquely identify answer concepts
+      | x                |
+      | label:employment |
+    When transaction closes
+
+    When connection open schema transaction for database: typedb
+    When typeql redefine
+      """
+      redefine relation employment owns start-date;
+      """
+    Then transaction commits
+
+    When connection open read transaction for database: typedb
+    When get answers of typeql get
+      """
+      match $x owns start-date; get;
+      """
+    Then uniquely identify answer concepts
+      | x                |
+      | label:employment |
 
 
   Scenario: redefining a relation type without a kind is acceptable
@@ -1105,3 +1239,7 @@ Feature: TypeQL Redefine Query
     Then uniquely identify answer concepts
       | x            |
       | label:pigeon |
+
+
+    # TODO 3.0: Add tests for structs
+    # TODO 3.0: Add tests for functions?


### PR DESCRIPTION
## Usage and product changes
We add base tests for `define` and `redefine` queries.

`define`:
* adapted the outdated grammar to the new 3.0 syntax;
* added more cases, especially for annotations;
* moved some tests that require `redefine` to the respective file;
* 5 tests fail because they wait for other queries and actions to be completed, there are some specific TODOs in the file for it;
* still requires a number of new features to be covered, it will be completed additionally.

`redefine`:
* added a new file for this type of queries;
* covered minimal base cases for types and all annotations (as a POC that it works as intended);
* still requires a number of new features to be covered, it will be completed additionally.

