### PR TITLE
Reimagine driver tests for 3.0 

### DIFF
--- a/concept/migration/data-validation.feature
+++ b/concept/migration/data-validation.feature
@@ -8,8 +8,8 @@ Feature: Data validation
   Background:
     Given typedb starts
     Given connection opens with default authentication
-    Given connection has been opened
-    Given connection does not have any database
+    Given connection is open: true
+    Given connection has 0 databases
     Given connection create database: typedb
     Given connection open schema transaction for database: typedb
 

--- a/concept/migration/function.feature
+++ b/concept/migration/function.feature
@@ -8,8 +8,8 @@ Feature: Schema validation
   Background:
     Given typedb starts
     Given connection opens with default authentication
-    Given connection has been opened
-    Given connection does not have any database
+    Given connection is open: true
+    Given connection has 0 databases
     Given connection create database: typedb
     Given connection open schema transaction for database: typedb
 
@@ -17,7 +17,7 @@ Feature: Schema validation
 
 #  TODO: Refactor to functions
 #  Scenario: Types which are referenced in rules may not be renamed
-#    Given typeql define
+#    Given typeql schema query
 #    """
 #    define
 #      rel00 sub relation, relates role00;
@@ -39,7 +39,7 @@ Feature: Schema validation
 
 #  TODO: Refactor to functions
 #  Scenario: Types which are referenced in rules may not be deleted
-#    Given typeql define
+#    Given typeql schema query
 #    """
 #    define
 #      rel00 sub relation, relates role00, relates extra_role;
@@ -75,7 +75,7 @@ Feature: Schema validation
 
 #  TODO: Refactor to functions
 #  Scenario: Rules made unsatisfiable by schema modifications are flagged at commit time
-#    Given typeql define
+#    Given typeql schema query
 #    """
 #    define
 #      rel00 sub relation, relates role00, relates extra_role;

--- a/concept/migration/migration.feature
+++ b/concept/migration/migration.feature
@@ -8,8 +8,8 @@ Feature: Schema migration
   Background:
     Given typedb starts
     Given connection opens with default authentication
-    Given connection has been opened
-    Given connection does not have any database
+    Given connection is open: true
+    Given connection has 0 databases
     Given connection create database: typedb
     Given connection open schema transaction for database: typedb
 

--- a/concept/thing/attribute.feature
+++ b/concept/thing/attribute.feature
@@ -8,8 +8,8 @@ Feature: Concept Attribute
   Background:
     Given typedb starts
     Given connection opens with default authentication
-    Given connection has been opened
-    Given connection does not have any database
+    Given connection is open: true
+    Given connection has 0 databases
     Given connection create database: typedb
     Given connection open schema transaction for database: typedb
     # Write schema for the test scenarios

--- a/concept/thing/entity.feature
+++ b/concept/thing/entity.feature
@@ -8,8 +8,8 @@ Feature: Concept Entity
   Background:
     Given typedb starts
     Given connection opens with default authentication
-    Given connection has been opened
-    Given connection does not have any database
+    Given connection is open: true
+    Given connection has 0 databases
     Given connection create database: typedb
     Given connection open schema transaction for database: typedb
     # Write schema for the test scenarios

--- a/concept/thing/has.feature
+++ b/concept/thing/has.feature
@@ -8,8 +8,8 @@ Feature: Concept Ownership
   Background:
     Given typedb starts
     Given connection opens with default authentication
-    Given connection has been opened
-    Given connection does not have any database
+    Given connection is open: true
+    Given connection has 0 databases
     Given connection create database: typedb
     Given connection open schema transaction for database: typedb
     # Write schema for the test scenarios

--- a/concept/thing/relation.feature
+++ b/concept/thing/relation.feature
@@ -8,8 +8,8 @@ Feature: Concept Relation
   Background:
     Given typedb starts
     Given connection opens with default authentication
-    Given connection has been opened
-    Given connection does not have any database
+    Given connection is open: true
+    Given connection has 0 databases
     Given connection create database: typedb
     Given connection open schema transaction for database: typedb
 

--- a/concept/thing/roleplayer.feature
+++ b/concept/thing/roleplayer.feature
@@ -8,8 +8,8 @@ Feature: Concept Role Players
   Background:
     Given typedb starts
     Given connection opens with default authentication
-    Given connection has been opened
-    Given connection does not have any database
+    Given connection is open: true
+    Given connection has 0 databases
     Given connection create database: typedb
     Given connection open schema transaction for database: typedb
 

--- a/concept/type/attributetype.feature
+++ b/concept/type/attributetype.feature
@@ -8,7 +8,7 @@ Feature: Concept Attribute Type
   Background:
     Given typedb starts
     Given connection opens with default authentication
-    Given connection has been opened
+    Given connection is open: true
     Given connection reset database: typedb
     Given connection open schema transaction for database: typedb
 

--- a/concept/type/entitytype.feature
+++ b/concept/type/entitytype.feature
@@ -8,7 +8,7 @@ Feature: Concept Entity Type
   Background:
     Given typedb starts
     Given connection opens with default authentication
-    Given connection has been opened
+    Given connection is open: true
     Given connection reset database: typedb
     Given connection open schema transaction for database: typedb
 

--- a/concept/type/owns-annotations.feature
+++ b/concept/type/owns-annotations.feature
@@ -10,7 +10,7 @@ Feature: Concept Owns Annotations
   Background:
     Given typedb starts
     Given connection opens with default authentication
-    Given connection has been opened
+    Given connection is open: true
     Given connection reset database: typedb
     Given connection open schema transaction for database: typedb
 

--- a/concept/type/owns.feature
+++ b/concept/type/owns.feature
@@ -8,7 +8,7 @@ Feature: Concept Owns
   Background:
     Given typedb starts
     Given connection opens with default authentication
-    Given connection has been opened
+    Given connection is open: true
     Given connection reset database: typedb
     Given connection open schema transaction for database: typedb
 

--- a/concept/type/plays.feature
+++ b/concept/type/plays.feature
@@ -8,7 +8,7 @@ Feature: Concept Plays
   Background:
     Given typedb starts
     Given connection opens with default authentication
-    Given connection has been opened
+    Given connection is open: true
     Given connection reset database: typedb
     Given connection open schema transaction for database: typedb
 

--- a/concept/type/relationtype.feature
+++ b/concept/type/relationtype.feature
@@ -8,7 +8,7 @@ Feature: Concept Relation Type and Role Type
   Background:
     Given typedb starts
     Given connection opens with default authentication
-    Given connection has been opened
+    Given connection is open: true
     Given connection reset database: typedb
     Given connection open schema transaction for database: typedb
 

--- a/connection/database.feature
+++ b/connection/database.feature
@@ -8,8 +8,8 @@ Feature: Connection Database
   Background:
     Given typedb starts
     Given connection opens with default authentication
-    Given connection has been opened
-    Given connection does not have any database
+    Given connection is open: true
+    Given connection has 0 databases
 
   Scenario: create one database
     When connection create database: alice
@@ -54,7 +54,7 @@ Feature: Connection Database
     Given connection create database: alice
     When connection delete database: alice
     Then connection does not have database: alice
-    Then connection does not have any database
+    Then connection has 0 databases
 
   Scenario: connection can delete many databases
       Given connection create databases:
@@ -81,7 +81,7 @@ Feature: Connection Database
       | eve     |
       | frank   |
 
-    Then connection does not have any database
+    Then connection has 0 databases
 
   Scenario: delete many databases in parallel
       Given connection create databases in parallel:
@@ -108,7 +108,7 @@ Feature: Connection Database
       | eve     |
       | frank   |
 
-    Then connection does not have any database
+    Then connection has 0 databases
 
   Scenario: create delete and recreate a database
     When connection create database: alice
@@ -127,7 +127,7 @@ Feature: Connection Database
     When connection open schema transaction for database: typedb
     Then transaction is open: true
     Then connection delete database: typedb; fails
-    Then typeql define
+    Then typeql schema query
       """
       define entity person;
       """

--- a/connection/transaction.feature
+++ b/connection/transaction.feature
@@ -314,7 +314,7 @@ Feature: Connection Transaction
 #      """
 #      match entity $x;
 #      """
-#    Then answer size is: 0
+#    Then answer size: 0
 
     # TODO: Fix rollback
 #  Scenario: commit after a write transaction rollback does nothing
@@ -337,7 +337,7 @@ Feature: Connection Transaction
 #      """
 #      match $x isa person;
 #      """
-#    Then answer size is: 0
+#    Then answer size: 0
 
   @ignore-typedb
   Scenario: transaction timeouts are configurable

--- a/connection/transaction.feature
+++ b/connection/transaction.feature
@@ -8,8 +8,8 @@ Feature: Connection Transaction
   Background:
     Given typedb starts
     Given connection opens with default authentication
-    Given connection has been opened
-    Given connection does not have any database
+    Given connection is open: true
+    Given connection has 0 databases
 
   Scenario Outline: one database, one <type> transaction
     When connection create database: typedb
@@ -225,7 +225,7 @@ Feature: Connection Transaction
   Scenario Outline: write in a <type> transaction fails
     Given connection create database: typedb
     Given connection open schema transaction for database: typedb
-    Given typeql define
+    Given typeql schema query
       """
       define entity person;
       """
@@ -247,7 +247,7 @@ Feature: Connection Transaction
   Scenario Outline: <command> in a schema transaction fails
     Given connection create database: typedb
     Given connection open schema transaction for database: typedb
-    Given typeql define
+    Given typeql schema query
       """
       define entity person;
       """
@@ -261,7 +261,7 @@ Feature: Connection Transaction
   Scenario Outline: <command> in a write transaction fails
     Given connection create database: typedb
     Given connection open schema transaction for database: typedb
-    Given typeql define
+    Given typeql schema query
       """
       define entity person;
       """
@@ -281,7 +281,7 @@ Feature: Connection Transaction
   Scenario: schema modification in a write transaction fails
     Given connection create database: typedb
     Given connection open write transaction for database: typedb
-    Then typeql define; fails
+    Then typeql schema query; fails
       """
       define entity person;
       """
@@ -289,7 +289,7 @@ Feature: Connection Transaction
   Scenario: write data in a schema transaction is allowed
     Given connection create database: typedb
     Given connection open schema transaction for database: typedb
-    Then typeql define
+    Then typeql schema query
       """
       define entity person;
       """
@@ -303,7 +303,7 @@ Feature: Connection Transaction
 #  Scenario: commit after a schema transaction rollback does nothing
 #    Given connection create database: typedb
 #    Given connection open schema transaction for database: typedb
-#    When typeql define
+#    When typeql schema query
 #      """
 #      define entity person;
 #      """
@@ -320,7 +320,7 @@ Feature: Connection Transaction
 #  Scenario: commit after a write transaction rollback does nothing
 #    Given connection create database: typedb
 #    Given connection open schema transaction for database: typedb
-#    Given typeql define
+#    Given typeql schema query
 #      """
 #      define entity person;
 #      """
@@ -347,12 +347,12 @@ Feature: Connection Transaction
     Given set transaction option transaction-timeout-millis to: 10000
     When session opens transaction of type: write
     Then wait 8 seconds
-    Then typeql define
+    Then typeql schema query
       """
       define entity person;
       """
     Then wait 4 seconds
-    Then typeql define; fails
+    Then typeql schema query; fails
       """
       define entity person;
       """

--- a/driver/BUILD
+++ b/driver/BUILD
@@ -7,7 +7,7 @@ package(default_visibility = ["//visibility:public"])
 load("@vaticle_dependencies//tool/checkstyle:rules.bzl", "checkstyle_test")
 
 files = [
-    "query.feature",
+    "driver.feature",
 ]
 
 filegroup(

--- a/driver/driver.feature
+++ b/driver/driver.feature
@@ -747,7 +747,7 @@ Feature: TypeDB Driver
     Then answer get row(0) get relation(p) get type is role type: false
 
 
-  Scenario: Driver processes attributes correctly
+  Scenario Outline: Driver processes attributes of type <value-type> correctly
     Given connection open schema transaction for database: typedb
     Given typeql schema query
       """
@@ -786,4 +786,91 @@ Feature: TypeDB Driver
     Then answer get row(0) get attribute(a) get type is attribute type: true
     Then answer get row(0) get attribute(a) get type is role type: false
 
-    # TODO: Check value
+    Then answer get row(0) get attribute(a) get type get value type: <value-type>
+    Then answer get row(0) get attribute(a) is boolean: <is-boolean>
+    Then answer get row(0) get attribute(a) is long: <is-long>
+    Then answer get row(0) get attribute(a) is double: <is-double>
+    Then answer get row(0) get attribute(a) is decimal: <is-decimal>
+    Then answer get row(0) get attribute(a) is string: <is-string>
+    Then answer get row(0) get attribute(a) is date: <is-date>
+    Then answer get row(0) get attribute(a) is datetime: <is-datetime>
+    Then answer get row(0) get attribute(a) is datetime-tz: <is-datetime-tz>
+    Then answer get row(0) get attribute(a) is duration: <is-duration>
+    Then answer get row(0) get attribute(a) is struct: <is-struct>
+    Then answer get row(0) get attribute(a) get <value-type> value: <value>
+    Examples:
+      | value-type  | value                                       | is-boolean | is-long | is-double | is-decimal | is-string | is-date | is-datetime | is-datetime-tz | is-duration | is-struct |
+      | boolean     | true                                        | true       | false   | false     | false      | false     | false   | false       | false          | false       | false     |
+      | long        | 12345090                                    | false      | true    | false     | false      | false     | false   | false       | false          | false       | false     |
+      | double      | 2.01234567                                  | false      | false   | true      | false      | false     | false   | false       | false          | false       | false     |
+      | decimal     | 1234567890.0001234567890                    | false      | false   | false     | true       | false     | false   | false       | false          | false       | false     |
+      | string      | "John \"Baba Yaga\" Wick"                   | false      | false   | false     | false      | true      | false   | false       | false          | false       | false     |
+      | date        | 2024-09-20                                  | false      | false   | false     | false      | false     | true    | false       | false          | false       | false     |
+      | datetime    | 1999-02-26T12:15:05                         | false      | false   | false     | false      | false     | false   | true        | false          | false       | false     |
+      | datetime    | 1999-02-26T12:15:05.000000001               | false      | false   | false     | false      | false     | false   | true        | false          | false       | false     |
+      | datetime-tz | 2024-09-20T16:40:05 Europe/London           | false      | false   | false     | false      | false     | false   | false       | true           | false       | false     |
+      | datetime-tz | 2024-09-20T16:40:05.000000001 Europe/London | false      | false   | false     | false      | false     | false   | false       | true           | false       | false     |
+      | duration    | P1Y10M7DT15H44M5.00394892S                  | false      | false   | false     | false      | false     | false   | false       | false          | true        | false     |
+  # TODO: Implement structs
+#      | struct      |                                             | false      | false   | false     | false      | false     | false   | false       | false          | false       | true      |
+
+
+  Scenario Outline: Driver processes values of type <value-type> correctly
+    Given connection open schema transaction for database: typedb
+    Given typeql schema query
+      """
+      define entity person, owns typed; attribute typed, value <value-type>;
+      """
+    Given transaction commits
+    Given connection open write transaction for database: typedb
+    Given typeql write query
+      """
+      insert $p isa person, has typed <value>;
+      """
+    When get answers of typeql read query
+      """
+      match $_ isa person, has typed $v;
+      """
+    Then answer type: concept rows
+    Then answer size: 1
+
+    Then answer get row(0) get variable(v) is type: false
+    Then answer get row(0) get variable(v) is thing type: false
+    Then answer get row(0) get variable(v) is thing: false
+    Then answer get row(0) get variable(v) is value: true
+    Then answer get row(0) get variable(v) is entity type: false
+    Then answer get row(0) get variable(v) is relation type: false
+    Then answer get row(0) get variable(v) is attribute type: false
+    Then answer get row(0) get variable(v) is role type: false
+    Then answer get row(0) get variable(v) is entity: false
+    Then answer get row(0) get variable(v) is relation: false
+    Then answer get row(0) get variable(v) is attribute: false
+
+    Then answer get row(0) get value(v) get value type: <value-type>
+    Then answer get row(0) get value(v) is boolean: <is-boolean>
+    Then answer get row(0) get value(v) is long: <is-long>
+    Then answer get row(0) get value(v) is double: <is-double>
+    Then answer get row(0) get value(v) is decimal: <is-decimal>
+    Then answer get row(0) get value(v) is string: <is-string>
+    Then answer get row(0) get value(v) is date: <is-date>
+    Then answer get row(0) get value(v) is datetime: <is-datetime>
+    Then answer get row(0) get value(v) is datetime-tz: <is-datetime-tz>
+    Then answer get row(0) get value(v) is duration: <is-duration>
+    Then answer get row(0) get value(v) is struct: <is-struct>
+    Then answer get row(0) get value(v) get: <value>
+    Then answer get row(0) get value(v) as <value-type>: <value>
+    Examples:
+      | value-type  | value                                       | is-boolean | is-long | is-double | is-decimal | is-string | is-date | is-datetime | is-datetime-tz | is-duration | is-struct |
+      | boolean     | true                                        | true       | false   | false     | false      | false     | false   | false       | false          | false       | false     |
+      | long        | 12345090                                    | false      | true    | false     | false      | false     | false   | false       | false          | false       | false     |
+      | double      | 2.01234567                                  | false      | false   | true      | false      | false     | false   | false       | false          | false       | false     |
+      | decimal     | 1234567890.0001234567890                    | false      | false   | false     | true       | false     | false   | false       | false          | false       | false     |
+      | string      | "John \"Baba Yaga\" Wick"                   | false      | false   | false     | false      | true      | false   | false       | false          | false       | false     |
+      | date        | 2024-09-20                                  | false      | false   | false     | false      | false     | true    | false       | false          | false       | false     |
+      | datetime    | 1999-02-26T12:15:05                         | false      | false   | false     | false      | false     | false   | true        | false          | false       | false     |
+      | datetime    | 1999-02-26T12:15:05.000000001               | false      | false   | false     | false      | false     | false   | true        | false          | false       | false     |
+      | datetime-tz | 2024-09-20T16:40:05 Europe/London           | false      | false   | false     | false      | false     | false   | false       | true           | false       | false     |
+      | datetime-tz | 2024-09-20T16:40:05.000000001 Europe/London | false      | false   | false     | false      | false     | false   | false       | true           | false       | false     |
+      | duration    | P1Y10M7DT15H44M5.00394892S                  | false      | false   | false     | false      | false     | false   | false       | false          | true        | false     |
+  # TODO: Implement structs
+#      | struct      |                                             | false      | false   | false     | false      | false     | false   | false       | false          | false       | true      |

--- a/driver/driver.feature
+++ b/driver/driver.feature
@@ -375,7 +375,8 @@ Feature: TypeDB Driver
     Then answer query type is not schema
     Then answer query type is not write
     Then answer size: 1
-    Then answer header is: (p)
+    Then answer column names are:
+      | p |
     Then answer get row(0) get entity type(p) get label: person
     Then answer get row(0) get entity type by index of variable(p) get label: person
 
@@ -390,7 +391,9 @@ Feature: TypeDB Driver
     Then answer query type is not schema
     Then answer query type is not write
     Then answer size: 1
-    Then answer header is: (p, n)
+    Then answer column names are:
+      | p |
+      | n |
     Then answer get row(0) get entity type(p) get label: person
     Then answer get row(0) get attribute type(n) get label: name
     Then answer get row(0) get entity type by index of variable(p) get label: person
@@ -411,7 +414,9 @@ Feature: TypeDB Driver
     Then answer query type is not schema
     Then answer query type is not write
     Then answer size: 2
-    Then answer header is: (p, n)
+    Then answer column names are:
+      | p |
+      | n |
     Then answer get row(0) get entity type(p) get label: person
     Then answer get row(0) get attribute type(n) get label: name
     Then answer get row(0) get entity type by index of variable(p) get label: person
@@ -434,7 +439,9 @@ Feature: TypeDB Driver
     Then answer query type is not schema
     Then answer query type is not write
     Then answer size: 2
-    Then answer header is: (p, n)
+    Then answer column names are:
+      | p |
+      | n |
     Then answer get row(0) get entity type(p) get label: person
     Then answer get row(0) get attribute type(n) get label: name
     Then answer get row(0) get entity type by index of variable(p) get label: person
@@ -443,25 +450,21 @@ Feature: TypeDB Driver
     Then answer get row(1) get attribute type(n) get label: age
     Then answer get row(1) get entity type by index of variable(p) get label: person
     Then answer get row(1) get attribute type by index of variable(n) get label: age
-    Then transaction commits
 
     When get answers of typeql read query
       """
-      match relation $r;
+      match $p isa person;
       """
     Then answer type is concept rows
     Then answer type is not ok
     Then answer type is not concept trees
-    Then answer query type is read
-    Then answer query type is not schema
-    Then answer query type is not write
     Then answer size: 0
 
     When transaction closes
     When connection open write transaction for database: typedb
     When get answers of typeql write query
       """
-      insert person $p, has name "John";
+      insert $p isa person, has name "John";
       """
     Then answer type is concept rows
     Then answer type is not ok
@@ -470,9 +473,10 @@ Feature: TypeDB Driver
     Then answer query type is not schema
     Then answer query type is not read
     Then answer size: 1
-    Then answer header is: (p)
-    Then answer get row(0) get entity type(p) get label: person
-    Then answer get row(0) get entity type by index of variable(p) get label: person
+    Then answer column names are:
+      | p |
+    Then answer get row(0) get entity(p) get type get label: person
+    Then answer get row(0) get entity by index of variable(p) get type get label: person
 
     When get answers of typeql read query
       """
@@ -485,408 +489,548 @@ Feature: TypeDB Driver
     Then answer query type is not schema
     Then answer query type is not write
     Then answer size: 1
-    Then answer header is: (p, a)
+    Then answer column names are:
+      | p |
+      | a |
     Then answer get row(0) get entity(p) get type get label: person
     Then answer get row(0) get entity by index of variable(p) get type get label: person
     Then answer get row(0) get attribute(a) get type get label: name
     Then answer get row(0) get attribute(a) get string value: "John"
-    Then answer get row(0) get attribute by index of variable(n) get type get label: name
-    Then answer get row(0) get attribute by index of variable(n) get string value: "John"
+    Then answer get row(0) get attribute by index of variable(a) get type get label: name
+    Then answer get row(0) get attribute by index of variable(a) get string value: "John"
     Then transaction commits
 
 
-#  # TODO: Implement value groups checks
-#  #Scenario: Driver processes concept row query answers with value groups correctly
-#
-#
-#  # TODO: Implement concept trees checks
-#  #Scenario: Driver processes concept tree query answers correctly
-#
-#
-#  Scenario: Driver processes query errors correctly
-#    Given connection open schema transaction for database: typedb
-#    Then get answers of typeql schema query; fails
-#      """
-#      """
-#    Then get answers of typeql schema query; fails
-#      """
-#
-#      """
-#    Then get answers of typeql schema query; fails
-#      """
-#
-#      """
-#    Then get answers of typeql schema query; fails
-#      """
-#      define entity entity;
-#      """
-#    Then get answers of typeql schema query; fails
-#      """
-#      define attribute name owns name;
-#      """
-#
-#
-#  ############
-#  # CONCEPTS #
-#  ############
-#
-#  Scenario: Driver processes entity types correctly
+  # TODO: Implement value groups checks
+  #Scenario: Driver processes concept row query answers with value groups correctly
+
+
+  # TODO: Implement concept trees checks
+  #Scenario: Driver processes concept tree query answers correctly
+
+
+  Scenario: Driver processes query errors correctly
+    Given connection open schema transaction for database: typedb
+    Then typeql schema query; fails
+      """
+      """
+    Then typeql schema query; fails
+      """
+
+      """
+    Then typeql schema query; fails
+      """
+
+      """
+    Then typeql read query; fails
+      """
+      match relation $r;
+      """
+    Then typeql schema query; fails
+      """
+      define entity entity;
+      """
+    Then typeql schema query; fails
+      """
+      define attribute name owns name;
+      """
+
+
+  ############
+  # CONCEPTS #
+  ############
+
+  Scenario: Driver processes entity types correctly
+    Given connection open schema transaction for database: typedb
+    Given typeql schema query
+      """
+      define entity person;
+      """
+    When get answers of typeql read query
+      """
+      match entity $p;
+      """
+    Then answer type is concept rows
+    Then answer size: 1
+
+    Then answer get row(0) get variable(p) is type: true
+    Then answer get row(0) get variable(p) is thing type: true
+    Then answer get row(0) get variable(p) is thing: false
+    Then answer get row(0) get variable(p) is value: false
+    Then answer get row(0) get variable(p) is entity type: true
+    Then answer get row(0) get variable(p) is relation type: false
+    Then answer get row(0) get variable(p) is attribute type: false
+    Then answer get row(0) get variable(p) is role type: false
+    Then answer get row(0) get variable(p) is entity: false
+    Then answer get row(0) get variable(p) is relation: false
+    Then answer get row(0) get variable(p) is attribute: false
+
+    Then answer get row(0) get type(p) get label: person
+    Then answer get row(0) get thing type(p) get label: person
+    Then answer get row(0) get entity type(p) get label: person
+
+
+  Scenario: Driver processes relation types correctly
+    Given connection open schema transaction for database: typedb
+    Given typeql schema query
+      """
+      define relation parentship, relates parent;
+      """
+    When get answers of typeql read query
+      """
+      match relation $p;
+      """
+    Then answer type is concept rows
+    Then answer query type is read
+    Then answer size: 1
+
+    Then answer get row(0) get variable(p) is type: true
+    Then answer get row(0) get variable(p) is thing type: true
+    Then answer get row(0) get variable(p) is thing: false
+    Then answer get row(0) get variable(p) is value: false
+    Then answer get row(0) get variable(p) is entity type: false
+    Then answer get row(0) get variable(p) is relation type: true
+    Then answer get row(0) get variable(p) is attribute type: false
+    Then answer get row(0) get variable(p) is role type: false
+    Then answer get row(0) get variable(p) is entity: false
+    Then answer get row(0) get variable(p) is relation: false
+    Then answer get row(0) get variable(p) is attribute: false
+
+    Then answer get row(0) get type(p) get label: parentship
+    Then answer get row(0) get thing type(p) get label: parentship
+    Then answer get row(0) get relation type(p) get label: parentship
+
+
+  Scenario: Driver processes role types correctly
+    Given connection open schema transaction for database: typedb
+    Given typeql schema query
+      """
+      define relation parentship, relates parent;
+      """
+    When get answers of typeql read query
+      """
+      match $_ sub parentship, relates $p;
+      """
+    Then answer type is concept rows
+    Then answer query type is read
+    Then answer size: 1
+
+    Then answer get row(0) get variable(p) is type: true
+    Then answer get row(0) get variable(p) is thing type: false
+    Then answer get row(0) get variable(p) is thing: false
+    Then answer get row(0) get variable(p) is value: false
+    Then answer get row(0) get variable(p) is entity type: false
+    Then answer get row(0) get variable(p) is relation type: false
+    Then answer get row(0) get variable(p) is attribute type: false
+    Then answer get row(0) get variable(p) is role type: true
+    Then answer get row(0) get variable(p) is entity: false
+    Then answer get row(0) get variable(p) is relation: false
+    Then answer get row(0) get variable(p) is attribute: false
+
+    Then answer get row(0) get type(p) get label: parentship:parent
+    Then answer get row(0) get role type(p) get label: parentship:parent
+
+
+  Scenario: Driver processes attribute types without value type correctly
+    Given connection open schema transaction for database: typedb
+    Given typeql schema query
+      """
+      define attribute untyped @abstract;
+      """
+    When get answers of typeql read query
+      """
+      match attribute $a;
+      """
+    Then answer type is concept rows
+    Then answer query type is read
+    Then answer size: 1
+
+    Then answer get row(0) get variable(a) is type: true
+    Then answer get row(0) get variable(a) is thing type: true
+    Then answer get row(0) get variable(a) is thing: false
+    Then answer get row(0) get variable(a) is value: false
+    Then answer get row(0) get variable(a) is entity type: false
+    Then answer get row(0) get variable(a) is relation type: false
+    Then answer get row(0) get variable(a) is attribute type: true
+    Then answer get row(0) get variable(a) is role type: false
+    Then answer get row(0) get variable(a) is entity: false
+    Then answer get row(0) get variable(a) is relation: false
+    Then answer get row(0) get variable(a) is attribute: false
+
+    Then answer get row(0) get type(a) get label: untyped
+    Then answer get row(0) get thing type(a) get label: untyped
+    Then answer get row(0) get attribute type(a) get label: untyped
+
+    Then answer get row(0) get attribute type(a) get value type: none
+    Then answer get row(0) get attribute type(a) is untyped: true
+    Then answer get row(0) get attribute type(a) is boolean: false
+    Then answer get row(0) get attribute type(a) is long: false
+    Then answer get row(0) get attribute type(a) is double: false
+    Then answer get row(0) get attribute type(a) is decimal: false
+    Then answer get row(0) get attribute type(a) is string: false
+    Then answer get row(0) get attribute type(a) is date: false
+    Then answer get row(0) get attribute type(a) is datetime: false
+    Then answer get row(0) get attribute type(a) is datetime-tz: false
+    Then answer get row(0) get attribute type(a) is duration: false
+    Then answer get row(0) get attribute type(a) is struct: false
+
+
+  Scenario Outline: Driver processes attribute types with value type <value-type> correctly
+    Given connection open schema transaction for database: typedb
+    Given typeql schema query
+      """
+      define attribute typed, value <value-type>;
+      """
+    When get answers of typeql read query
+      """
+      match attribute $a;
+      """
+    Then answer type is concept rows
+    Then answer query type is read
+    Then answer size: 1
+
+    Then answer get row(0) get variable(a) is type: true
+    Then answer get row(0) get variable(a) is thing type: true
+    Then answer get row(0) get variable(a) is thing: false
+    Then answer get row(0) get variable(a) is value: false
+    Then answer get row(0) get variable(a) is entity type: false
+    Then answer get row(0) get variable(a) is relation type: false
+    Then answer get row(0) get variable(a) is attribute type: true
+    Then answer get row(0) get variable(a) is role type: false
+    Then answer get row(0) get variable(a) is entity: false
+    Then answer get row(0) get variable(a) is relation: false
+    Then answer get row(0) get variable(a) is attribute: false
+
+    Then answer get row(0) get type(a) get label: typed
+    Then answer get row(0) get thing type(a) get label: typed
+    Then answer get row(0) get attribute type(a) get label: typed
+
+    Then answer get row(0) get attribute type(a) get value type: <value-type>
+    Then answer get row(0) get attribute type(a) is untyped: false
+    Then answer get row(0) get attribute type(a) is boolean: <is-boolean>
+    Then answer get row(0) get attribute type(a) is long: <is-long>
+    Then answer get row(0) get attribute type(a) is double: <is-double>
+    Then answer get row(0) get attribute type(a) is decimal: <is-decimal>
+    Then answer get row(0) get attribute type(a) is string: <is-string>
+    Then answer get row(0) get attribute type(a) is date: <is-date>
+    Then answer get row(0) get attribute type(a) is datetime: <is-datetime>
+    Then answer get row(0) get attribute type(a) is datetime-tz: <is-datetime-tz>
+    Then answer get row(0) get attribute type(a) is duration: <is-duration>
+    Then answer get row(0) get attribute type(a) is struct: <is-struct>
+    Examples:
+      | value-type  | is-boolean | is-long | is-double | is-decimal | is-string | is-date | is-datetime | is-datetime-tz | is-duration | is-struct |
+      | boolean     | true       | false   | false     | false      | false     | false   | false       | false          | false       | false     |
+      | long        | false      | true    | false     | false      | false     | false   | false       | false          | false       | false     |
+      | double      | false      | false   | true      | false      | false     | false   | false       | false          | false       | false     |
+      | decimal     | false      | false   | false     | true       | false     | false   | false       | false          | false       | false     |
+      | string      | false      | false   | false     | false      | true      | false   | false       | false          | false       | false     |
+      | date        | false      | false   | false     | false      | false     | true    | false       | false          | false       | false     |
+      | datetime    | false      | false   | false     | false      | false     | false   | true        | false          | false       | false     |
+      | datetime-tz | false      | false   | false     | false      | false     | false   | false       | true           | false       | false     |
+      | duration    | false      | false   | false     | false      | false     | false   | false       | false          | true        | false     |
+
+
+  Scenario: Driver processes attribute types with value type struct correctly
+    Given connection open schema transaction for database: typedb
+    Given typeql schema query
+      """
+      define
+      attribute film, value film-properties;
+      struct film-genre:
+        name value string,
+        description value string,
+        invented value date;
+      struct film-properties:
+        name value string,
+        genre value film-genre,
+        duration value duration,
+        reviews value long,
+        score value double,
+        revenue value decimal,
+        premier value datetime,
+        local-premier value datetime-tz,
+        is-verified value boolean;
+      """
+    When get answers of typeql read query
+      """
+      match attribute $a;
+      """
+    Then answer type is concept rows
+    Then answer query type is read
+    Then answer size: 1
+
+    Then answer get row(0) get variable(a) is type: true
+    Then answer get row(0) get variable(a) is thing type: true
+    Then answer get row(0) get variable(a) is thing: false
+    Then answer get row(0) get variable(a) is value: false
+    Then answer get row(0) get variable(a) is entity type: false
+    Then answer get row(0) get variable(a) is relation type: false
+    Then answer get row(0) get variable(a) is attribute type: true
+    Then answer get row(0) get variable(a) is role type: false
+    Then answer get row(0) get variable(a) is entity: false
+    Then answer get row(0) get variable(a) is relation: false
+    Then answer get row(0) get variable(a) is attribute: false
+
+    Then answer get row(0) get type(a) get label: film
+    Then answer get row(0) get thing type(a) get label: film
+    Then answer get row(0) get attribute type(a) get label: film
+
+    Then answer get row(0) get attribute type(a) get value type: film-properties
+    Then answer get row(0) get attribute type(a) is untyped: false
+    Then answer get row(0) get attribute type(a) is boolean: false
+    Then answer get row(0) get attribute type(a) is long: false
+    Then answer get row(0) get attribute type(a) is double: false
+    Then answer get row(0) get attribute type(a) is decimal: false
+    Then answer get row(0) get attribute type(a) is string: false
+    Then answer get row(0) get attribute type(a) is date: false
+    Then answer get row(0) get attribute type(a) is datetime: false
+    Then answer get row(0) get attribute type(a) is datetime-tz: false
+    Then answer get row(0) get attribute type(a) is duration: false
+    Then answer get row(0) get attribute type(a) is struct: true
+
+
+  Scenario: Driver processes entities correctly
+    Given connection open schema transaction for database: typedb
+    Given typeql schema query
+      """
+      define entity person;
+      """
+    Given transaction commits
+    Given connection open write transaction for database: typedb
+    Given typeql write query
+      """
+      insert $p isa person;
+      """
+    When get answers of typeql read query
+      """
+      match $p isa person;
+      """
+    Then answer type is concept rows
+    Then answer query type is read
+    Then answer size: 1
+
+    Then answer get row(0) get variable(p) is type: false
+    Then answer get row(0) get variable(p) is thing type: false
+    Then answer get row(0) get variable(p) is thing: true
+    Then answer get row(0) get variable(p) is value: false
+    Then answer get row(0) get variable(p) is entity type: false
+    Then answer get row(0) get variable(p) is relation type: false
+    Then answer get row(0) get variable(p) is attribute type: false
+    Then answer get row(0) get variable(p) is role type: false
+    Then answer get row(0) get variable(p) is entity: true
+    Then answer get row(0) get variable(p) is relation: false
+    Then answer get row(0) get variable(p) is attribute: false
+
+    Then answer get row(0) get thing(p) get type get label: person
+    Then answer get row(0) get entity(p) get iid exists
+    Then answer get row(0) get entity(p) get type get label: person
+    Then answer get row(0) get entity(p) get type is entity: false
+    Then answer get row(0) get entity(p) get type is entity type: true
+    Then answer get row(0) get entity(p) get type is relation type: false
+    Then answer get row(0) get entity(p) get type is attribute type: false
+    Then answer get row(0) get entity(p) get type is role type: false
+
+
+  Scenario: Driver processes relations correctly
+    Given connection open schema transaction for database: typedb
+    Given typeql schema query
+      """
+      define relation parentship, relates parent;
+      """
+    Given transaction commits
+    Given connection open write transaction for database: typedb
+    Given typeql write query
+      """
+      insert $p isa parentship;
+      """
+    When get answers of typeql read query
+      """
+      match $p isa parentship;
+      """
+    Then answer type is concept rows
+    Then answer query type is read
+    Then answer size: 1
+
+    Then answer get row(0) get variable(p) is type: false
+    Then answer get row(0) get variable(p) is thing type: false
+    Then answer get row(0) get variable(p) is thing: true
+    Then answer get row(0) get variable(p) is value: false
+    Then answer get row(0) get variable(p) is entity type: false
+    Then answer get row(0) get variable(p) is relation type: false
+    Then answer get row(0) get variable(p) is attribute type: false
+    Then answer get row(0) get variable(p) is role type: false
+    Then answer get row(0) get variable(p) is entity: false
+    Then answer get row(0) get variable(p) is relation: true
+    Then answer get row(0) get variable(p) is attribute: false
+
+    Then answer get row(0) get thing(p) get type get label: parentship
+    Then answer get row(0) get relation(p) get iid exists
+    Then answer get row(0) get relation(p) get type get label: parentship
+    Then answer get row(0) get relation(p) get type is relation: false
+    Then answer get row(0) get relation(p) get type is entity type: false
+    Then answer get row(0) get relation(p) get type is relation type: true
+    Then answer get row(0) get relation(p) get type is attribute type: false
+    Then answer get row(0) get relation(p) get type is role type: false
+
+
+  Scenario Outline: Driver processes attributes of type <value-type> correctly
+    Given connection open schema transaction for database: typedb
+    Given typeql schema query
+      """
+      define entity person, owns typed; attribute typed, value <value-type>;
+      """
+    Given transaction commits
+    Given connection open write transaction for database: typedb
+    Given typeql write query
+      """
+      insert $p isa person, has typed <value>;
+      """
+    When get answers of typeql read query
+      """
+      match $_ isa person, has $a;
+      """
+    Then answer type is concept rows
+    Then answer query type is read
+    Then answer size: 1
+
+    Then answer get row(0) get variable(a) is type: false
+    Then answer get row(0) get variable(a) is thing type: false
+    Then answer get row(0) get variable(a) is thing: true
+    Then answer get row(0) get variable(a) is value: false
+    Then answer get row(0) get variable(a) is entity type: false
+    Then answer get row(0) get variable(a) is relation type: false
+    Then answer get row(0) get variable(a) is attribute type: false
+    Then answer get row(0) get variable(a) is role type: false
+    Then answer get row(0) get variable(a) is entity: false
+    Then answer get row(0) get variable(a) is relation: false
+    Then answer get row(0) get variable(a) is attribute: true
+
+    Then answer get row(0) get thing(a) get type get label: typed
+    Then answer get row(0) get attribute(a) get type get label: typed
+    Then answer get row(0) get attribute(a) get type is attribute: false
+    Then answer get row(0) get attribute(a) get type is entity type: false
+    Then answer get row(0) get attribute(a) get type is relation type: false
+    Then answer get row(0) get attribute(a) get type is attribute type: true
+    Then answer get row(0) get attribute(a) get type is role type: false
+
+    Then answer get row(0) get attribute(a) get type get value type: <value-type>
+    Then answer get row(0) get attribute(a) is boolean: <is-boolean>
+    Then answer get row(0) get attribute(a) is long: <is-long>
+    Then answer get row(0) get attribute(a) is double: <is-double>
+    Then answer get row(0) get attribute(a) is decimal: <is-decimal>
+    Then answer get row(0) get attribute(a) is string: <is-string>
+    Then answer get row(0) get attribute(a) is date: <is-date>
+    Then answer get row(0) get attribute(a) is datetime: <is-datetime>
+    Then answer get row(0) get attribute(a) is datetime-tz: <is-datetime-tz>
+    Then answer get row(0) get attribute(a) is duration: <is-duration>
+    Then answer get row(0) get attribute(a) is struct: false
+    Then answer get row(0) get attribute(a) get <value-type> value: <value>
+#    Then answer get row(0) get attribute(a) as <value-type>: <value>
+    Examples:
+      | value-type  | value                                       | is-boolean | is-long | is-double | is-decimal | is-string | is-date | is-datetime | is-datetime-tz | is-duration |
+      | boolean     | true                                        | true       | false   | false     | false      | false     | false   | false       | false          | false       |
+      | long        | 12345090                                    | false      | true    | false     | false      | false     | false   | false       | false          | false       |
+      | double      | 2.01234567                                  | false      | false   | true      | false      | false     | false   | false       | false          | false       |
+      | decimal     | 1234567890.0001234567890                    | false      | false   | false     | true       | false     | false   | false       | false          | false       |
+      | decimal     | 0.000000000000000001                        | false      | false   | false     | true       | false     | false   | false       | false          | false       |
+      | string      | "John \"Baba Yaga\" Wick"                   | false      | false   | false     | false      | true      | false   | false       | false          | false       |
+      | date        | 2024-09-20                                  | false      | false   | false     | false      | false     | true    | false       | false          | false       |
+      | datetime    | 1999-02-26T12:15:05                         | false      | false   | false     | false      | false     | false   | true        | false          | false       |
+      | datetime    | 1999-02-26T12:15:05.000000001               | false      | false   | false     | false      | false     | false   | true        | false          | false       |
+      | datetime-tz | 2024-09-20T16:40:05 America/New_York        | false      | false   | false     | false      | false     | false   | false       | true           | false       |
+      | datetime-tz | 2024-09-20T16:40:05.000000001 Europe/London | false      | false   | false     | false      | false     | false   | false       | true           | false       |
+      # TODO: Add datetime-tz with offsets
+      | duration    | P1Y10M7DT15H44M5.00394892S                  | false      | false   | false     | false      | false     | false   | false       | false          | true        |
+      | duration    | P66W                                        | false      | false   | false     | false      | false     | false   | false       | false          | true        |
+
+
+  # TODO: Implement structs
+#  Scenario: Driver processes attributes of type struct correctly
 #    Given connection open schema transaction for database: typedb
 #    Given typeql schema query
 #      """
-#      define entity person;
-#      """
-#    When get answers of typeql read query
-#      """
-#      match entity $p;
-#      """
-#    Then answer type is concept rows
-#    Then answer size: 1
-#
-#    Then answer get row(0) get variable(p) is type: true
-#    Then answer get row(0) get variable(p) is thing type: true
-#    Then answer get row(0) get variable(p) is thing: false
-#    Then answer get row(0) get variable(p) is value: false
-#    Then answer get row(0) get variable(p) is entity type: true
-#    Then answer get row(0) get variable(p) is relation type: false
-#    Then answer get row(0) get variable(p) is attribute type: false
-#    Then answer get row(0) get variable(p) is role type: false
-#    Then answer get row(0) get variable(p) is entity: false
-#    Then answer get row(0) get variable(p) is relation: false
-#    Then answer get row(0) get variable(p) is attribute: false
-#
-#    Then answer get row(0) get type(p) get label: person
-#    Then answer get row(0) get thing type(p) get label: person
-#    Then answer get row(0) get entity type(p) get label: person
-#    Then answer get row(0) get entity type(p) get name: person
-#    Then answer get row(0) get entity type(p) get scope is none
-#
-#
-#  Scenario: Driver processes relation types correctly
-#    Given connection open schema transaction for database: typedb
-#    Given typeql schema query
-#      """
-#      define relation parentship, relates parent;
-#      """
-#    When get answers of typeql read query
-#      """
-#      match relation $p;
-#      """
-#    Then answer type is concept rows
-#    Then answer query type is read
-#    Then answer size: 1
-#
-#    Then answer get row(0) get variable(p) is type: true
-#    Then answer get row(0) get variable(p) is thing type: true
-#    Then answer get row(0) get variable(p) is thing: false
-#    Then answer get row(0) get variable(p) is value: false
-#    Then answer get row(0) get variable(p) is entity type: false
-#    Then answer get row(0) get variable(p) is relation type: true
-#    Then answer get row(0) get variable(p) is attribute type: false
-#    Then answer get row(0) get variable(p) is role type: false
-#    Then answer get row(0) get variable(p) is entity: false
-#    Then answer get row(0) get variable(p) is relation: false
-#    Then answer get row(0) get variable(p) is attribute: false
-#
-#    Then answer get row(0) get type(p) get label: parentship
-#    Then answer get row(0) get thing type(p) get label: parentship
-#    Then answer get row(0) get relation type(p) get label: parentship
-#    Then answer get row(0) get relation type(p) get name: parentship
-#    Then answer get row(0) get relation type(p) get scope is none
-#
-#
-#  Scenario: Driver processes role types correctly
-#    Given connection open schema transaction for database: typedb
-#    Given typeql schema query
-#      """
-#      define relation parentship, relates parent;
-#      """
-#    When get answers of typeql read query
-#      """
-#      match relation parentship, relates $p;
-#      """
-#    Then answer type is concept rows
-#    Then answer query type is read
-#    Then answer size: 1
-#
-#    Then answer get row(0) get variable(p) is type: true
-#    Then answer get row(0) get variable(p) is thing type: false
-#    Then answer get row(0) get variable(p) is thing: false
-#    Then answer get row(0) get variable(p) is value: false
-#    Then answer get row(0) get variable(p) is entity type: false
-#    Then answer get row(0) get variable(p) is relation type: false
-#    Then answer get row(0) get variable(p) is attribute type: false
-#    Then answer get row(0) get variable(p) is role type: true
-#    Then answer get row(0) get variable(p) is entity: false
-#    Then answer get row(0) get variable(p) is relation: false
-#    Then answer get row(0) get variable(p) is attribute: false
-#
-#    Then answer get row(0) get type(p) get label: parentship:parent
-#    Then answer get row(0) get role type(p) get label: parentship:parent
-#    Then answer get row(0) get role type(p) get name: parent
-#    Then answer get row(0) get role type(p) get scope: parentship
-#
-#
-#  Scenario: Driver processes attribute types without value type correctly
-#    Given connection open schema transaction for database: typedb
-#    Given typeql schema query
-#      """
-#      define attribute untyped @abstract;
-#      """
-#    When get answers of typeql read query
-#      """
-#      match attribute $a;
-#      """
-#    Then answer type is concept rows
-#    Then answer query type is read
-#    Then answer size: 1
-#
-#    Then answer get row(0) get variable(a) is type: true
-#    Then answer get row(0) get variable(a) is thing type: true
-#    Then answer get row(0) get variable(a) is thing: false
-#    Then answer get row(0) get variable(a) is value: false
-#    Then answer get row(0) get variable(a) is entity type: false
-#    Then answer get row(0) get variable(a) is relation type: false
-#    Then answer get row(0) get variable(a) is attribute type: true
-#    Then answer get row(0) get variable(a) is role type: false
-#    Then answer get row(0) get variable(a) is entity: false
-#    Then answer get row(0) get variable(a) is relation: false
-#    Then answer get row(0) get variable(a) is attribute: false
-#
-#    Then answer get row(0) get type(a) get label: untyped
-#    Then answer get row(0) get thing type(a) get label: untyped
-#    Then answer get row(0) get attribute type(a) get label: untyped
-#    Then answer get row(0) get attribute type(a) get name: untyped
-#    Then answer get row(0) get attribute type(a) get scope is none
-#
-#    Then answer get row(0) get attribute type(a) get value type: none
-#    Then answer get row(0) get attribute type(a) is untyped: true
-#    Then answer get row(0) get attribute type(a) is boolean: false
-#    Then answer get row(0) get attribute type(a) is long: false
-#    Then answer get row(0) get attribute type(a) is double: false
-#    Then answer get row(0) get attribute type(a) is decimal: false
-#    Then answer get row(0) get attribute type(a) is string: false
-#    Then answer get row(0) get attribute type(a) is date: false
-#    Then answer get row(0) get attribute type(a) is datetime: false
-#    Then answer get row(0) get attribute type(a) is datetime-tz: false
-#    Then answer get row(0) get attribute type(a) is duration: false
-#    Then answer get row(0) get attribute type(a) is struct: false
-#
-#
-#  Scenario Outline: Driver processes attribute types with value type <value-type> correctly
-#    Given connection open schema transaction for database: typedb
-#    Given typeql schema query
-#      """
-#      define attribute typed, value <value-type>;
-#      """
-#    When get answers of typeql read query
-#      """
-#      match attribute $a;
-#      """
-#    Then answer type is concept rows
-#    Then answer query type is read
-#    Then answer size: 1
-#
-#    Then answer get row(0) get variable(a) is type: true
-#    Then answer get row(0) get variable(a) is thing type: true
-#    Then answer get row(0) get variable(a) is thing: false
-#    Then answer get row(0) get variable(a) is value: false
-#    Then answer get row(0) get variable(a) is entity type: false
-#    Then answer get row(0) get variable(a) is relation type: false
-#    Then answer get row(0) get variable(a) is attribute type: true
-#    Then answer get row(0) get variable(a) is role type: false
-#    Then answer get row(0) get variable(a) is entity: false
-#    Then answer get row(0) get variable(a) is relation: false
-#    Then answer get row(0) get variable(a) is attribute: false
-#
-#    Then answer get row(0) get type(a) get label: typed
-#    Then answer get row(0) get thing type(a) get label: typed
-#    Then answer get row(0) get attribute type(a) get label: typed
-#    Then answer get row(0) get attribute type(a) get name: typed
-#    Then answer get row(0) get attribute type(a) get scope is none
-#
-#    Then answer get row(0) get attribute type(a) get value type: <value-type>
-#    Then answer get row(0) get attribute type(a) is untyped: false
-#    Then answer get row(0) get attribute type(a) is boolean: <is-boolean>
-#    Then answer get row(0) get attribute type(a) is long: <is-long>
-#    Then answer get row(0) get attribute type(a) is double: <is-double>
-#    Then answer get row(0) get attribute type(a) is decimal: <is-decimal>
-#    Then answer get row(0) get attribute type(a) is string: <is-string>
-#    Then answer get row(0) get attribute type(a) is date: <is-date>
-#    Then answer get row(0) get attribute type(a) is datetime: <is-datetime>
-#    Then answer get row(0) get attribute type(a) is datetime-tz: <is-datetime-tz>
-#    Then answer get row(0) get attribute type(a) is duration: <is-duration>
-#    Then answer get row(0) get attribute type(a) is struct: <is-struct>
-#    Examples:
-#      | value-type  | is-boolean | is-long | is-double | is-decimal | is-string | is-date | is-datetime | is-datetime-tz | is-duration | is-struct |
-#      | boolean     | true       | false   | false     | false      | false     | false   | false       | false          | false       | false     |
-#      | long        | false      | true    | false     | false      | false     | false   | false       | false          | false       | false     |
-#      | double      | false      | false   | true      | false      | false     | false   | false       | false          | false       | false     |
-#      | decimal     | false      | false   | false     | true       | false     | false   | false       | false          | false       | false     |
-#      | string      | false      | false   | false     | false      | true      | false   | false       | false          | false       | false     |
-#      | date        | false      | false   | false     | false      | false     | true    | false       | false          | false       | false     |
-#      | datetime    | false      | false   | false     | false      | false     | false   | true        | false          | false       | false     |
-#      | datetime-tz | false      | false   | false     | false      | false     | false   | false       | true           | false       | false     |
-#      | duration    | false      | false   | false     | false      | false     | false   | false       | false          | true        | false     |
-#      | struct      | false      | false   | false     | false      | false     | false   | false       | false          | false       | true      |
-#
-#
-#  Scenario: Driver processes entities correctly
-#    Given connection open schema transaction for database: typedb
-#    Given typeql schema query
-#      """
-#      define entity person;
+#      define
+#      entity director, owns film;
+#      attribute film, value film-properties;
+#      struct film-genre:
+#        name value string,
+#        description value string,
+#        invented value date;
+#      struct film-properties:
+#        name value string,
+#        genre value film-genre,
+#        duration value duration,
+#        reviews value long,
+#        score value double,
+#        revenue value decimal,
+#        premier value datetime,
+#        local-premier value datetime-tz,
+#        is-verified value boolean;
 #      """
 #    Given transaction commits
 #    Given connection open write transaction for database: typedb
 #    Given typeql write query
 #      """
-#      insert $p isa person;
+#      insert $d isa director, has film {
+#        name: "Twin Peaks: Fire Walk with Me",
+#        genre: film-genre {
+#          name: surrealism,
+#          description: "Surrealism is an art and cultural movement that developed in Europe in the aftermath of World War I in which artists aimed to allow the unconscious mind to express itself, often resulting in the depiction of illogical or dreamlike scenes and ideas. Its intention was, according to leader André Breton, to \"resolve the previously contradictory conditions of dream and reality into an absolute reality, a super-reality\", or surreality. It produced works of painting, writing, theatre, filmmaking, photography, and other media as well.",
+#          invented: 1917-01-01,
+#        },
+#        duration: PT2H14M,
+#        reviews: 130,
+#        score: 45.13,
+#        revenue: 4200000.123456789087654321,
+#        premier: 1992-05-16T01:02:34,
+#        local-premier: 1992-07-03T01:02:34 Europe/Paris,
+#        is-verified: true,
+#      };
 #      """
 #    When get answers of typeql read query
 #      """
-#      match $p isa person;
+#      match $_ isa director, has $f;
 #      """
 #    Then answer type is concept rows
 #    Then answer query type is read
 #    Then answer size: 1
 #
-#    Then answer get row(0) get variable(p) is type: false
-#    Then answer get row(0) get variable(p) is thing type: false
-#    Then answer get row(0) get variable(p) is thing: true
-#    Then answer get row(0) get variable(p) is value: false
-#    Then answer get row(0) get variable(p) is entity type: false
-#    Then answer get row(0) get variable(p) is relation type: false
-#    Then answer get row(0) get variable(p) is attribute type: false
-#    Then answer get row(0) get variable(p) is role type: false
-#    Then answer get row(0) get variable(p) is entity: true
-#    Then answer get row(0) get variable(p) is relation: false
-#    Then answer get row(0) get variable(p) is attribute: false
+#    Then answer get row(0) get variable(f) is type: false
+#    Then answer get row(0) get variable(f) is thing type: false
+#    Then answer get row(0) get variable(f) is thing: true
+#    Then answer get row(0) get variable(f) is value: false
+#    Then answer get row(0) get variable(f) is entity type: false
+#    Then answer get row(0) get variable(f) is relation type: false
+#    Then answer get row(0) get variable(f) is attribute type: false
+#    Then answer get row(0) get variable(f) is role type: false
+#    Then answer get row(0) get variable(f) is entity: false
+#    Then answer get row(0) get variable(f) is relation: false
+#    Then answer get row(0) get variable(f) is attribute: true
 #
-#    Then answer get row(0) get thing(p) get type get label: person
-#    Then answer get row(0) get entity(p) get iid exists
-#    Then answer get row(0) get entity(p) get type get label: person
-#    Then answer get row(0) get entity(p) get type is entity: false
-#    Then answer get row(0) get entity(p) get type is entity type: true
-#    Then answer get row(0) get entity(p) get type is relation type: false
-#    Then answer get row(0) get entity(p) get type is attribute type: false
-#    Then answer get row(0) get entity(p) get type is role type: false
+#    Then answer get row(0) get thing(f) get type get label: typed
+#    Then answer get row(0) get attribute(f) get type get label: typed
+#    Then answer get row(0) get attribute(f) get type is attribute: false
+#    Then answer get row(0) get attribute(f) get type is entity type: false
+#    Then answer get row(0) get attribute(f) get type is relation type: true
+#    Then answer get row(0) get attribute(f) get type is attribute type: true
+#    Then answer get row(0) get attribute(f) get type is role type: false
 #
-#
-#  Scenario: Driver processes relations correctly
-#    Given connection open schema transaction for database: typedb
-#    Given typeql schema query
-#      """
-#      define relation parentship, relates parent;
-#      """
-#    Given transaction commits
-#    Given connection open write transaction for database: typedb
-#    Given typeql write query
-#      """
-#      insert $p isa parentship;
-#      """
-#    When get answers of typeql read query
-#      """
-#      match $p isa parentship;
-#      """
-#    Then answer type is concept rows
-#    Then answer query type is read
-#    Then answer size: 1
-#
-#    Then answer get row(0) get variable(p) is type: false
-#    Then answer get row(0) get variable(p) is thing type: false
-#    Then answer get row(0) get variable(p) is thing: true
-#    Then answer get row(0) get variable(p) is value: false
-#    Then answer get row(0) get variable(p) is entity type: false
-#    Then answer get row(0) get variable(p) is relation type: false
-#    Then answer get row(0) get variable(p) is attribute type: false
-#    Then answer get row(0) get variable(p) is role type: false
-#    Then answer get row(0) get variable(p) is entity: false
-#    Then answer get row(0) get variable(p) is relation: true
-#    Then answer get row(0) get variable(p) is attribute: false
-#
-#    Then answer get row(0) get thing(p) get type get label: parentship
-#    Then answer get row(0) get relation(p) get iid exists
-#    Then answer get row(0) get relation(p) get type get label: parentship
-#    Then answer get row(0) get relation(p) get type is relation: false
-#    Then answer get row(0) get relation(p) get type is entity type: false
-#    Then answer get row(0) get relation(p) get type is relation type: true
-#    Then answer get row(0) get relation(p) get type is attribute type: false
-#    Then answer get row(0) get relation(p) get type is role type: false
-#
-#
-#  Scenario Outline: Driver processes attributes of type <value-type> correctly
-#    Given connection open schema transaction for database: typedb
-#    Given typeql schema query
-#      """
-#      define entity person, owns typed; attribute typed, value <value-type>;
-#      """
-#    Given transaction commits
-#    Given connection open write transaction for database: typedb
-#    Given typeql write query
-#      """
-#      insert $p isa person, has typed <value>;
-#      """
-#    When get answers of typeql read query
-#      """
-#      match $_ isa person, has $a;
-#      """
-#    Then answer type is concept rows
-#    Then answer query type is read
-#    Then answer size: 1
-#
-#    Then answer get row(0) get variable(a) is type: false
-#    Then answer get row(0) get variable(a) is thing type: false
-#    Then answer get row(0) get variable(a) is thing: true
-#    Then answer get row(0) get variable(a) is value: false
-#    Then answer get row(0) get variable(a) is entity type: false
-#    Then answer get row(0) get variable(a) is relation type: false
-#    Then answer get row(0) get variable(a) is attribute type: false
-#    Then answer get row(0) get variable(a) is role type: false
-#    Then answer get row(0) get variable(a) is entity: false
-#    Then answer get row(0) get variable(a) is relation: false
-#    Then answer get row(0) get variable(a) is attribute: true
-#
-#    Then answer get row(0) get thing(a) get type get label: typed
-#    Then answer get row(0) get attribute(a) get type get label: typed
-#    Then answer get row(0) get attribute(a) get type is attribute: false
-#    Then answer get row(0) get attribute(a) get type is entity type: false
-#    Then answer get row(0) get attribute(a) get type is relation type: true
-#    Then answer get row(0) get attribute(a) get type is attribute type: true
-#    Then answer get row(0) get attribute(a) get type is role type: false
-#
-#    Then answer get row(0) get attribute(a) get type get value type: <value-type>
-#    Then answer get row(0) get attribute(a) is boolean: <is-boolean>
-#    Then answer get row(0) get attribute(a) is long: <is-long>
-#    Then answer get row(0) get attribute(a) is double: <is-double>
-#    Then answer get row(0) get attribute(a) is decimal: <is-decimal>
-#    Then answer get row(0) get attribute(a) is string: <is-string>
-#    Then answer get row(0) get attribute(a) is date: <is-date>
-#    Then answer get row(0) get attribute(a) is datetime: <is-datetime>
-#    Then answer get row(0) get attribute(a) is datetime-tz: <is-datetime-tz>
-#    Then answer get row(0) get attribute(a) is duration: <is-duration>
-#    Then answer get row(0) get attribute(a) is struct: <is-struct>
-#    Then answer get row(0) get attribute(a) get <value-type> value: <value>
-#    Examples:
-#      | value-type  | value                                       | is-boolean | is-long | is-double | is-decimal | is-string | is-date | is-datetime | is-datetime-tz | is-duration | is-struct |
-#      | boolean     | true                                        | true       | false   | false     | false      | false     | false   | false       | false          | false       | false     |
-#      | long        | 12345090                                    | false      | true    | false     | false      | false     | false   | false       | false          | false       | false     |
-#      | double      | 2.01234567                                  | false      | false   | true      | false      | false     | false   | false       | false          | false       | false     |
-#      | decimal     | 1234567890.0001234567890                    | false      | false   | false     | true       | false     | false   | false       | false          | false       | false     |
-#      | decimal     | 0.000000000000000001                        | false      | false   | false     | true       | false     | false   | false       | false          | false       | false     |
-#      | string      | "John \"Baba Yaga\" Wick"                   | false      | false   | false     | false      | true      | false   | false       | false          | false       | false     |
-#      | date        | 2024-09-20                                  | false      | false   | false     | false      | false     | true    | false       | false          | false       | false     |
-#      | datetime    | 1999-02-26T12:15:05                         | false      | false   | false     | false      | false     | false   | true        | false          | false       | false     |
-#      | datetime    | 1999-02-26T12:15:05.000000001               | false      | false   | false     | false      | false     | false   | true        | false          | false       | false     |
-#      | datetime-tz | 2024-09-20T16:40:05 America/New_York        | false      | false   | false     | false      | false     | false   | false       | true           | false       | false     |
-#      | datetime-tz | 2024-09-20T16:40:05.000000001 Europe/London | false      | false   | false     | false      | false     | false   | false       | true           | false       | false     |
-#      # TODO: Add datetime-tz with offsets
-#      | duration    | P1Y10M7DT15H44M5.00394892S                  | false      | false   | false     | false      | false     | false   | false       | false          | true        | false     |
-#      | duration    | P66W                                        | false      | false   | false     | false      | false     | false   | false       | false          | true        | false     |
-#      # TODO: Implement structs
-##      | struct      |                                             | false      | false   | false     | false      | false     | false   | false       | false          | false       | true      |
-#
-#
+#    Then answer get row(0) get attribute(f) get type get value type: film-properties
+#    Then answer get row(0) get attribute(f) is boolean: false
+#    Then answer get row(0) get attribute(f) is long: false
+#    Then answer get row(0) get attribute(f) is double: false
+#    Then answer get row(0) get attribute(f) is decimal: false
+#    Then answer get row(0) get attribute(f) is string: false
+#    Then answer get row(0) get attribute(f) is date: false
+#    Then answer get row(0) get attribute(f) is datetime: false
+#    Then answer get row(0) get attribute(f) is datetime-tz: false
+#    Then answer get row(0) get attribute(f) is duration: false
+#    Then answer get row(0) get attribute(f) is struct: true
+#    Then answer get row(0) get attribute(f) get <value-type> value: <value>
+#    Then answer get row(0) get attribute(a) as <value-type>: <value>
+
+
+  # TODO: Implement value variables
 #  Scenario Outline: Driver processes values of type <value-type> correctly
 #    Given connection open schema transaction for database: typedb
 #    Given typeql schema query
@@ -902,6 +1046,101 @@ Feature: TypeDB Driver
 #    When get answers of typeql read query
 #      """
 #      match $_ isa person, has typed $v;
+#      $value = $v;
+#      """
+#    Then answer type is concept rows
+#    Then answer query type is read
+#    Then answer size: 1
+#
+#    Then answer get row(0) get variable(value) is type: false
+#    Then answer get row(0) get variable(value) is thing type: false
+#    Then answer get row(0) get variable(value) is thing: false
+#    Then answer get row(0) get variable(value) is value: true
+#    Then answer get row(0) get variable(value) is entity type: false
+#    Then answer get row(0) get variable(value) is relation type: false
+#    Then answer get row(0) get variable(value) is attribute type: false
+#    Then answer get row(0) get variable(value) is role type: false
+#    Then answer get row(0) get variable(value) is entity: false
+#    Then answer get row(0) get variable(value) is relation: false
+#    Then answer get row(0) get variable(value) is attribute: false
+#
+#    Then answer get row(0) get value(value) get value type: <value-type>
+#    Then answer get row(0) get value(value) is boolean: <is-boolean>
+#    Then answer get row(0) get value(value) is long: <is-long>
+#    Then answer get row(0) get value(value) is double: <is-double>
+#    Then answer get row(0) get value(value) is decimal: <is-decimal>
+#    Then answer get row(0) get value(value) is string: <is-string>
+#    Then answer get row(0) get value(value) is date: <is-date>
+#    Then answer get row(0) get value(value) is datetime: <is-datetime>
+#    Then answer get row(0) get value(value) is datetime-tz: <is-datetime-tz>
+#    Then answer get row(0) get value(value) is duration: <is-duration>
+#    Then answer get row(0) get value(value) is struct: true
+#    Then answer get row(0) get value(value) get: <value>
+#    Then answer get row(0) get value(value) as <value-type>: <value>
+#    Examples:
+#      | value-type  | value                                       | is-boolean | is-long | is-double | is-decimal | is-string | is-date | is-datetime | is-datetime-tz | is-duration |
+#      | boolean     | true                                        | true       | false   | false     | false      | false     | false   | false       | false          | false       |
+#      | long        | 12345090                                    | false      | true    | false     | false      | false     | false   | false       | false          | false       |
+#      | double      | 2.01234567                                  | false      | false   | true      | false      | false     | false   | false       | false          | false       |
+#      | decimal     | 1234567890.0001234567890                    | false      | false   | false     | true       | false     | false   | false       | false          | false       |
+#      | decimal     | 0.000000000000000001                        | false      | false   | false     | true       | false     | false   | false       | false          | false       |
+#      | string      | "John \"Baba Yaga\" Wick"                   | false      | false   | false     | false      | true      | false   | false       | false          | false       |
+#      | date        | 2024-09-20                                  | false      | false   | false     | false      | false     | true    | false       | false          | false       |
+#      | datetime    | 1999-02-26T12:15:05                         | false      | false   | false     | false      | false     | false   | true        | false          | false       |
+#      | datetime    | 1999-02-26T12:15:05.000000001               | false      | false   | false     | false      | false     | false   | true        | false          | false       |
+#      | datetime-tz | 2024-09-20T16:40:05 America/New_York        | false      | false   | false     | false      | false     | false   | false       | true           | false       |
+#      | datetime-tz | 2024-09-20T16:40:05.000000001 Europe/London | false      | false   | false     | false      | false     | false   | false       | true           | false       |
+#      # TODO: Add datetime-tz with offsets
+#      | duration    | P1Y10M7DT15H44M5.00394892S                  | false      | false   | false     | false      | false     | false   | false       | false          | true        |
+#      | duration    | P66W                                        | false      | false   | false     | false      | false     | false   | false       | false          | true        |
+
+
+  # TODO: Implement structs
+#  Scenario: Driver processes values of type struct correctly
+#    Given connection open schema transaction for database: typedb
+#    Given typeql schema query
+#      """
+#      define
+#      entity director, owns film;
+#      attribute film, value film-properties;
+#      struct film-genre:
+#        name value string,
+#        description value string,
+#        invented value date;
+#      struct film-properties:
+#        name value string,
+#        genre value film-genre,
+#        duration value duration,
+#        reviews value long,
+#        score value double,
+#        revenue value decimal,
+#        premier value datetime,
+#        local-premier value datetime-tz,
+#        is-verified value boolean;
+#      """
+#    Given transaction commits
+#    Given connection open write transaction for database: typedb
+#    Given typeql write query
+#      """
+#      insert $d isa director, has film {
+#        name: "Twin Peaks: Fire Walk with Me",
+#        genre: film-genre {
+#          name: surrealism,
+#          description: "Surrealism is an art and cultural movement that developed in Europe in the aftermath of World War I in which artists aimed to allow the unconscious mind to express itself, often resulting in the depiction of illogical or dreamlike scenes and ideas. Its intention was, according to leader André Breton, to \"resolve the previously contradictory conditions of dream and reality into an absolute reality, a super-reality\", or surreality. It produced works of painting, writing, theatre, filmmaking, photography, and other media as well.",
+#          invented: 1917-01-01,
+#        },
+#        duration: PT2H14M,
+#        reviews: 130,
+#        score: 45.13,
+#        revenue: 4200000.123456789087654321,
+#        premier: 1992-05-16T01:02:34,
+#        local-premier: 1992-07-03T01:02:34 Europe/Paris,
+#        is-verified: true,
+#      };
+#      """
+#    When get answers of typeql read query
+#      """
+#      match $_ isa director, has film $v;
 #      """
 #    Then answer type is concept rows
 #    Then answer query type is read
@@ -932,23 +1171,6 @@ Feature: TypeDB Driver
 #    Then answer get row(0) get value(v) is struct: <is-struct>
 #    Then answer get row(0) get value(v) get: <value>
 #    Then answer get row(0) get value(v) as <value-type>: <value>
-#    Examples:
-#      | value-type  | value                                       | is-boolean | is-long | is-double | is-decimal | is-string | is-date | is-datetime | is-datetime-tz | is-duration | is-struct |
-#      | boolean     | true                                        | true       | false   | false     | false      | false     | false   | false       | false          | false       | false     |
-#      | long        | 12345090                                    | false      | true    | false     | false      | false     | false   | false       | false          | false       | false     |
-#      | double      | 2.01234567                                  | false      | false   | true      | false      | false     | false   | false       | false          | false       | false     |
-#      | decimal     | 1234567890.0001234567890                    | false      | false   | false     | true       | false     | false   | false       | false          | false       | false     |
-#      | decimal     | 0.000000000000000001                        | false      | false   | false     | true       | false     | false   | false       | false          | false       | false     |
-#      | string      | "John \"Baba Yaga\" Wick"                   | false      | false   | false     | false      | true      | false   | false       | false          | false       | false     |
-#      | date        | 2024-09-20                                  | false      | false   | false     | false      | false     | true    | false       | false          | false       | false     |
-#      | datetime    | 1999-02-26T12:15:05                         | false      | false   | false     | false      | false     | false   | true        | false          | false       | false     |
-#      | datetime    | 1999-02-26T12:15:05.000000001               | false      | false   | false     | false      | false     | false   | true        | false          | false       | false     |
-#      | datetime-tz | 2024-09-20T16:40:05 America/New_York        | false      | false   | false     | false      | false     | false   | false       | true           | false       | false     |
-#      | datetime-tz | 2024-09-20T16:40:05.000000001 Europe/London | false      | false   | false     | false      | false     | false   | false       | true           | false       | false     |
-#      # TODO: Add datetime-tz with offsets
-#      | duration    | P1Y10M7DT15H44M5.00394892S                  | false      | false   | false     | false      | false     | false   | false       | false          | true        | false     |
-#      | duration    | P66W                                        | false      | false   | false     | false      | false     | false   | false       | false          | true        | false     |
-#      # TODO: Implement structs
-##      | struct      |                                             | false      | false   | false     | false      | false     | false   | false       | false          | false       | true      |
-#
-#  # TODO: Add tests with time-zones for datetime, datetime-tz
+
+
+  # TODO: Add tests with time-zones set through "set time-zone" steps for datetime and datetime-tz

--- a/driver/driver.feature
+++ b/driver/driver.feature
@@ -19,6 +19,8 @@ Feature: TypeDB Driver
     Given connection create database: typedb
     Given connection has database: typedb
 
+    # TODO: Add error strings checks
+
   ##############
   # CONNECTION #
   ##############

--- a/driver/driver.feature
+++ b/driver/driver.feature
@@ -804,14 +804,17 @@ Feature: TypeDB Driver
       | long        | 12345090                                    | false      | true    | false     | false      | false     | false   | false       | false          | false       | false     |
       | double      | 2.01234567                                  | false      | false   | true      | false      | false     | false   | false       | false          | false       | false     |
       | decimal     | 1234567890.0001234567890                    | false      | false   | false     | true       | false     | false   | false       | false          | false       | false     |
+      | decimal     | 0.000000000000000001                        | false      | false   | false     | true       | false     | false   | false       | false          | false       | false     |
       | string      | "John \"Baba Yaga\" Wick"                   | false      | false   | false     | false      | true      | false   | false       | false          | false       | false     |
       | date        | 2024-09-20                                  | false      | false   | false     | false      | false     | true    | false       | false          | false       | false     |
       | datetime    | 1999-02-26T12:15:05                         | false      | false   | false     | false      | false     | false   | true        | false          | false       | false     |
       | datetime    | 1999-02-26T12:15:05.000000001               | false      | false   | false     | false      | false     | false   | true        | false          | false       | false     |
-      | datetime-tz | 2024-09-20T16:40:05 Europe/London           | false      | false   | false     | false      | false     | false   | false       | true           | false       | false     |
+      | datetime-tz | 2024-09-20T16:40:05 America/New_York        | false      | false   | false     | false      | false     | false   | false       | true           | false       | false     |
       | datetime-tz | 2024-09-20T16:40:05.000000001 Europe/London | false      | false   | false     | false      | false     | false   | false       | true           | false       | false     |
+      # TODO: Add datetime-tz with offsets
       | duration    | P1Y10M7DT15H44M5.00394892S                  | false      | false   | false     | false      | false     | false   | false       | false          | true        | false     |
-  # TODO: Implement structs
+      | duration    | P66W                                        | false      | false   | false     | false      | false     | false   | false       | false          | true        | false     |
+      # TODO: Implement structs
 #      | struct      |                                             | false      | false   | false     | false      | false     | false   | false       | false          | false       | true      |
 
 
@@ -865,12 +868,17 @@ Feature: TypeDB Driver
       | long        | 12345090                                    | false      | true    | false     | false      | false     | false   | false       | false          | false       | false     |
       | double      | 2.01234567                                  | false      | false   | true      | false      | false     | false   | false       | false          | false       | false     |
       | decimal     | 1234567890.0001234567890                    | false      | false   | false     | true       | false     | false   | false       | false          | false       | false     |
+      | decimal     | 0.000000000000000001                        | false      | false   | false     | true       | false     | false   | false       | false          | false       | false     |
       | string      | "John \"Baba Yaga\" Wick"                   | false      | false   | false     | false      | true      | false   | false       | false          | false       | false     |
       | date        | 2024-09-20                                  | false      | false   | false     | false      | false     | true    | false       | false          | false       | false     |
       | datetime    | 1999-02-26T12:15:05                         | false      | false   | false     | false      | false     | false   | true        | false          | false       | false     |
       | datetime    | 1999-02-26T12:15:05.000000001               | false      | false   | false     | false      | false     | false   | true        | false          | false       | false     |
-      | datetime-tz | 2024-09-20T16:40:05 Europe/London           | false      | false   | false     | false      | false     | false   | false       | true           | false       | false     |
+      | datetime-tz | 2024-09-20T16:40:05 America/New_York        | false      | false   | false     | false      | false     | false   | false       | true           | false       | false     |
       | datetime-tz | 2024-09-20T16:40:05.000000001 Europe/London | false      | false   | false     | false      | false     | false   | false       | true           | false       | false     |
+      # TODO: Add datetime-tz with offsets
       | duration    | P1Y10M7DT15H44M5.00394892S                  | false      | false   | false     | false      | false     | false   | false       | false          | true        | false     |
-  # TODO: Implement structs
+      | duration    | P66W                                        | false      | false   | false     | false      | false     | false   | false       | false          | true        | false     |
+      # TODO: Implement structs
 #      | struct      |                                             | false      | false   | false     | false      | false     | false   | false       | false          | false       | true      |
+
+  # TODO: Add tests with time-zones for datetime, datetime-tz

--- a/driver/driver.feature
+++ b/driver/driver.feature
@@ -281,7 +281,7 @@ Feature: TypeDB Driver
 #    Then transaction is open: false
 
 
-#  # TODO: Check options setting and retrieval
+  # TODO: Check options setting and retrieval
 
 
   # TODO: Fix on_close
@@ -338,7 +338,7 @@ Feature: TypeDB Driver
     Then transaction commits; fails
 
 
-  # TODO: check errors on transaction commits with callbacks set!
+  # TODO: check errors on transaction commits with callbacks (on_close) set!
 
   ###########
   # QUERIES #
@@ -350,9 +350,9 @@ Feature: TypeDB Driver
       """
       define entity person;
       """
-    Then answer type is ok
-    Then answer type is not concept rows
-    Then answer type is not concept trees
+    Then answer type is: ok
+    Then answer type is not: concept rows
+    Then answer type is not: concept trees
     Then result is a successful ok
     Then transaction commits
 
@@ -368,9 +368,9 @@ Feature: TypeDB Driver
       """
       match entity $p;
       """
-    Then answer type is concept rows
-    Then answer type is not ok
-    Then answer type is not concept trees
+    Then answer type is: concept rows
+    Then answer type is not: ok
+    Then answer type is not: concept trees
     Then answer query type is read
     Then answer query type is not schema
     Then answer query type is not write
@@ -384,9 +384,9 @@ Feature: TypeDB Driver
       """
       match entity $p; attribute $n;
       """
-    Then answer type is concept rows
-    Then answer type is not ok
-    Then answer type is not concept trees
+    Then answer type is: concept rows
+    Then answer type is not: ok
+    Then answer type is not: concept trees
     Then answer query type is read
     Then answer query type is not schema
     Then answer query type is not write
@@ -407,9 +407,9 @@ Feature: TypeDB Driver
       """
       match entity $p; attribute $n;
       """
-    Then answer type is concept rows
-    Then answer type is not ok
-    Then answer type is not concept trees
+    Then answer type is: concept rows
+    Then answer type is not: ok
+    Then answer type is not: concept trees
     Then answer query type is read
     Then answer query type is not schema
     Then answer query type is not write
@@ -432,9 +432,9 @@ Feature: TypeDB Driver
       """
       match entity $p; attribute $n;
       """
-    Then answer type is concept rows
-    Then answer type is not ok
-    Then answer type is not concept trees
+    Then answer type is: concept rows
+    Then answer type is not: ok
+    Then answer type is not: concept trees
     Then answer query type is read
     Then answer query type is not schema
     Then answer query type is not write
@@ -455,9 +455,9 @@ Feature: TypeDB Driver
       """
       match $p isa person;
       """
-    Then answer type is concept rows
-    Then answer type is not ok
-    Then answer type is not concept trees
+    Then answer type is: concept rows
+    Then answer type is not: ok
+    Then answer type is not: concept trees
     Then answer size: 0
 
     When transaction closes
@@ -466,9 +466,9 @@ Feature: TypeDB Driver
       """
       insert $p isa person, has name "John";
       """
-    Then answer type is concept rows
-    Then answer type is not ok
-    Then answer type is not concept trees
+    Then answer type is: concept rows
+    Then answer type is not: ok
+    Then answer type is not: concept trees
     Then answer query type is write
     Then answer query type is not schema
     Then answer query type is not read
@@ -482,9 +482,9 @@ Feature: TypeDB Driver
       """
       match $p isa person, has name $a;
       """
-    Then answer type is concept rows
-    Then answer type is not ok
-    Then answer type is not concept trees
+    Then answer type is: concept rows
+    Then answer type is not: ok
+    Then answer type is not: concept trees
     Then answer query type is read
     Then answer query type is not schema
     Then answer query type is not write
@@ -495,9 +495,9 @@ Feature: TypeDB Driver
     Then answer get row(0) get entity(p) get type get label: person
     Then answer get row(0) get entity by index of variable(p) get type get label: person
     Then answer get row(0) get attribute(a) get type get label: name
-    Then answer get row(0) get attribute(a) get string value: "John"
+    Then answer get row(0) get attribute(a) get value is: "John"
     Then answer get row(0) get attribute by index of variable(a) get type get label: name
-    Then answer get row(0) get attribute by index of variable(a) get string value: "John"
+    Then answer get row(0) get attribute by index of variable(a) get value is: "John"
     Then transaction commits
 
 
@@ -550,7 +550,7 @@ Feature: TypeDB Driver
       """
       match entity $p;
       """
-    Then answer type is concept rows
+    Then answer type is: concept rows
     Then answer size: 1
 
     Then answer get row(0) get variable(p) is type: true
@@ -580,7 +580,7 @@ Feature: TypeDB Driver
       """
       match relation $p;
       """
-    Then answer type is concept rows
+    Then answer type is: concept rows
     Then answer query type is read
     Then answer size: 1
 
@@ -611,7 +611,7 @@ Feature: TypeDB Driver
       """
       match $_ sub parentship, relates $p;
       """
-    Then answer type is concept rows
+    Then answer type is: concept rows
     Then answer query type is read
     Then answer size: 1
 
@@ -641,7 +641,7 @@ Feature: TypeDB Driver
       """
       match attribute $a;
       """
-    Then answer type is concept rows
+    Then answer type is: concept rows
     Then answer query type is read
     Then answer size: 1
 
@@ -685,7 +685,7 @@ Feature: TypeDB Driver
       """
       match attribute $a;
       """
-    Then answer type is concept rows
+    Then answer type is: concept rows
     Then answer query type is read
     Then answer size: 1
 
@@ -755,7 +755,7 @@ Feature: TypeDB Driver
       """
       match attribute $a;
       """
-    Then answer type is concept rows
+    Then answer type is: concept rows
     Then answer query type is read
     Then answer size: 1
 
@@ -805,7 +805,7 @@ Feature: TypeDB Driver
       """
       match $p isa person;
       """
-    Then answer type is concept rows
+    Then answer type is: concept rows
     Then answer query type is read
     Then answer size: 1
 
@@ -847,7 +847,7 @@ Feature: TypeDB Driver
       """
       match $p isa parentship;
       """
-    Then answer type is concept rows
+    Then answer type is: concept rows
     Then answer query type is read
     Then answer size: 1
 
@@ -889,7 +889,7 @@ Feature: TypeDB Driver
       """
       match $_ isa person, has $a;
       """
-    Then answer type is concept rows
+    Then answer type is: concept rows
     Then answer query type is read
     Then answer size: 1
 
@@ -924,24 +924,27 @@ Feature: TypeDB Driver
     Then answer get row(0) get attribute(a) is datetime-tz: <is-datetime-tz>
     Then answer get row(0) get attribute(a) is duration: <is-duration>
     Then answer get row(0) get attribute(a) is struct: false
-    Then answer get row(0) get attribute(a) get <value-type> value: <value>
-#    Then answer get row(0) get attribute(a) as <value-type>: <value>
+    Then answer get row(0) get attribute(a) get value is: <value>
+    Then answer get row(0) get attribute(a) as <value-type> is: <value>
+    Then answer get row(0) get attribute(a) get value is not: <not-value>
+    Then answer get row(0) get attribute(a) as <value-type> is not: <not-value>
     Examples:
-      | value-type  | value                                       | is-boolean | is-long | is-double | is-decimal | is-string | is-date | is-datetime | is-datetime-tz | is-duration |
-      | boolean     | true                                        | true       | false   | false     | false      | false     | false   | false       | false          | false       |
-      | long        | 12345090                                    | false      | true    | false     | false      | false     | false   | false       | false          | false       |
-      | double      | 2.01234567                                  | false      | false   | true      | false      | false     | false   | false       | false          | false       |
-      | decimal     | 1234567890.0001234567890                    | false      | false   | false     | true       | false     | false   | false       | false          | false       |
-      | decimal     | 0.000000000000000001                        | false      | false   | false     | true       | false     | false   | false       | false          | false       |
-      | string      | "John \"Baba Yaga\" Wick"                   | false      | false   | false     | false      | true      | false   | false       | false          | false       |
-      | date        | 2024-09-20                                  | false      | false   | false     | false      | false     | true    | false       | false          | false       |
-      | datetime    | 1999-02-26T12:15:05                         | false      | false   | false     | false      | false     | false   | true        | false          | false       |
-      | datetime    | 1999-02-26T12:15:05.000000001               | false      | false   | false     | false      | false     | false   | true        | false          | false       |
-      | datetime-tz | 2024-09-20T16:40:05 America/New_York        | false      | false   | false     | false      | false     | false   | false       | true           | false       |
-      | datetime-tz | 2024-09-20T16:40:05.000000001 Europe/London | false      | false   | false     | false      | false     | false   | false       | true           | false       |
+      | value-type  | value                                       | not-value                                    | is-boolean | is-long | is-double | is-decimal | is-string | is-date | is-datetime | is-datetime-tz | is-duration |
+      | boolean     | true                                        | false                                        | true       | false   | false     | false      | false     | false   | false       | false          | false       |
+      | long        | 12345090                                    | 0                                            | false      | true    | false     | false      | false     | false   | false       | false          | false       |
+      | double      | 0.0000000000000000001                       | 0.000000000000000001                         | false      | false   | true      | false      | false     | false   | false       | false          | false       |
+      | double      | 2.01234567                                  | 2.01234568                                   | false      | false   | true      | false      | false     | false   | false       | false          | false       |
+      | decimal     | 1234567890.0001234567890                    | 1234567890.001234567890                      | false      | false   | false     | true       | false     | false   | false       | false          | false       |
+      | decimal     | 0.0000000000000000001                       | 0.000000000000000001                         | false      | false   | false     | true       | false     | false   | false       | false          | false       |
+      | string      | "John \"Baba Yaga\" Wick"                   | "John Baba Yaga Wick"                        | false      | false   | false     | false      | true      | false   | false       | false          | false       |
+      | date        | 2024-09-20                                  | 2025-09-20                                   | false      | false   | false     | false      | false     | true    | false       | false          | false       |
+      | datetime    | 1999-02-26T12:15:05                         | 1999-02-26T12:15:00                          | false      | false   | false     | false      | false     | false   | true        | false          | false       |
+      | datetime    | 1999-02-26T12:15:05.000000001               | 1999-02-26T12:15:05.00000001                 | false      | false   | false     | false      | false     | false   | true        | false          | false       |
+      | datetime-tz | 2024-09-20T16:40:05 America/New_York        | 2024-06-20T15:40:05 America/New_York         | false      | false   | false     | false      | false     | false   | false       | true           | false       |
+      | datetime-tz | 2024-09-20T16:40:05.000000001 Europe/London | 2024-09-20T16:40:05.000000001 Europe/Belfast | false      | false   | false     | false      | false     | false   | false       | true           | false       |
       # TODO: Add datetime-tz with offsets
-      | duration    | P1Y10M7DT15H44M5.00394892S                  | false      | false   | false     | false      | false     | false   | false       | false          | true        |
-      | duration    | P66W                                        | false      | false   | false     | false      | false     | false   | false       | false          | true        |
+      | duration    | P1Y10M7DT15H44M5.00394892S                  | P1Y10M7DT15H44M5.0394892S                    | false      | false   | false     | false      | false     | false   | false       | false          | true        |
+      | duration    | P66W                                        | P67W                                         | false      | false   | false     | false      | false     | false   | false       | false          | true        |
 
 
   # TODO: Implement structs
@@ -991,7 +994,7 @@ Feature: TypeDB Driver
 #      """
 #      match $_ isa director, has $f;
 #      """
-#    Then answer type is concept rows
+#    Then answer type is: concept rows
 #    Then answer query type is read
 #    Then answer size: 1
 #
@@ -1026,8 +1029,10 @@ Feature: TypeDB Driver
 #    Then answer get row(0) get attribute(f) is datetime-tz: false
 #    Then answer get row(0) get attribute(f) is duration: false
 #    Then answer get row(0) get attribute(f) is struct: true
-#    Then answer get row(0) get attribute(f) get <value-type> value: <value>
-#    Then answer get row(0) get attribute(a) as <value-type>: <value>
+#    Then answer get row(0) get attribute(f) get value is: <value>
+#    Then answer get row(0) get attribute(f) as <value-type> is: <value>
+#    Then answer get row(0) get attribute(f) get value is not: <value>
+#    Then answer get row(0) get attribute(f) as <value-type> is not: <not-value>
 
 
   # TODO: Implement value variables
@@ -1048,7 +1053,7 @@ Feature: TypeDB Driver
 #      match $_ isa person, has typed $v;
 #      $value = $v;
 #      """
-#    Then answer type is concept rows
+#    Then answer type is: concept rows
 #    Then answer query type is read
 #    Then answer size: 1
 #
@@ -1074,25 +1079,28 @@ Feature: TypeDB Driver
 #    Then answer get row(0) get value(value) is datetime: <is-datetime>
 #    Then answer get row(0) get value(value) is datetime-tz: <is-datetime-tz>
 #    Then answer get row(0) get value(value) is duration: <is-duration>
-#    Then answer get row(0) get value(value) is struct: true
-#    Then answer get row(0) get value(value) get: <value>
-#    Then answer get row(0) get value(value) as <value-type>: <value>
+#    Then answer get row(0) get value(value) is struct: false
+#    Then answer get row(0) get value(value) get is: <value>
+#    Then answer get row(0) get value(value) as <value-type> is: <value>
+#    Then answer get row(0) get value(value) get is not: <not-value>
+#    Then answer get row(0) get value(value) as <value-type> is not: <not-value>
 #    Examples:
-#      | value-type  | value                                       | is-boolean | is-long | is-double | is-decimal | is-string | is-date | is-datetime | is-datetime-tz | is-duration |
-#      | boolean     | true                                        | true       | false   | false     | false      | false     | false   | false       | false          | false       |
-#      | long        | 12345090                                    | false      | true    | false     | false      | false     | false   | false       | false          | false       |
-#      | double      | 2.01234567                                  | false      | false   | true      | false      | false     | false   | false       | false          | false       |
-#      | decimal     | 1234567890.0001234567890                    | false      | false   | false     | true       | false     | false   | false       | false          | false       |
-#      | decimal     | 0.000000000000000001                        | false      | false   | false     | true       | false     | false   | false       | false          | false       |
-#      | string      | "John \"Baba Yaga\" Wick"                   | false      | false   | false     | false      | true      | false   | false       | false          | false       |
-#      | date        | 2024-09-20                                  | false      | false   | false     | false      | false     | true    | false       | false          | false       |
-#      | datetime    | 1999-02-26T12:15:05                         | false      | false   | false     | false      | false     | false   | true        | false          | false       |
-#      | datetime    | 1999-02-26T12:15:05.000000001               | false      | false   | false     | false      | false     | false   | true        | false          | false       |
-#      | datetime-tz | 2024-09-20T16:40:05 America/New_York        | false      | false   | false     | false      | false     | false   | false       | true           | false       |
-#      | datetime-tz | 2024-09-20T16:40:05.000000001 Europe/London | false      | false   | false     | false      | false     | false   | false       | true           | false       |
+#      | value-type  | value                                       | not-value                                    | is-boolean | is-long | is-double | is-decimal | is-string | is-date | is-datetime | is-datetime-tz | is-duration |
+#      | boolean     | true                                        | false                                        | true       | false   | false     | false      | false     | false   | false       | false          | false       |
+#      | long        | 12345090                                    | 0                                            | false      | true    | false     | false      | false     | false   | false       | false          | false       |
+#      | double      | 0.0000000000000000001                       | 0.000000000000000001                         | false      | false   | true      | false      | false     | false   | false       | false          | false       |
+#      | double      | 2.01234567                                  | 2.01234568                                   | false      | false   | true      | false      | false     | false   | false       | false          | false       |
+#      | decimal     | 1234567890.0001234567890                    | 1234567890.001234567890                      | false      | false   | false     | true       | false     | false   | false       | false          | false       |
+#      | decimal     | 0.0000000000000000001                       | 0.000000000000000001                         | false      | false   | false     | true       | false     | false   | false       | false          | false       |
+#      | string      | "John \"Baba Yaga\" Wick"                   | "John Baba Yaga Wick"                        | false      | false   | false     | false      | true      | false   | false       | false          | false       |
+#      | date        | 2024-09-20                                  | 2025-09-20                                   | false      | false   | false     | false      | false     | true    | false       | false          | false       |
+#      | datetime    | 1999-02-26T12:15:05                         | 1999-02-26T12:15:00                          | false      | false   | false     | false      | false     | false   | true        | false          | false       |
+#      | datetime    | 1999-02-26T12:15:05.000000001               | 1999-02-26T12:15:05.00000001                 | false      | false   | false     | false      | false     | false   | true        | false          | false       |
+#      | datetime-tz | 2024-09-20T16:40:05 America/New_York        | 2024-06-20T15:40:05 America/New_York         | false      | false   | false     | false      | false     | false   | false       | true           | false       |
+#      | datetime-tz | 2024-09-20T16:40:05.000000001 Europe/London | 2024-09-20T16:40:05.000000001 Europe/Belfast | false      | false   | false     | false      | false     | false   | false       | true           | false       |
 #      # TODO: Add datetime-tz with offsets
-#      | duration    | P1Y10M7DT15H44M5.00394892S                  | false      | false   | false     | false      | false     | false   | false       | false          | true        |
-#      | duration    | P66W                                        | false      | false   | false     | false      | false     | false   | false       | false          | true        |
+#      | duration    | P1Y10M7DT15H44M5.00394892S                  | P1Y10M7DT15H44M5.0394892S                    | false      | false   | false     | false      | false     | false   | false       | false          | true        |
+#      | duration    | P66W                                        | P67W                                         | false      | false   | false     | false      | false     | false   | false       | false          | true        |
 
 
   # TODO: Implement structs
@@ -1142,7 +1150,7 @@ Feature: TypeDB Driver
 #      """
 #      match $_ isa director, has film $v;
 #      """
-#    Then answer type is concept rows
+#    Then answer type is: concept rows
 #    Then answer query type is read
 #    Then answer size: 1
 #
@@ -1169,8 +1177,87 @@ Feature: TypeDB Driver
 #    Then answer get row(0) get value(v) is datetime-tz: <is-datetime-tz>
 #    Then answer get row(0) get value(v) is duration: <is-duration>
 #    Then answer get row(0) get value(v) is struct: <is-struct>
-#    Then answer get row(0) get value(v) get: <value>
-#    Then answer get row(0) get value(v) as <value-type>: <value>
+#    Then answer get row(0) get value(v) get is: <value>
+#    Then answer get row(0) get value(v) as <value-type> is: <value>
+#    Then answer get row(0) get value(v) get is not: <not-value>
+#    Then answer get row(0) get value(v) as <value-type> is not: <not-value>
 
 
-  # TODO: Add tests with time-zones set through "set time-zone" steps for datetime and datetime-tz
+  Scenario: Driver processes datetime values in different user time-zones identically
+    Given set time-zone: Asia/Calcutta
+    Given connection open schema transaction for database: typedb
+    Given typeql schema query
+      """
+      define attribute dt @independent, value datetime;
+      """
+    Given transaction commits
+    Given connection open write transaction for database: typedb
+    When get answers of typeql write query
+      """
+      insert $dt 2023-05-01T00:00:00 isa dt;
+      """
+    Then answer get row(0) get attribute(dt) get value is: 2023-05-01T00:00:00
+    Then answer get row(0) get attribute(dt) get value is not: 2023-04-30T13:30:00
+
+    When get answers of typeql read query
+      """
+      match $x isa dt;
+      """
+    Then answer get row(0) get attribute(x) get value is: 2023-05-01T00:00:00
+    Then answer get row(0) get attribute(x) get value is not: 2023-04-30T13:30:00
+    When transaction commits
+
+    When connection closes
+    When set time-zone: America/Chicago
+    When connection opens with default authentication
+
+    When connection open read transaction for database: typedb
+    When get answers of typeql read query
+      """
+      match $x isa dt;
+      """
+    Then answer get row(0) get attribute(x) get value is: 2023-05-01T00:00:00
+    Then answer get row(0) get attribute(x) get value is not: 2023-04-30T13:30:00
+
+
+  Scenario: Driver processes datetime-tz values in different user time-zones identically
+    Given set time-zone: Asia/Calcutta
+    Given connection open schema transaction for database: typedb
+    Given typeql schema query
+      """
+      define attribute dt @independent, value datetime-tz;
+      """
+    Given transaction commits
+    Given connection open write transaction for database: typedb
+    When get answers of typeql write query
+      """
+      insert $dt 2023-05-01T00:00:00 Asia/Calcutta isa dt;
+      """
+    Then answer get row(0) get attribute(dt) get value is: 2023-05-01T00:00:00 Asia/Calcutta
+    Then answer get row(0) get attribute(dt) get value is not: 2023-04-30T13:30:00 Asia/Calcutta
+    Then answer get row(0) get attribute(dt) get value is not: 2023-05-01T00:00:00 America/Chicago
+    Then answer get row(0) get attribute(dt) get value is not: 2023-04-30T13:30:00 America/Chicago
+
+    When get answers of typeql read query
+      """
+      match $x isa dt;
+      """
+    Then answer get row(0) get attribute(x) get value is: 2023-05-01T00:00:00 Asia/Calcutta
+    Then answer get row(0) get attribute(x) get value is not: 2023-04-30T13:30:00 Asia/Calcutta
+    Then answer get row(0) get attribute(x) get value is not: 2023-05-01T00:00:00 America/Chicago
+    Then answer get row(0) get attribute(x) get value is not: 2023-04-30T13:30:00 America/Chicago
+    When transaction commits
+
+    When connection closes
+    When set time-zone: America/Chicago
+    When connection opens with default authentication
+
+    When connection open read transaction for database: typedb
+    When get answers of typeql read query
+      """
+      match $x isa dt;
+      """
+    Then answer get row(0) get attribute(x) get value is: 2023-05-01T00:00:00 Asia/Calcutta
+    Then answer get row(0) get attribute(x) get value is not: 2023-04-30T13:30:00 Asia/Calcutta
+    Then answer get row(0) get attribute(x) get value is not: 2023-05-01T00:00:00 America/Chicago
+    Then answer get row(0) get attribute(x) get value is not: 2023-04-30T13:30:00 America/Chicago

--- a/driver/driver.feature
+++ b/driver/driver.feature
@@ -32,7 +32,7 @@ Feature: TypeDB Driver
     When connection closes
     When connection opens with a wrong port; fails
     Then connection is open: false
-    When connection opens with a wrong address; fails
+    When connection opens with a wrong host; fails
     Then connection is open: false
     When connection opens with default authentication
     Then connection is open: true
@@ -66,9 +66,9 @@ Feature: TypeDB Driver
   # DATABASES #
   #############
 
-  Scenario: Driver can delete non-existing database
+  Scenario: Driver cannot delete non-existing database
     Given connection does not have database: does-not-exist
-    When connection delete database: does-not-exist
+    Then connection delete database: does-not-exist; fails
     Then connection does not have database: does-not-exist
 
   Scenario: Driver can create and delete databases
@@ -127,81 +127,82 @@ Feature: TypeDB Driver
     Then connection has database: typedb
 
 
-  Scenario: Driver can acquire database schema
-    Given connection has database: typedb
-    Then connection get database(typedb) has schema:
-    """
-    """
-    Then connection get database(typedb) has type schema:
-    """
-    """
-
-    When connection open schema transaction for database: typedb
-    When typeql schema query
-    """
-    define
-    entity person @abstract, owns age @card(1..1);
-    attribute age, value long @range(0..150);
-    """
-    Then connection get database(typedb) has schema:
-    """
-    """
-    Then connection get database(typedb) has type schema:
-    """
-    """
-    When transaction commits
-    Then connection get database(typedb) has schema:
-    """
-    define
-    entity person @abstract, owns age @card(1..1);
-    attribute age, value long @range(0..150);
-    """
-    Then connection get database(typedb) has type schema:
-    """
-    define
-    entity person @abstract, owns age @card(1..1);
-    attribute age, value long @range(0..150);
-    """
-
-    When connection open schema transaction for database: typedb
-    When typeql schema query
-    """
-    redefine
-    attribute age, value long @range(0..);
-    """
-    When typeql schema query
-    """
-    define
-    entity person owns age @range(0..150);
-    entity fictional-character owns age;
-    """
-    Then connection get database(typedb) has schema:
-    """
-    define
-    entity person @abstract, owns age @card(1..1);
-    attribute age, value long @range(0..150);
-    """
-    Then connection get database(typedb) has type schema:
-    """
-    define
-    entity person @abstract, owns age @card(1..1);
-    attribute age, value long @range(0..150);
-    """
-    When transaction commits
-    Then connection get database(typedb) has schema:
-    """
-    define
-    entity person @abstract, owns age @card(1..1) @range(0..150);
-    entity fictional-character owns age;
-    attribute age, value long @range(0..);
-    """
-    Then connection get database(typedb) has type schema:
-    """
-    define
-    entity person @abstract, owns age @card(1..1) @range(0..150);
-    entity fictional-character owns age;
-    attribute age, value long @range(0..);
-    """
+# TODO: Implement database schema retrieval. Fix steps if needed.
+#  Scenario: Driver can acquire database schema
+#    Given connection has database: typedb
+#    Then connection get database(typedb) has schema:
+#    """
+#    """
+#    Then connection get database(typedb) has type schema:
+#    """
+#    """
+#
+#    When connection open schema transaction for database: typedb
+#    When typeql schema query
+#    """
+#    define
+#    entity person @abstract, owns age @card(1..1);
+#    attribute age, value long @range(0..150);
+#    """
+#    Then connection get database(typedb) has schema:
+#    """
+#    """
+#    Then connection get database(typedb) has type schema:
+#    """
+#    """
+#    When transaction commits
+#    Then connection get database(typedb) has schema:
+#    """
+#    define
+#    entity person @abstract, owns age @card(1..1);
+#    attribute age, value long @range(0..150);
+#    """
+#    Then connection get database(typedb) has type schema:
+#    """
+#    define
+#    entity person @abstract, owns age @card(1..1);
+#    attribute age, value long @range(0..150);
+#    """
+#
+#    When connection open schema transaction for database: typedb
+#    When typeql schema query
+#    """
+#    redefine
+#    attribute age, value long @range(0..);
+#    """
+#    When typeql schema query
+#    """
+#    define
+#    entity person owns age @range(0..150);
+#    entity fictional-character owns age;
+#    """
+#    Then connection get database(typedb) has schema:
+#    """
+#    define
+#    entity person @abstract, owns age @card(1..1);
+#    attribute age, value long @range(0..150);
+#    """
+#    Then connection get database(typedb) has type schema:
+#    """
+#    define
+#    entity person @abstract, owns age @card(1..1);
+#    attribute age, value long @range(0..150);
+#    """
+#    When transaction commits
+#    Then connection get database(typedb) has schema:
+#    """
+#    define
+#    entity person @abstract, owns age @card(1..1) @range(0..150);
+#    entity fictional-character owns age;
+#    attribute age, value long @range(0..);
+#    """
+#    Then connection get database(typedb) has type schema:
+#    """
+#    define
+#    entity person @abstract, owns age @card(1..1) @range(0..150);
+#    entity fictional-character owns age;
+#    attribute age, value long @range(0..);
+#    """
 
   ###############
   # TRANSACTION #
@@ -259,80 +260,85 @@ Feature: TypeDB Driver
     Then transaction is open: false
 
 
-  Scenario: Driver can rollback transactions of schema and write types, cannot rollback transaction of type read
-    When connection open schema transaction for database: typedb
-    Then transaction has type: schema
-    Then transaction is open: true
-    When transaction rollbacks
-    Then transaction is open: false
-
-    When connection open write transaction for database: typedb
-    Then transaction has type: write
-    Then transaction is open: true
-    When transaction rollbacks
-    Then transaction is open: false
-
-    When connection open read transaction for database: typedb
-    Then transaction has type: read
-    Then transaction is open: true
-    Then transaction rollbacks; fails
-    Then transaction is open: false
-
-
-  # TODO: Check options setting and retrieval
+  # TODO: Fix rollbacks on the server side
+#  Scenario: Driver can rollback transactions of schema and write types, cannot rollback transaction of type read
+#    When connection open schema transaction for database: typedb
+#    Then transaction has type: schema
+#    Then transaction is open: true
+#    When transaction rollbacks
+#    Then transaction is open: false
+#
+#    When connection open write transaction for database: typedb
+#    Then transaction has type: write
+#    Then transaction is open: true
+#    When transaction rollbacks
+#    Then transaction is open: false
+#
+#    When connection open read transaction for database: typedb
+#    Then transaction has type: read
+#    Then transaction is open: true
+#    Then transaction rollbacks; fails
+#    Then transaction is open: false
 
 
-  Scenario: Driver can schedule "transaction on close" jobs
-    Given connection does not have database: created-after-schema
-    Given connection does not have database: created-after-write
-    Given connection does not have database: created-after-read
-    When connection open schema transaction for database: typedb
-    When schedule database creation on transaction close: created-after-schema
-    Then connection does not have database: created-after-schema
-    Then connection does not have database: created-after-write
-    Then connection does not have database: created-after-read
-    When transaction closes
-    Then connection has database: created-after-schema
-    Then connection does not have database: created-after-write
-    Then connection does not have database: created-after-read
+#  # TODO: Check options setting and retrieval
 
-    When connection open write transaction for database: typedb
-    Then connection has database: created-after-schema
-    Then connection does not have database: created-after-write
-    Then connection does not have database: created-after-read
-    When transaction closes
-    Then connection has database: created-after-schema
-    Then connection does not have database: created-after-write
-    Then connection does not have database: created-after-read
 
-    When connection open write transaction for database: typedb
-    When schedule database creation on transaction close: created-after-write
-    Then connection has database: created-after-schema
-    Then connection does not have database: created-after-write
-    Then connection does not have database: created-after-read
-    When transaction closes
-    Then connection has database: created-after-schema
-    Then connection has database: created-after-write
-    Then connection does not have database: created-after-read
-
-    When connection open read transaction for database: typedb
-    When schedule database creation on transaction close: created-after-read
-    Then connection has database: created-after-schema
-    Then connection has database: created-after-write
-    Then connection does not have database: created-after-read
-    When transaction closes
-    Then connection has database: created-after-schema
-    Then connection has database: created-after-write
-    Then connection has database: created-after-read
+  # TODO: Fix on_close
+#  Scenario: Driver can schedule "transaction on close" jobs
+#    Given connection does not have database: created-after-schema
+#    Given connection does not have database: created-after-write
+#    Given connection does not have database: created-after-read
+#    When connection open schema transaction for database: typedb
+#    When schedule database creation on transaction close: created-after-schema
+#    Then connection does not have database: created-after-schema
+#    Then connection does not have database: created-after-write
+#    Then connection does not have database: created-after-read
+#    When transaction closes
+#    Then connection has database: created-after-schema
+#    Then connection does not have database: created-after-write
+#    Then connection does not have database: created-after-read
+#
+#    When connection open write transaction for database: typedb
+#    Then connection has database: created-after-schema
+#    Then connection does not have database: created-after-write
+#    Then connection does not have database: created-after-read
+#    When transaction closes
+#    Then connection has database: created-after-schema
+#    Then connection does not have database: created-after-write
+#    Then connection does not have database: created-after-read
+#
+#    When connection open write transaction for database: typedb
+#    When schedule database creation on transaction close: created-after-write
+#    Then connection has database: created-after-schema
+#    Then connection does not have database: created-after-write
+#    Then connection does not have database: created-after-read
+#    When transaction closes
+#    Then connection has database: created-after-schema
+#    Then connection has database: created-after-write
+#    Then connection does not have database: created-after-read
+#
+#    When connection open read transaction for database: typedb
+#    When schedule database creation on transaction close: created-after-read
+#    Then connection has database: created-after-schema
+#    Then connection has database: created-after-write
+#    Then connection does not have database: created-after-read
+#    When transaction closes
+#    Then connection has database: created-after-schema
+#    Then connection has database: created-after-write
+#    Then connection has database: created-after-read
 
 
   Scenario: Driver processes transaction commit errors correctly
     Given connection open schema transaction for database: typedb
-    When get answers of typeql schema query; fails
+    When typeql schema query
       """
       define attribute name;
       """
     Then transaction commits; fails
+
+
+  # TODO: check errors on transaction commits with callbacks set!
 
   ###########
   # QUERIES #
@@ -344,12 +350,14 @@ Feature: TypeDB Driver
       """
       define entity person;
       """
-    Then answer type: ok
-    Then answer size: 1
+    Then answer type is ok
+    Then answer type is not concept rows
+    Then answer type is not concept trees
     Then result is a successful ok
     Then transaction commits
 
 
+    # TODO: Test optionals when introduced
   Scenario: Driver processes concept row query answers correctly
     Given connection open schema transaction for database: typedb
     Given typeql schema query
@@ -360,18 +368,33 @@ Feature: TypeDB Driver
       """
       match entity $p;
       """
-    Then answer type: concept rows
+    Then answer type is concept rows
+    Then answer type is not ok
+    Then answer type is not concept trees
+    Then answer query type is read
+    Then answer query type is not schema
+    Then answer query type is not write
     Then answer size: 1
-    Then result is a single row with variable 'p': person
+    Then answer header is: (p)
+    Then answer get row(0) get entity type(p) get label: person
+    Then answer get row(0) get entity type by index of variable(p) get label: person
 
     When get answers of typeql read query
       """
       match entity $p; attribute $n;
       """
-    Then answer type: concept rows
-    Then uniquely identify answer concepts
-      | p      | n    |
-      | person | name |
+    Then answer type is concept rows
+    Then answer type is not ok
+    Then answer type is not concept trees
+    Then answer query type is read
+    Then answer query type is not schema
+    Then answer query type is not write
+    Then answer size: 1
+    Then answer header is: (p, n)
+    Then answer get row(0) get entity type(p) get label: person
+    Then answer get row(0) get attribute type(n) get label: name
+    Then answer get row(0) get entity type by index of variable(p) get label: person
+    Then answer get row(0) get attribute type by index of variable(n) get label: name
 
     When typeql schema query
       """
@@ -381,12 +404,22 @@ Feature: TypeDB Driver
       """
       match entity $p; attribute $n;
       """
-    Then answer type: concept rows
+    Then answer type is concept rows
+    Then answer type is not ok
+    Then answer type is not concept trees
+    Then answer query type is read
+    Then answer query type is not schema
+    Then answer query type is not write
     Then answer size: 2
-    Then uniquely identify answer concepts
-      | p      | n    |
-      | person | name |
-      | person | age  |
+    Then answer header is: (p, n)
+    Then answer get row(0) get entity type(p) get label: person
+    Then answer get row(0) get attribute type(n) get label: name
+    Then answer get row(0) get entity type by index of variable(p) get label: person
+    Then answer get row(0) get attribute type by index of variable(n) get label: name
+    Then answer get row(1) get entity type(p) get label: person
+    Then answer get row(1) get attribute type(n) get label: age
+    Then answer get row(1) get entity type by index of variable(p) get label: person
+    Then answer get row(1) get attribute type by index of variable(n) get label: age
     Then transaction commits
 
     When connection open read transaction for database: typedb
@@ -394,19 +427,34 @@ Feature: TypeDB Driver
       """
       match entity $p; attribute $n;
       """
-    Then answer type: concept rows
+    Then answer type is concept rows
+    Then answer type is not ok
+    Then answer type is not concept trees
+    Then answer query type is read
+    Then answer query type is not schema
+    Then answer query type is not write
     Then answer size: 2
-    Then uniquely identify answer concepts
-      | p      | n    |
-      | person | name |
-      | person | age  |
+    Then answer header is: (p, n)
+    Then answer get row(0) get entity type(p) get label: person
+    Then answer get row(0) get attribute type(n) get label: name
+    Then answer get row(0) get entity type by index of variable(p) get label: person
+    Then answer get row(0) get attribute type by index of variable(n) get label: name
+    Then answer get row(1) get entity type(p) get label: person
+    Then answer get row(1) get attribute type(n) get label: age
+    Then answer get row(1) get entity type by index of variable(p) get label: person
+    Then answer get row(1) get attribute type by index of variable(n) get label: age
     Then transaction commits
 
     When get answers of typeql read query
       """
       match relation $r;
       """
-    Then answer type: concept rows
+    Then answer type is concept rows
+    Then answer type is not ok
+    Then answer type is not concept trees
+    Then answer query type is read
+    Then answer query type is not schema
+    Then answer query type is not write
     Then answer size: 0
 
     When transaction closes
@@ -415,470 +463,492 @@ Feature: TypeDB Driver
       """
       insert person $p, has name "John";
       """
-    Then answer type: concept rows
+    Then answer type is concept rows
+    Then answer type is not ok
+    Then answer type is not concept trees
+    Then answer query type is write
+    Then answer query type is not schema
+    Then answer query type is not read
     Then answer size: 1
-    Then uniquely identify answer concepts
-      | p      |
-      | person |
+    Then answer header is: (p)
+    Then answer get row(0) get entity type(p) get label: person
+    Then answer get row(0) get entity type by index of variable(p) get label: person
 
     When get answers of typeql read query
       """
-      match $p isa person, has name $n;
+      match $p isa person, has name $a;
       """
-    Then answer type: concept rows
+    Then answer type is concept rows
+    Then answer type is not ok
+    Then answer type is not concept trees
+    Then answer query type is read
+    Then answer query type is not schema
+    Then answer query type is not write
     Then answer size: 1
-    Then uniquely identify answer concepts
-      | p      | n      |
-      | person | "John" |
+    Then answer header is: (p, a)
+    Then answer get row(0) get entity(p) get type get label: person
+    Then answer get row(0) get entity by index of variable(p) get type get label: person
+    Then answer get row(0) get attribute(a) get type get label: name
+    Then answer get row(0) get attribute(a) get string value: "John"
+    Then answer get row(0) get attribute by index of variable(n) get type get label: name
+    Then answer get row(0) get attribute by index of variable(n) get string value: "John"
     Then transaction commits
 
 
-  # TODO: Implement value groups checks
-  #Scenario: Driver processes concept row query answers with value groups correctly
-
-
-  # TODO: Implement concept trees checks
-  #Scenario: Driver processes concept tree query answers correctly
-
-
-  Scenario: Driver processes query errors correctly
-    Given connection open schema transaction for database: typedb
-    Then get answers of typeql schema query; fails
-      """
-      """
-    Then get answers of typeql schema query; fails
-      """
-
-      """
-    Then get answers of typeql schema query; fails
-      """
-
-      """
-    Then get answers of typeql schema query; fails
-      """
-      define entity entity;
-      """
-    Then get answers of typeql schema query; fails
-      """
-      define attribute name owns name;
-      """
-
-
-  ############
-  # CONCEPTS #
-  ############
-
-  Scenario: Driver processes entity types correctly
-    Given connection open schema transaction for database: typedb
-    Given typeql schema query
-      """
-      define entity person;
-      """
-    When get answers of typeql read query
-      """
-      match entity $p;
-      """
-    Then answer type: concept rows
-    Then answer size: 1
-
-    Then answer get row(0) get variable(p) is type: true
-    Then answer get row(0) get variable(p) is thing type: true
-    Then answer get row(0) get variable(p) is thing: false
-    Then answer get row(0) get variable(p) is value: false
-    Then answer get row(0) get variable(p) is entity type: true
-    Then answer get row(0) get variable(p) is relation type: false
-    Then answer get row(0) get variable(p) is attribute type: false
-    Then answer get row(0) get variable(p) is role type: false
-    Then answer get row(0) get variable(p) is entity: false
-    Then answer get row(0) get variable(p) is relation: false
-    Then answer get row(0) get variable(p) is attribute: false
-
-    Then answer get row(0) get type(p) get label: person
-    Then answer get row(0) get thing type(p) get label: person
-    Then answer get row(0) get entity type(p) get label: person
-    Then answer get row(0) get entity type(p) get name: person
-    Then answer get row(0) get entity type(p) get scope is none
-
-
-  Scenario: Driver processes relation types correctly
-    Given connection open schema transaction for database: typedb
-    Given typeql schema query
-      """
-      define relation parentship, relates parent;
-      """
-    When get answers of typeql read query
-      """
-      match relation $p;
-      """
-    Then answer type: concept rows
-    Then answer size: 1
-
-    Then answer get row(0) get variable(p) is type: true
-    Then answer get row(0) get variable(p) is thing type: true
-    Then answer get row(0) get variable(p) is thing: false
-    Then answer get row(0) get variable(p) is value: false
-    Then answer get row(0) get variable(p) is entity type: false
-    Then answer get row(0) get variable(p) is relation type: true
-    Then answer get row(0) get variable(p) is attribute type: false
-    Then answer get row(0) get variable(p) is role type: false
-    Then answer get row(0) get variable(p) is entity: false
-    Then answer get row(0) get variable(p) is relation: false
-    Then answer get row(0) get variable(p) is attribute: false
-
-    Then answer get row(0) get type(p) get label: parentship
-    Then answer get row(0) get thing type(p) get label: parentship
-    Then answer get row(0) get relation type(p) get label: parentship
-    Then answer get row(0) get relation type(p) get name: parentship
-    Then answer get row(0) get relation type(p) get scope is none
-
-
-  Scenario: Driver processes role types correctly
-    Given connection open schema transaction for database: typedb
-    Given typeql schema query
-      """
-      define relation parentship, relates parent;
-      """
-    When get answers of typeql read query
-      """
-      match relation parentship, relates $p;
-      """
-    Then answer type: concept rows
-    Then answer size: 1
-
-    Then answer get row(0) get variable(p) is type: true
-    Then answer get row(0) get variable(p) is thing type: false
-    Then answer get row(0) get variable(p) is thing: false
-    Then answer get row(0) get variable(p) is value: false
-    Then answer get row(0) get variable(p) is entity type: false
-    Then answer get row(0) get variable(p) is relation type: false
-    Then answer get row(0) get variable(p) is attribute type: false
-    Then answer get row(0) get variable(p) is role type: true
-    Then answer get row(0) get variable(p) is entity: false
-    Then answer get row(0) get variable(p) is relation: false
-    Then answer get row(0) get variable(p) is attribute: false
-
-    Then answer get row(0) get type(p) get label: parentship:parent
-    Then answer get row(0) get role type(p) get label: parentship:parent
-    Then answer get row(0) get role type(p) get name: parent
-    Then answer get row(0) get role type(p) get scope: parentship
-
-
-  Scenario: Driver processes attribute types without value type correctly
-    Given connection open schema transaction for database: typedb
-    Given typeql schema query
-      """
-      define attribute untyped @abstract;
-      """
-    When get answers of typeql read query
-      """
-      match attribute $a;
-      """
-    Then answer type: concept rows
-    Then answer size: 1
-
-    Then answer get row(0) get variable(a) is type: true
-    Then answer get row(0) get variable(a) is thing type: true
-    Then answer get row(0) get variable(a) is thing: false
-    Then answer get row(0) get variable(a) is value: false
-    Then answer get row(0) get variable(a) is entity type: false
-    Then answer get row(0) get variable(a) is relation type: false
-    Then answer get row(0) get variable(a) is attribute type: true
-    Then answer get row(0) get variable(a) is role type: false
-    Then answer get row(0) get variable(a) is entity: false
-    Then answer get row(0) get variable(a) is relation: false
-    Then answer get row(0) get variable(a) is attribute: false
-
-    Then answer get row(0) get type(a) get label: untyped
-    Then answer get row(0) get thing type(a) get label: untyped
-    Then answer get row(0) get attribute type(a) get label: untyped
-    Then answer get row(0) get attribute type(a) get name: untyped
-    Then answer get row(0) get attribute type(a) get scope is none
-
-    Then answer get row(0) get attribute type(a) get value type: none
-    Then answer get row(0) get attribute type(a) is untyped: true
-    Then answer get row(0) get attribute type(a) is boolean: false
-    Then answer get row(0) get attribute type(a) is long: false
-    Then answer get row(0) get attribute type(a) is double: false
-    Then answer get row(0) get attribute type(a) is decimal: false
-    Then answer get row(0) get attribute type(a) is string: false
-    Then answer get row(0) get attribute type(a) is date: false
-    Then answer get row(0) get attribute type(a) is datetime: false
-    Then answer get row(0) get attribute type(a) is datetime-tz: false
-    Then answer get row(0) get attribute type(a) is duration: false
-    Then answer get row(0) get attribute type(a) is struct: false
-
-
-  Scenario Outline: Driver processes attribute types with value type <value-type> correctly
-    Given connection open schema transaction for database: typedb
-    Given typeql schema query
-      """
-      define attribute typed, value <value-type>;
-      """
-    When get answers of typeql read query
-      """
-      match attribute $a;
-      """
-    Then answer type: concept rows
-    Then answer size: 1
-
-    Then answer get row(0) get variable(a) is type: true
-    Then answer get row(0) get variable(a) is thing type: true
-    Then answer get row(0) get variable(a) is thing: false
-    Then answer get row(0) get variable(a) is value: false
-    Then answer get row(0) get variable(a) is entity type: false
-    Then answer get row(0) get variable(a) is relation type: false
-    Then answer get row(0) get variable(a) is attribute type: true
-    Then answer get row(0) get variable(a) is role type: false
-    Then answer get row(0) get variable(a) is entity: false
-    Then answer get row(0) get variable(a) is relation: false
-    Then answer get row(0) get variable(a) is attribute: false
-
-    Then answer get row(0) get type(a) get label: typed
-    Then answer get row(0) get thing type(a) get label: typed
-    Then answer get row(0) get attribute type(a) get label: typed
-    Then answer get row(0) get attribute type(a) get name: typed
-    Then answer get row(0) get attribute type(a) get scope is none
-
-    Then answer get row(0) get attribute type(a) get value type: <value-type>
-    Then answer get row(0) get attribute type(a) is untyped: false
-    Then answer get row(0) get attribute type(a) is boolean: <is-boolean>
-    Then answer get row(0) get attribute type(a) is long: <is-long>
-    Then answer get row(0) get attribute type(a) is double: <is-double>
-    Then answer get row(0) get attribute type(a) is decimal: <is-decimal>
-    Then answer get row(0) get attribute type(a) is string: <is-string>
-    Then answer get row(0) get attribute type(a) is date: <is-date>
-    Then answer get row(0) get attribute type(a) is datetime: <is-datetime>
-    Then answer get row(0) get attribute type(a) is datetime-tz: <is-datetime-tz>
-    Then answer get row(0) get attribute type(a) is duration: <is-duration>
-    Then answer get row(0) get attribute type(a) is struct: <is-struct>
-    Examples:
-      | value-type  | is-boolean | is-long | is-double | is-decimal | is-string | is-date | is-datetime | is-datetime-tz | is-duration | is-struct |
-      | boolean     | true       | false   | false     | false      | false     | false   | false       | false          | false       | false     |
-      | long        | false      | true    | false     | false      | false     | false   | false       | false          | false       | false     |
-      | double      | false      | false   | true      | false      | false     | false   | false       | false          | false       | false     |
-      | decimal     | false      | false   | false     | true       | false     | false   | false       | false          | false       | false     |
-      | string      | false      | false   | false     | false      | true      | false   | false       | false          | false       | false     |
-      | date        | false      | false   | false     | false      | false     | true    | false       | false          | false       | false     |
-      | datetime    | false      | false   | false     | false      | false     | false   | true        | false          | false       | false     |
-      | datetime-tz | false      | false   | false     | false      | false     | false   | false       | true           | false       | false     |
-      | duration    | false      | false   | false     | false      | false     | false   | false       | false          | true        | false     |
-      | struct      | false      | false   | false     | false      | false     | false   | false       | false          | false       | true      |
-
-
-  Scenario: Driver processes entities correctly
-    Given connection open schema transaction for database: typedb
-    Given typeql schema query
-      """
-      define entity person;
-      """
-    Given transaction commits
-    Given connection open write transaction for database: typedb
-    Given typeql write query
-      """
-      insert $p isa person;
-      """
-    When get answers of typeql read query
-      """
-      match $p isa person;
-      """
-    Then answer type: concept rows
-    Then answer size: 1
-
-    Then answer get row(0) get variable(p) is type: false
-    Then answer get row(0) get variable(p) is thing type: false
-    Then answer get row(0) get variable(p) is thing: true
-    Then answer get row(0) get variable(p) is value: false
-    Then answer get row(0) get variable(p) is entity type: false
-    Then answer get row(0) get variable(p) is relation type: false
-    Then answer get row(0) get variable(p) is attribute type: false
-    Then answer get row(0) get variable(p) is role type: false
-    Then answer get row(0) get variable(p) is entity: true
-    Then answer get row(0) get variable(p) is relation: false
-    Then answer get row(0) get variable(p) is attribute: false
-
-    Then answer get row(0) get thing(p) get type get label: person
-    Then answer get row(0) get entity(p) get iid exists
-    Then answer get row(0) get entity(p) get type get label: person
-    Then answer get row(0) get entity(p) get type is entity: false
-    Then answer get row(0) get entity(p) get type is entity type: true
-    Then answer get row(0) get entity(p) get type is relation type: false
-    Then answer get row(0) get entity(p) get type is attribute type: false
-    Then answer get row(0) get entity(p) get type is role type: false
-
-
-  Scenario: Driver processes relations correctly
-    Given connection open schema transaction for database: typedb
-    Given typeql schema query
-      """
-      define relation parentship, relates parent;
-      """
-    Given transaction commits
-    Given connection open write transaction for database: typedb
-    Given typeql write query
-      """
-      insert $p isa parentship;
-      """
-    When get answers of typeql read query
-      """
-      match $p isa parentship;
-      """
-    Then answer type: concept rows
-    Then answer size: 1
-
-    Then answer get row(0) get variable(p) is type: false
-    Then answer get row(0) get variable(p) is thing type: false
-    Then answer get row(0) get variable(p) is thing: true
-    Then answer get row(0) get variable(p) is value: false
-    Then answer get row(0) get variable(p) is entity type: false
-    Then answer get row(0) get variable(p) is relation type: false
-    Then answer get row(0) get variable(p) is attribute type: false
-    Then answer get row(0) get variable(p) is role type: false
-    Then answer get row(0) get variable(p) is entity: false
-    Then answer get row(0) get variable(p) is relation: true
-    Then answer get row(0) get variable(p) is attribute: false
-
-    Then answer get row(0) get thing(p) get type get label: parentship
-    Then answer get row(0) get relation(p) get iid exists
-    Then answer get row(0) get relation(p) get type get label: parentship
-    Then answer get row(0) get relation(p) get type is relation: false
-    Then answer get row(0) get relation(p) get type is entity type: false
-    Then answer get row(0) get relation(p) get type is relation type: true
-    Then answer get row(0) get relation(p) get type is attribute type: false
-    Then answer get row(0) get relation(p) get type is role type: false
-
-
-  Scenario Outline: Driver processes attributes of type <value-type> correctly
-    Given connection open schema transaction for database: typedb
-    Given typeql schema query
-      """
-      define entity person, owns typed; attribute typed, value <value-type>;
-      """
-    Given transaction commits
-    Given connection open write transaction for database: typedb
-    Given typeql write query
-      """
-      insert $p isa person, has typed <value>;
-      """
-    When get answers of typeql read query
-      """
-      match $_ isa person, has $a;
-      """
-    Then answer type: concept rows
-    Then answer size: 1
-
-    Then answer get row(0) get variable(a) is type: false
-    Then answer get row(0) get variable(a) is thing type: false
-    Then answer get row(0) get variable(a) is thing: true
-    Then answer get row(0) get variable(a) is value: false
-    Then answer get row(0) get variable(a) is entity type: false
-    Then answer get row(0) get variable(a) is relation type: false
-    Then answer get row(0) get variable(a) is attribute type: false
-    Then answer get row(0) get variable(a) is role type: false
-    Then answer get row(0) get variable(a) is entity: false
-    Then answer get row(0) get variable(a) is relation: false
-    Then answer get row(0) get variable(a) is attribute: true
-
-    Then answer get row(0) get thing(a) get type get label: typed
-    Then answer get row(0) get attribute(a) get type get label: typed
-    Then answer get row(0) get attribute(a) get type is attribute: false
-    Then answer get row(0) get attribute(a) get type is entity type: false
-    Then answer get row(0) get attribute(a) get type is relation type: true
-    Then answer get row(0) get attribute(a) get type is attribute type: true
-    Then answer get row(0) get attribute(a) get type is role type: false
-
-    Then answer get row(0) get attribute(a) get type get value type: <value-type>
-    Then answer get row(0) get attribute(a) is boolean: <is-boolean>
-    Then answer get row(0) get attribute(a) is long: <is-long>
-    Then answer get row(0) get attribute(a) is double: <is-double>
-    Then answer get row(0) get attribute(a) is decimal: <is-decimal>
-    Then answer get row(0) get attribute(a) is string: <is-string>
-    Then answer get row(0) get attribute(a) is date: <is-date>
-    Then answer get row(0) get attribute(a) is datetime: <is-datetime>
-    Then answer get row(0) get attribute(a) is datetime-tz: <is-datetime-tz>
-    Then answer get row(0) get attribute(a) is duration: <is-duration>
-    Then answer get row(0) get attribute(a) is struct: <is-struct>
-    Then answer get row(0) get attribute(a) get <value-type> value: <value>
-    Examples:
-      | value-type  | value                                       | is-boolean | is-long | is-double | is-decimal | is-string | is-date | is-datetime | is-datetime-tz | is-duration | is-struct |
-      | boolean     | true                                        | true       | false   | false     | false      | false     | false   | false       | false          | false       | false     |
-      | long        | 12345090                                    | false      | true    | false     | false      | false     | false   | false       | false          | false       | false     |
-      | double      | 2.01234567                                  | false      | false   | true      | false      | false     | false   | false       | false          | false       | false     |
-      | decimal     | 1234567890.0001234567890                    | false      | false   | false     | true       | false     | false   | false       | false          | false       | false     |
-      | decimal     | 0.000000000000000001                        | false      | false   | false     | true       | false     | false   | false       | false          | false       | false     |
-      | string      | "John \"Baba Yaga\" Wick"                   | false      | false   | false     | false      | true      | false   | false       | false          | false       | false     |
-      | date        | 2024-09-20                                  | false      | false   | false     | false      | false     | true    | false       | false          | false       | false     |
-      | datetime    | 1999-02-26T12:15:05                         | false      | false   | false     | false      | false     | false   | true        | false          | false       | false     |
-      | datetime    | 1999-02-26T12:15:05.000000001               | false      | false   | false     | false      | false     | false   | true        | false          | false       | false     |
-      | datetime-tz | 2024-09-20T16:40:05 America/New_York        | false      | false   | false     | false      | false     | false   | false       | true           | false       | false     |
-      | datetime-tz | 2024-09-20T16:40:05.000000001 Europe/London | false      | false   | false     | false      | false     | false   | false       | true           | false       | false     |
-      # TODO: Add datetime-tz with offsets
-      | duration    | P1Y10M7DT15H44M5.00394892S                  | false      | false   | false     | false      | false     | false   | false       | false          | true        | false     |
-      | duration    | P66W                                        | false      | false   | false     | false      | false     | false   | false       | false          | true        | false     |
-      # TODO: Implement structs
-#      | struct      |                                             | false      | false   | false     | false      | false     | false   | false       | false          | false       | true      |
-
-
-  Scenario Outline: Driver processes values of type <value-type> correctly
-    Given connection open schema transaction for database: typedb
-    Given typeql schema query
-      """
-      define entity person, owns typed; attribute typed, value <value-type>;
-      """
-    Given transaction commits
-    Given connection open write transaction for database: typedb
-    Given typeql write query
-      """
-      insert $p isa person, has typed <value>;
-      """
-    When get answers of typeql read query
-      """
-      match $_ isa person, has typed $v;
-      """
-    Then answer type: concept rows
-    Then answer size: 1
-
-    Then answer get row(0) get variable(v) is type: false
-    Then answer get row(0) get variable(v) is thing type: false
-    Then answer get row(0) get variable(v) is thing: false
-    Then answer get row(0) get variable(v) is value: true
-    Then answer get row(0) get variable(v) is entity type: false
-    Then answer get row(0) get variable(v) is relation type: false
-    Then answer get row(0) get variable(v) is attribute type: false
-    Then answer get row(0) get variable(v) is role type: false
-    Then answer get row(0) get variable(v) is entity: false
-    Then answer get row(0) get variable(v) is relation: false
-    Then answer get row(0) get variable(v) is attribute: false
-
-    Then answer get row(0) get value(v) get value type: <value-type>
-    Then answer get row(0) get value(v) is boolean: <is-boolean>
-    Then answer get row(0) get value(v) is long: <is-long>
-    Then answer get row(0) get value(v) is double: <is-double>
-    Then answer get row(0) get value(v) is decimal: <is-decimal>
-    Then answer get row(0) get value(v) is string: <is-string>
-    Then answer get row(0) get value(v) is date: <is-date>
-    Then answer get row(0) get value(v) is datetime: <is-datetime>
-    Then answer get row(0) get value(v) is datetime-tz: <is-datetime-tz>
-    Then answer get row(0) get value(v) is duration: <is-duration>
-    Then answer get row(0) get value(v) is struct: <is-struct>
-    Then answer get row(0) get value(v) get: <value>
-    Then answer get row(0) get value(v) as <value-type>: <value>
-    Examples:
-      | value-type  | value                                       | is-boolean | is-long | is-double | is-decimal | is-string | is-date | is-datetime | is-datetime-tz | is-duration | is-struct |
-      | boolean     | true                                        | true       | false   | false     | false      | false     | false   | false       | false          | false       | false     |
-      | long        | 12345090                                    | false      | true    | false     | false      | false     | false   | false       | false          | false       | false     |
-      | double      | 2.01234567                                  | false      | false   | true      | false      | false     | false   | false       | false          | false       | false     |
-      | decimal     | 1234567890.0001234567890                    | false      | false   | false     | true       | false     | false   | false       | false          | false       | false     |
-      | decimal     | 0.000000000000000001                        | false      | false   | false     | true       | false     | false   | false       | false          | false       | false     |
-      | string      | "John \"Baba Yaga\" Wick"                   | false      | false   | false     | false      | true      | false   | false       | false          | false       | false     |
-      | date        | 2024-09-20                                  | false      | false   | false     | false      | false     | true    | false       | false          | false       | false     |
-      | datetime    | 1999-02-26T12:15:05                         | false      | false   | false     | false      | false     | false   | true        | false          | false       | false     |
-      | datetime    | 1999-02-26T12:15:05.000000001               | false      | false   | false     | false      | false     | false   | true        | false          | false       | false     |
-      | datetime-tz | 2024-09-20T16:40:05 America/New_York        | false      | false   | false     | false      | false     | false   | false       | true           | false       | false     |
-      | datetime-tz | 2024-09-20T16:40:05.000000001 Europe/London | false      | false   | false     | false      | false     | false   | false       | true           | false       | false     |
-      # TODO: Add datetime-tz with offsets
-      | duration    | P1Y10M7DT15H44M5.00394892S                  | false      | false   | false     | false      | false     | false   | false       | false          | true        | false     |
-      | duration    | P66W                                        | false      | false   | false     | false      | false     | false   | false       | false          | true        | false     |
-      # TODO: Implement structs
-#      | struct      |                                             | false      | false   | false     | false      | false     | false   | false       | false          | false       | true      |
-
-  # TODO: Add tests with time-zones for datetime, datetime-tz
+#  # TODO: Implement value groups checks
+#  #Scenario: Driver processes concept row query answers with value groups correctly
+#
+#
+#  # TODO: Implement concept trees checks
+#  #Scenario: Driver processes concept tree query answers correctly
+#
+#
+#  Scenario: Driver processes query errors correctly
+#    Given connection open schema transaction for database: typedb
+#    Then get answers of typeql schema query; fails
+#      """
+#      """
+#    Then get answers of typeql schema query; fails
+#      """
+#
+#      """
+#    Then get answers of typeql schema query; fails
+#      """
+#
+#      """
+#    Then get answers of typeql schema query; fails
+#      """
+#      define entity entity;
+#      """
+#    Then get answers of typeql schema query; fails
+#      """
+#      define attribute name owns name;
+#      """
+#
+#
+#  ############
+#  # CONCEPTS #
+#  ############
+#
+#  Scenario: Driver processes entity types correctly
+#    Given connection open schema transaction for database: typedb
+#    Given typeql schema query
+#      """
+#      define entity person;
+#      """
+#    When get answers of typeql read query
+#      """
+#      match entity $p;
+#      """
+#    Then answer type is concept rows
+#    Then answer size: 1
+#
+#    Then answer get row(0) get variable(p) is type: true
+#    Then answer get row(0) get variable(p) is thing type: true
+#    Then answer get row(0) get variable(p) is thing: false
+#    Then answer get row(0) get variable(p) is value: false
+#    Then answer get row(0) get variable(p) is entity type: true
+#    Then answer get row(0) get variable(p) is relation type: false
+#    Then answer get row(0) get variable(p) is attribute type: false
+#    Then answer get row(0) get variable(p) is role type: false
+#    Then answer get row(0) get variable(p) is entity: false
+#    Then answer get row(0) get variable(p) is relation: false
+#    Then answer get row(0) get variable(p) is attribute: false
+#
+#    Then answer get row(0) get type(p) get label: person
+#    Then answer get row(0) get thing type(p) get label: person
+#    Then answer get row(0) get entity type(p) get label: person
+#    Then answer get row(0) get entity type(p) get name: person
+#    Then answer get row(0) get entity type(p) get scope is none
+#
+#
+#  Scenario: Driver processes relation types correctly
+#    Given connection open schema transaction for database: typedb
+#    Given typeql schema query
+#      """
+#      define relation parentship, relates parent;
+#      """
+#    When get answers of typeql read query
+#      """
+#      match relation $p;
+#      """
+#    Then answer type is concept rows
+#    Then answer query type is read
+#    Then answer size: 1
+#
+#    Then answer get row(0) get variable(p) is type: true
+#    Then answer get row(0) get variable(p) is thing type: true
+#    Then answer get row(0) get variable(p) is thing: false
+#    Then answer get row(0) get variable(p) is value: false
+#    Then answer get row(0) get variable(p) is entity type: false
+#    Then answer get row(0) get variable(p) is relation type: true
+#    Then answer get row(0) get variable(p) is attribute type: false
+#    Then answer get row(0) get variable(p) is role type: false
+#    Then answer get row(0) get variable(p) is entity: false
+#    Then answer get row(0) get variable(p) is relation: false
+#    Then answer get row(0) get variable(p) is attribute: false
+#
+#    Then answer get row(0) get type(p) get label: parentship
+#    Then answer get row(0) get thing type(p) get label: parentship
+#    Then answer get row(0) get relation type(p) get label: parentship
+#    Then answer get row(0) get relation type(p) get name: parentship
+#    Then answer get row(0) get relation type(p) get scope is none
+#
+#
+#  Scenario: Driver processes role types correctly
+#    Given connection open schema transaction for database: typedb
+#    Given typeql schema query
+#      """
+#      define relation parentship, relates parent;
+#      """
+#    When get answers of typeql read query
+#      """
+#      match relation parentship, relates $p;
+#      """
+#    Then answer type is concept rows
+#    Then answer query type is read
+#    Then answer size: 1
+#
+#    Then answer get row(0) get variable(p) is type: true
+#    Then answer get row(0) get variable(p) is thing type: false
+#    Then answer get row(0) get variable(p) is thing: false
+#    Then answer get row(0) get variable(p) is value: false
+#    Then answer get row(0) get variable(p) is entity type: false
+#    Then answer get row(0) get variable(p) is relation type: false
+#    Then answer get row(0) get variable(p) is attribute type: false
+#    Then answer get row(0) get variable(p) is role type: true
+#    Then answer get row(0) get variable(p) is entity: false
+#    Then answer get row(0) get variable(p) is relation: false
+#    Then answer get row(0) get variable(p) is attribute: false
+#
+#    Then answer get row(0) get type(p) get label: parentship:parent
+#    Then answer get row(0) get role type(p) get label: parentship:parent
+#    Then answer get row(0) get role type(p) get name: parent
+#    Then answer get row(0) get role type(p) get scope: parentship
+#
+#
+#  Scenario: Driver processes attribute types without value type correctly
+#    Given connection open schema transaction for database: typedb
+#    Given typeql schema query
+#      """
+#      define attribute untyped @abstract;
+#      """
+#    When get answers of typeql read query
+#      """
+#      match attribute $a;
+#      """
+#    Then answer type is concept rows
+#    Then answer query type is read
+#    Then answer size: 1
+#
+#    Then answer get row(0) get variable(a) is type: true
+#    Then answer get row(0) get variable(a) is thing type: true
+#    Then answer get row(0) get variable(a) is thing: false
+#    Then answer get row(0) get variable(a) is value: false
+#    Then answer get row(0) get variable(a) is entity type: false
+#    Then answer get row(0) get variable(a) is relation type: false
+#    Then answer get row(0) get variable(a) is attribute type: true
+#    Then answer get row(0) get variable(a) is role type: false
+#    Then answer get row(0) get variable(a) is entity: false
+#    Then answer get row(0) get variable(a) is relation: false
+#    Then answer get row(0) get variable(a) is attribute: false
+#
+#    Then answer get row(0) get type(a) get label: untyped
+#    Then answer get row(0) get thing type(a) get label: untyped
+#    Then answer get row(0) get attribute type(a) get label: untyped
+#    Then answer get row(0) get attribute type(a) get name: untyped
+#    Then answer get row(0) get attribute type(a) get scope is none
+#
+#    Then answer get row(0) get attribute type(a) get value type: none
+#    Then answer get row(0) get attribute type(a) is untyped: true
+#    Then answer get row(0) get attribute type(a) is boolean: false
+#    Then answer get row(0) get attribute type(a) is long: false
+#    Then answer get row(0) get attribute type(a) is double: false
+#    Then answer get row(0) get attribute type(a) is decimal: false
+#    Then answer get row(0) get attribute type(a) is string: false
+#    Then answer get row(0) get attribute type(a) is date: false
+#    Then answer get row(0) get attribute type(a) is datetime: false
+#    Then answer get row(0) get attribute type(a) is datetime-tz: false
+#    Then answer get row(0) get attribute type(a) is duration: false
+#    Then answer get row(0) get attribute type(a) is struct: false
+#
+#
+#  Scenario Outline: Driver processes attribute types with value type <value-type> correctly
+#    Given connection open schema transaction for database: typedb
+#    Given typeql schema query
+#      """
+#      define attribute typed, value <value-type>;
+#      """
+#    When get answers of typeql read query
+#      """
+#      match attribute $a;
+#      """
+#    Then answer type is concept rows
+#    Then answer query type is read
+#    Then answer size: 1
+#
+#    Then answer get row(0) get variable(a) is type: true
+#    Then answer get row(0) get variable(a) is thing type: true
+#    Then answer get row(0) get variable(a) is thing: false
+#    Then answer get row(0) get variable(a) is value: false
+#    Then answer get row(0) get variable(a) is entity type: false
+#    Then answer get row(0) get variable(a) is relation type: false
+#    Then answer get row(0) get variable(a) is attribute type: true
+#    Then answer get row(0) get variable(a) is role type: false
+#    Then answer get row(0) get variable(a) is entity: false
+#    Then answer get row(0) get variable(a) is relation: false
+#    Then answer get row(0) get variable(a) is attribute: false
+#
+#    Then answer get row(0) get type(a) get label: typed
+#    Then answer get row(0) get thing type(a) get label: typed
+#    Then answer get row(0) get attribute type(a) get label: typed
+#    Then answer get row(0) get attribute type(a) get name: typed
+#    Then answer get row(0) get attribute type(a) get scope is none
+#
+#    Then answer get row(0) get attribute type(a) get value type: <value-type>
+#    Then answer get row(0) get attribute type(a) is untyped: false
+#    Then answer get row(0) get attribute type(a) is boolean: <is-boolean>
+#    Then answer get row(0) get attribute type(a) is long: <is-long>
+#    Then answer get row(0) get attribute type(a) is double: <is-double>
+#    Then answer get row(0) get attribute type(a) is decimal: <is-decimal>
+#    Then answer get row(0) get attribute type(a) is string: <is-string>
+#    Then answer get row(0) get attribute type(a) is date: <is-date>
+#    Then answer get row(0) get attribute type(a) is datetime: <is-datetime>
+#    Then answer get row(0) get attribute type(a) is datetime-tz: <is-datetime-tz>
+#    Then answer get row(0) get attribute type(a) is duration: <is-duration>
+#    Then answer get row(0) get attribute type(a) is struct: <is-struct>
+#    Examples:
+#      | value-type  | is-boolean | is-long | is-double | is-decimal | is-string | is-date | is-datetime | is-datetime-tz | is-duration | is-struct |
+#      | boolean     | true       | false   | false     | false      | false     | false   | false       | false          | false       | false     |
+#      | long        | false      | true    | false     | false      | false     | false   | false       | false          | false       | false     |
+#      | double      | false      | false   | true      | false      | false     | false   | false       | false          | false       | false     |
+#      | decimal     | false      | false   | false     | true       | false     | false   | false       | false          | false       | false     |
+#      | string      | false      | false   | false     | false      | true      | false   | false       | false          | false       | false     |
+#      | date        | false      | false   | false     | false      | false     | true    | false       | false          | false       | false     |
+#      | datetime    | false      | false   | false     | false      | false     | false   | true        | false          | false       | false     |
+#      | datetime-tz | false      | false   | false     | false      | false     | false   | false       | true           | false       | false     |
+#      | duration    | false      | false   | false     | false      | false     | false   | false       | false          | true        | false     |
+#      | struct      | false      | false   | false     | false      | false     | false   | false       | false          | false       | true      |
+#
+#
+#  Scenario: Driver processes entities correctly
+#    Given connection open schema transaction for database: typedb
+#    Given typeql schema query
+#      """
+#      define entity person;
+#      """
+#    Given transaction commits
+#    Given connection open write transaction for database: typedb
+#    Given typeql write query
+#      """
+#      insert $p isa person;
+#      """
+#    When get answers of typeql read query
+#      """
+#      match $p isa person;
+#      """
+#    Then answer type is concept rows
+#    Then answer query type is read
+#    Then answer size: 1
+#
+#    Then answer get row(0) get variable(p) is type: false
+#    Then answer get row(0) get variable(p) is thing type: false
+#    Then answer get row(0) get variable(p) is thing: true
+#    Then answer get row(0) get variable(p) is value: false
+#    Then answer get row(0) get variable(p) is entity type: false
+#    Then answer get row(0) get variable(p) is relation type: false
+#    Then answer get row(0) get variable(p) is attribute type: false
+#    Then answer get row(0) get variable(p) is role type: false
+#    Then answer get row(0) get variable(p) is entity: true
+#    Then answer get row(0) get variable(p) is relation: false
+#    Then answer get row(0) get variable(p) is attribute: false
+#
+#    Then answer get row(0) get thing(p) get type get label: person
+#    Then answer get row(0) get entity(p) get iid exists
+#    Then answer get row(0) get entity(p) get type get label: person
+#    Then answer get row(0) get entity(p) get type is entity: false
+#    Then answer get row(0) get entity(p) get type is entity type: true
+#    Then answer get row(0) get entity(p) get type is relation type: false
+#    Then answer get row(0) get entity(p) get type is attribute type: false
+#    Then answer get row(0) get entity(p) get type is role type: false
+#
+#
+#  Scenario: Driver processes relations correctly
+#    Given connection open schema transaction for database: typedb
+#    Given typeql schema query
+#      """
+#      define relation parentship, relates parent;
+#      """
+#    Given transaction commits
+#    Given connection open write transaction for database: typedb
+#    Given typeql write query
+#      """
+#      insert $p isa parentship;
+#      """
+#    When get answers of typeql read query
+#      """
+#      match $p isa parentship;
+#      """
+#    Then answer type is concept rows
+#    Then answer query type is read
+#    Then answer size: 1
+#
+#    Then answer get row(0) get variable(p) is type: false
+#    Then answer get row(0) get variable(p) is thing type: false
+#    Then answer get row(0) get variable(p) is thing: true
+#    Then answer get row(0) get variable(p) is value: false
+#    Then answer get row(0) get variable(p) is entity type: false
+#    Then answer get row(0) get variable(p) is relation type: false
+#    Then answer get row(0) get variable(p) is attribute type: false
+#    Then answer get row(0) get variable(p) is role type: false
+#    Then answer get row(0) get variable(p) is entity: false
+#    Then answer get row(0) get variable(p) is relation: true
+#    Then answer get row(0) get variable(p) is attribute: false
+#
+#    Then answer get row(0) get thing(p) get type get label: parentship
+#    Then answer get row(0) get relation(p) get iid exists
+#    Then answer get row(0) get relation(p) get type get label: parentship
+#    Then answer get row(0) get relation(p) get type is relation: false
+#    Then answer get row(0) get relation(p) get type is entity type: false
+#    Then answer get row(0) get relation(p) get type is relation type: true
+#    Then answer get row(0) get relation(p) get type is attribute type: false
+#    Then answer get row(0) get relation(p) get type is role type: false
+#
+#
+#  Scenario Outline: Driver processes attributes of type <value-type> correctly
+#    Given connection open schema transaction for database: typedb
+#    Given typeql schema query
+#      """
+#      define entity person, owns typed; attribute typed, value <value-type>;
+#      """
+#    Given transaction commits
+#    Given connection open write transaction for database: typedb
+#    Given typeql write query
+#      """
+#      insert $p isa person, has typed <value>;
+#      """
+#    When get answers of typeql read query
+#      """
+#      match $_ isa person, has $a;
+#      """
+#    Then answer type is concept rows
+#    Then answer query type is read
+#    Then answer size: 1
+#
+#    Then answer get row(0) get variable(a) is type: false
+#    Then answer get row(0) get variable(a) is thing type: false
+#    Then answer get row(0) get variable(a) is thing: true
+#    Then answer get row(0) get variable(a) is value: false
+#    Then answer get row(0) get variable(a) is entity type: false
+#    Then answer get row(0) get variable(a) is relation type: false
+#    Then answer get row(0) get variable(a) is attribute type: false
+#    Then answer get row(0) get variable(a) is role type: false
+#    Then answer get row(0) get variable(a) is entity: false
+#    Then answer get row(0) get variable(a) is relation: false
+#    Then answer get row(0) get variable(a) is attribute: true
+#
+#    Then answer get row(0) get thing(a) get type get label: typed
+#    Then answer get row(0) get attribute(a) get type get label: typed
+#    Then answer get row(0) get attribute(a) get type is attribute: false
+#    Then answer get row(0) get attribute(a) get type is entity type: false
+#    Then answer get row(0) get attribute(a) get type is relation type: true
+#    Then answer get row(0) get attribute(a) get type is attribute type: true
+#    Then answer get row(0) get attribute(a) get type is role type: false
+#
+#    Then answer get row(0) get attribute(a) get type get value type: <value-type>
+#    Then answer get row(0) get attribute(a) is boolean: <is-boolean>
+#    Then answer get row(0) get attribute(a) is long: <is-long>
+#    Then answer get row(0) get attribute(a) is double: <is-double>
+#    Then answer get row(0) get attribute(a) is decimal: <is-decimal>
+#    Then answer get row(0) get attribute(a) is string: <is-string>
+#    Then answer get row(0) get attribute(a) is date: <is-date>
+#    Then answer get row(0) get attribute(a) is datetime: <is-datetime>
+#    Then answer get row(0) get attribute(a) is datetime-tz: <is-datetime-tz>
+#    Then answer get row(0) get attribute(a) is duration: <is-duration>
+#    Then answer get row(0) get attribute(a) is struct: <is-struct>
+#    Then answer get row(0) get attribute(a) get <value-type> value: <value>
+#    Examples:
+#      | value-type  | value                                       | is-boolean | is-long | is-double | is-decimal | is-string | is-date | is-datetime | is-datetime-tz | is-duration | is-struct |
+#      | boolean     | true                                        | true       | false   | false     | false      | false     | false   | false       | false          | false       | false     |
+#      | long        | 12345090                                    | false      | true    | false     | false      | false     | false   | false       | false          | false       | false     |
+#      | double      | 2.01234567                                  | false      | false   | true      | false      | false     | false   | false       | false          | false       | false     |
+#      | decimal     | 1234567890.0001234567890                    | false      | false   | false     | true       | false     | false   | false       | false          | false       | false     |
+#      | decimal     | 0.000000000000000001                        | false      | false   | false     | true       | false     | false   | false       | false          | false       | false     |
+#      | string      | "John \"Baba Yaga\" Wick"                   | false      | false   | false     | false      | true      | false   | false       | false          | false       | false     |
+#      | date        | 2024-09-20                                  | false      | false   | false     | false      | false     | true    | false       | false          | false       | false     |
+#      | datetime    | 1999-02-26T12:15:05                         | false      | false   | false     | false      | false     | false   | true        | false          | false       | false     |
+#      | datetime    | 1999-02-26T12:15:05.000000001               | false      | false   | false     | false      | false     | false   | true        | false          | false       | false     |
+#      | datetime-tz | 2024-09-20T16:40:05 America/New_York        | false      | false   | false     | false      | false     | false   | false       | true           | false       | false     |
+#      | datetime-tz | 2024-09-20T16:40:05.000000001 Europe/London | false      | false   | false     | false      | false     | false   | false       | true           | false       | false     |
+#      # TODO: Add datetime-tz with offsets
+#      | duration    | P1Y10M7DT15H44M5.00394892S                  | false      | false   | false     | false      | false     | false   | false       | false          | true        | false     |
+#      | duration    | P66W                                        | false      | false   | false     | false      | false     | false   | false       | false          | true        | false     |
+#      # TODO: Implement structs
+##      | struct      |                                             | false      | false   | false     | false      | false     | false   | false       | false          | false       | true      |
+#
+#
+#  Scenario Outline: Driver processes values of type <value-type> correctly
+#    Given connection open schema transaction for database: typedb
+#    Given typeql schema query
+#      """
+#      define entity person, owns typed; attribute typed, value <value-type>;
+#      """
+#    Given transaction commits
+#    Given connection open write transaction for database: typedb
+#    Given typeql write query
+#      """
+#      insert $p isa person, has typed <value>;
+#      """
+#    When get answers of typeql read query
+#      """
+#      match $_ isa person, has typed $v;
+#      """
+#    Then answer type is concept rows
+#    Then answer query type is read
+#    Then answer size: 1
+#
+#    Then answer get row(0) get variable(v) is type: false
+#    Then answer get row(0) get variable(v) is thing type: false
+#    Then answer get row(0) get variable(v) is thing: false
+#    Then answer get row(0) get variable(v) is value: true
+#    Then answer get row(0) get variable(v) is entity type: false
+#    Then answer get row(0) get variable(v) is relation type: false
+#    Then answer get row(0) get variable(v) is attribute type: false
+#    Then answer get row(0) get variable(v) is role type: false
+#    Then answer get row(0) get variable(v) is entity: false
+#    Then answer get row(0) get variable(v) is relation: false
+#    Then answer get row(0) get variable(v) is attribute: false
+#
+#    Then answer get row(0) get value(v) get value type: <value-type>
+#    Then answer get row(0) get value(v) is boolean: <is-boolean>
+#    Then answer get row(0) get value(v) is long: <is-long>
+#    Then answer get row(0) get value(v) is double: <is-double>
+#    Then answer get row(0) get value(v) is decimal: <is-decimal>
+#    Then answer get row(0) get value(v) is string: <is-string>
+#    Then answer get row(0) get value(v) is date: <is-date>
+#    Then answer get row(0) get value(v) is datetime: <is-datetime>
+#    Then answer get row(0) get value(v) is datetime-tz: <is-datetime-tz>
+#    Then answer get row(0) get value(v) is duration: <is-duration>
+#    Then answer get row(0) get value(v) is struct: <is-struct>
+#    Then answer get row(0) get value(v) get: <value>
+#    Then answer get row(0) get value(v) as <value-type>: <value>
+#    Examples:
+#      | value-type  | value                                       | is-boolean | is-long | is-double | is-decimal | is-string | is-date | is-datetime | is-datetime-tz | is-duration | is-struct |
+#      | boolean     | true                                        | true       | false   | false     | false      | false     | false   | false       | false          | false       | false     |
+#      | long        | 12345090                                    | false      | true    | false     | false      | false     | false   | false       | false          | false       | false     |
+#      | double      | 2.01234567                                  | false      | false   | true      | false      | false     | false   | false       | false          | false       | false     |
+#      | decimal     | 1234567890.0001234567890                    | false      | false   | false     | true       | false     | false   | false       | false          | false       | false     |
+#      | decimal     | 0.000000000000000001                        | false      | false   | false     | true       | false     | false   | false       | false          | false       | false     |
+#      | string      | "John \"Baba Yaga\" Wick"                   | false      | false   | false     | false      | true      | false   | false       | false          | false       | false     |
+#      | date        | 2024-09-20                                  | false      | false   | false     | false      | false     | true    | false       | false          | false       | false     |
+#      | datetime    | 1999-02-26T12:15:05                         | false      | false   | false     | false      | false     | false   | true        | false          | false       | false     |
+#      | datetime    | 1999-02-26T12:15:05.000000001               | false      | false   | false     | false      | false     | false   | true        | false          | false       | false     |
+#      | datetime-tz | 2024-09-20T16:40:05 America/New_York        | false      | false   | false     | false      | false     | false   | false       | true           | false       | false     |
+#      | datetime-tz | 2024-09-20T16:40:05.000000001 Europe/London | false      | false   | false     | false      | false     | false   | false       | true           | false       | false     |
+#      # TODO: Add datetime-tz with offsets
+#      | duration    | P1Y10M7DT15H44M5.00394892S                  | false      | false   | false     | false      | false     | false   | false       | false          | true        | false     |
+#      | duration    | P66W                                        | false      | false   | false     | false      | false     | false   | false       | false          | true        | false     |
+#      # TODO: Implement structs
+##      | struct      |                                             | false      | false   | false     | false      | false     | false   | false       | false          | false       | true      |
+#
+#  # TODO: Add tests with time-zones for datetime, datetime-tz

--- a/driver/query.feature
+++ b/driver/query.feature
@@ -13,75 +13,28 @@ Feature: TypeDB Driver Queries
     Given typedb starts
     Given connection opens with default authentication
     Given connection has been opened
-    Given connection does not have any database
-    Given connection create database: typedb
-    Given connection open schema session for database: typedb
-    Given session opens transaction of type: write
+    Given connection reset database: typedb
 
-    Given typeql define
+  ###############
+  # OK RESPONSE #
+  ###############
+
+  Scenario: Ok response is processed correctly
+    Given connection open schema transaction for database: typedb
+
+    When typeql query
       """
-      define
-
-      person sub entity,
-        plays employment:employee,
-        plays friendship:friend,
-        owns name,
-        owns age,
-        owns ref @key,
-        owns email @unique;
-
-      company sub entity,
-        plays employment:employer,
-        owns name,
-        owns ref @key;
-
-      employment sub relation,
-        relates employee,
-        relates employer,
-        owns ref @key;
-
-      friendship sub relation,
-        relates friend,
-        owns ref @key;
-
-      name sub attribute,
-        value string;
-
-      age sub attribute,
-        value long;
-
-      ref sub attribute,
-        value long;
-
-      email sub attribute,
-        value string;
+      define entity person;
       """
-    Given transaction commits
+    Then query answer type: ok
 
-    Given connection close all sessions
-
-  ##########
-  # DEFINE #
-  ##########
-
-  # A define query should already successfully run as part of Background and multiple other tests
-
-  Scenario: when specialising a role that doesn't exist on the parent relation, an error is thrown
-    Given connection open schema session for database: typedb
-    Given session opens transaction of type: write
-
-    Then typeql define; throws exception
-      """
-      define
-      close-friendship sub relation, relates close-friend as friend;
-      """
 
   ############
   # UNDEFINE #
   ############
 
   Scenario: calling 'undefine' with 'sub entity' on a subtype of 'entity' deletes it
-    Given connection open schema session for database: typedb
+    Given connection open schema transaction for database: typedb
     Given session opens transaction of type: write
 
     Given get answers of typeql read query
@@ -110,7 +63,7 @@ Feature: TypeDB Driver Queries
       | label:company       |
 
   Scenario: undefining a relation type throws on commit if it has existing instances
-    Given connection open data session for database: typedb
+    Given connection open data transaction for database: typedb
     Given session opens transaction of type: write
     Given typeql insert
       """
@@ -121,7 +74,7 @@ Feature: TypeDB Driver Queries
     Given transaction commits
     Given connection close all sessions
 
-    Given connection open schema session for database: typedb
+    Given connection open schema transaction for database: typedb
     Given session opens transaction of type: write
     Then typeql undefine; throws exception
       """
@@ -137,7 +90,7 @@ Feature: TypeDB Driver Queries
   ##########
 
   Scenario: one query can insert multiple things
-    Given connection open data session for database: typedb
+    Given connection open data transaction for database: typedb
     Given session opens transaction of type: write
 
     When typeql insert
@@ -159,7 +112,7 @@ Feature: TypeDB Driver Queries
       | key:ref:1 |
 
   Scenario: when inserting a roleplayer that can't play the role, an error is thrown
-    Given connection open data session for database: typedb
+    Given connection open data transaction for database: typedb
     Given session opens transaction of type: write
     Then typeql insert; throws exception
       """
@@ -173,7 +126,7 @@ Feature: TypeDB Driver Queries
   ##########
 
   Scenario: one delete statement can delete multiple things
-    Given connection open data session for database: typedb
+    Given connection open data transaction for database: typedb
     Given session opens transaction of type: write
 
     Given get answers of typeql insert
@@ -205,7 +158,7 @@ Feature: TypeDB Driver Queries
     Then answer size is: 0
 
   Scenario: deleting an instance using an unrelated type label throws
-    Given connection open data session for database: typedb
+    Given connection open data transaction for database: typedb
     Given session opens transaction of type: write
 
     Given typeql insert
@@ -231,7 +184,7 @@ Feature: TypeDB Driver Queries
   ##########
 
   Scenario: Roleplayer exchange
-    Given connection open schema session for database: typedb
+    Given connection open schema transaction for database: typedb
     Given session opens transaction of type: write
 
     Given typeql define
@@ -247,7 +200,7 @@ Feature: TypeDB Driver Queries
     Given transaction commits
     Given connection close all sessions
 
-    Given connection open data session for database: typedb
+    Given connection open data transaction for database: typedb
     Given session opens transaction of type: write
 
     Given get answers of typeql insert
@@ -259,7 +212,7 @@ Feature: TypeDB Driver Queries
       """
     Given transaction commits
 
-    Given connection open data session for database: typedb
+    Given connection open data transaction for database: typedb
     Given session opens transaction of type: write
     When typeql update
       """
@@ -269,7 +222,7 @@ Feature: TypeDB Driver Queries
       """
 
   Scenario: Deleting anonymous variables throws an exception
-    Given connection open data session for database: typedb
+    Given connection open data transaction for database: typedb
     Given session opens transaction of type: write
 
     Given get answers of typeql insert
@@ -295,7 +248,7 @@ Feature: TypeDB Driver Queries
   #########
 
   Scenario: when a 'get' has unbound variables, an error is thrown
-    Given connection open data session for database: typedb
+    Given connection open data transaction for database: typedb
     Given session opens transaction of type: read
     Then typeql throws exception
       """
@@ -303,7 +256,7 @@ Feature: TypeDB Driver Queries
       """
 
   Scenario: Value variables can be specified in a 'get'
-    Given connection open data session for database: typedb
+    Given connection open data transaction for database: typedb
     Given session opens transaction of type: write
     Given typeql insert
       """
@@ -327,7 +280,7 @@ Feature: TypeDB Driver Queries
       | key:ref:0 | attr:name:Lisa | value:long:2001  |
 
   Scenario: 'count' returns the total number of answers
-    Given connection open data session for database: typedb
+    Given connection open data transaction for database: typedb
     Given session opens transaction of type: write
     Given typeql insert
       """
@@ -380,7 +333,7 @@ Feature: TypeDB Driver Queries
     Then aggregate value is: 6
 
   Scenario: answers can be grouped by a value variable contained in the answer set
-    Given connection open data session for database: typedb
+    Given connection open data transaction for database: typedb
     Given session opens transaction of type: write
     Given typeql insert
       """
@@ -409,7 +362,7 @@ Feature: TypeDB Driver Queries
       | value:long:3000 | key:ref:3000 |
 
   Scenario: the size of each answer group can be retrieved using a group 'count'
-    Given connection open data session for database: typedb
+    Given connection open data transaction for database: typedb
     Given session opens transaction of type: write
     Given typeql insert
       """
@@ -446,7 +399,7 @@ Feature: TypeDB Driver Queries
   ###############
 
   Scenario: A value variable must have exactly one assignment constraint in the same scope
-    Given connection open data session for database: typedb
+    Given connection open data transaction for database: typedb
 
     Given session opens transaction of type: read
     Then typeql throws exception containing "value variable '?v' is never assigned to"
@@ -471,7 +424,7 @@ Feature: TypeDB Driver Queries
       """
 
   Scenario: Test operator definitions
-    Given connection open data session for database: typedb
+    Given connection open data transaction for database: typedb
     Given session opens transaction of type: read
 
     When get answers of typeql read query
@@ -535,7 +488,7 @@ Feature: TypeDB Driver Queries
   #########
 
   Scenario: an attribute projection can be relabeled
-    Given connection open data session for database: typedb
+    Given connection open data transaction for database: typedb
     Given session opens transaction of type: write
     Given typeql insert
       """
@@ -582,7 +535,7 @@ Feature: TypeDB Driver Queries
 
 
   Scenario: a fetch with zero projections throws
-    Given connection open data session for database: typedb
+    Given connection open data transaction for database: typedb
     Given session opens transaction of type: read
 
     When typeql fetch; throws exception
@@ -593,7 +546,7 @@ Feature: TypeDB Driver Queries
       """
 
   Scenario: a subquery that is not connected to the match throws
-    Given connection open data session for database: typedb
+    Given connection open data transaction for database: typedb
     Given session opens transaction of type: read
 
     When typeql fetch; throws exception

--- a/query/explanation/language.feature
+++ b/query/explanation/language.feature
@@ -8,7 +8,7 @@ Feature: TypeQL Reasoning Explanation
   Background: Initialise a session and transaction for each scenario
     Given typedb starts
     Given connection opens with default authentication
-    Given connection has been opened
+    Given connection is open: true
     Given connection open schema session for database: test_explanation
     Given transaction is initialised
 
@@ -17,7 +17,7 @@ Feature: TypeQL Reasoning Explanation
 
   Verify the code path for atomic queries produces correct explanation and pattern.
 
-    Given typeql define
+    Given typeql schema query
       """
       define
       name sub attribute,
@@ -48,7 +48,7 @@ Feature: TypeQL Reasoning Explanation
 
   @ignore-typedb-driver
   Scenario: relation has lookup explanation
-    Given typeql define
+    Given typeql schema query
       """
       define
       name sub attribute,
@@ -104,7 +104,7 @@ Feature: TypeQL Reasoning Explanation
 
   Verify the code path for non-atomic queries produces correct explanation and pattern.
 
-    Given typeql define
+    Given typeql schema query
       """
       define
       name sub attribute,
@@ -165,7 +165,7 @@ Feature: TypeQL Reasoning Explanation
   A negation explanation shows the resolution that occurred. It contains the pattern for the lookup that was performed,
   indicating that this lookup was then checked against the negation to verify that it satisfied the query.
 
-    Given typeql define
+    Given typeql schema query
       """
       define
 
@@ -214,7 +214,7 @@ Feature: TypeQL Reasoning Explanation
   Ids in the answer's pattern should sit outside the disjunction, this makes the disjunction valid as it provides outer scope variables for the disjunction to bind to.
   The explanation beneath should explain the disjunctive clause that was used to provide the original answer.
 
-    Given typeql define
+    Given typeql schema query
       """
       define
 
@@ -263,7 +263,7 @@ Feature: TypeQL Reasoning Explanation
   Due to the use of Disjunctive Normal Form, the answer's pattern should contain only one disjunction with ids outside as the outer scope.
   The explanation beneath should explain the disjunctive clause that was used to provide the original answer.
 
-    Given typeql define
+    Given typeql schema query
       """
       define
 

--- a/query/explanation/reasoner.feature
+++ b/query/explanation/reasoner.feature
@@ -10,13 +10,13 @@ Feature: TypeQL Reasoning Explanation
   Background: Initialise a session and transaction for each scenario
     Given typedb starts
     Given connection opens with default authentication
-    Given connection has been opened
+    Given connection is open: true
     Given connection open schema session for database: test_explanation
     Given transaction is initialised
 
   @ignore-typedb-driver
   Scenario: a rule explanation is given when a rule is applied
-    Given typeql define
+    Given typeql schema query
       """
       define
 
@@ -65,7 +65,7 @@ Feature: TypeQL Reasoning Explanation
 
   @ignore-typedb-driver
   Scenario: nested rule explanations are given when multiple rules are applied
-    Given typeql define
+    Given typeql schema query
       """
       define
 
@@ -130,7 +130,7 @@ Feature: TypeQL Reasoning Explanation
 
   @ignore-typedb-driver
   Scenario: a join explanation can be given directly and inside a rule explanation
-    Given typeql define
+    Given typeql schema query
       """
       define
       name sub attribute,
@@ -209,7 +209,7 @@ Feature: TypeQL Reasoning Explanation
 
   @ignore-typedb-driver
   Scenario: an answer with a more specific type can be retrieved from the cache with correct explanations
-    Given typeql define
+    Given typeql schema query
       """
       define
 
@@ -303,7 +303,7 @@ Feature: TypeQL Reasoning Explanation
 
   A rule explanation is not be given since the rule was only used to infer facts that were later negated
 
-    Given typeql define
+    Given typeql schema query
       """
       define
 
@@ -366,7 +366,7 @@ Feature: TypeQL Reasoning Explanation
 
   @ignore-typedb-driver
   Scenario: a rule containing a negation gives a rule explanation with a negation explanation inside
-    Given typeql define
+    Given typeql schema query
       """
       define
 
@@ -432,7 +432,7 @@ Feature: TypeQL Reasoning Explanation
 
   A rule explanation is not be given since the rule was only used to infer facts that were later negated
 
-    Given typeql define
+    Given typeql schema query
       """
       define
 

--- a/query/language/define.feature
+++ b/query/language/define.feature
@@ -773,7 +773,7 @@ Feature: TypeQL Define Query
         attribute $x;
      
       """
-    Then answer size is: 1
+    Then answer size: 1
 
     Examples:
       | value-type  | label              |
@@ -2058,7 +2058,7 @@ Feature: TypeQL Define Query
       """
       match $x label person, owns name;
       """
-    Then answer size is: 1
+    Then answer size: 1
 
 
   Scenario: an entity type cannot be changed into a relation type
@@ -2363,7 +2363,7 @@ Feature: TypeQL Define Query
       """
       match $x owns email @key;
       """
-    Then answer size is: 0
+    Then answer size: 0
 
 
   Scenario: defining a uniqueness on existing ownership is possible if data conforms to uniqueness requirements
@@ -2460,7 +2460,7 @@ Feature: TypeQL Define Query
       """
       match person owns $y @key;
       """
-    Then answer size is: 0
+    Then answer size: 0
     Given typeql insert; fails
       """
       insert $x isa person, has email "jane@gmail.com";

--- a/query/language/define.feature
+++ b/query/language/define.feature
@@ -8,11 +8,11 @@ Feature: TypeQL Define Query
   Background: Open connection and create a simple extensible schema
     Given typedb starts
     Given connection opens with default authentication
-    Given connection has been opened
+    Given connection is open: true
     Given connection reset database: typedb
     Given connection open schema transaction for database: typedb
 
-    Given typeql define
+    Given typeql schema query
       """
       define
       entity person plays employment:employee, plays income:earner, owns name, owns email @key, owns phone-nr @unique;
@@ -35,7 +35,7 @@ Feature: TypeQL Define Query
   ################
 
   Scenario: new entity types can be defined
-    When typeql define
+    When typeql schema query
       """
       define entity dog;
       """
@@ -52,7 +52,7 @@ Feature: TypeQL Define Query
 
 
   Scenario: a new entity type can be defined as a subtype, creating a new child of its parent type
-    When typeql define
+    When typeql schema query
       """
       define entity child sub person;
       """
@@ -70,49 +70,49 @@ Feature: TypeQL Define Query
 
 
   Scenario: when defining that a type owns a non-existent thing, an error is thrown
-    Then typeql define; fails
+    Then typeql schema query; fails
       """
       define entity book owns pages;
       """
 
 
   Scenario: types cannot own entity types
-    Then typeql define; fails
+    Then typeql schema query; fails
       """
       define entity house owns person;
       """
 
 
   Scenario: types cannot own relation types
-    Then typeql define; fails
+    Then typeql schema query; fails
       """
       define entity company owns employment;
       """
 
 
   Scenario: when defining that a type plays a non-existent role, an error is thrown
-    Then typeql define; fails
+    Then typeql schema query; fails
       """
       define entity house plays constructed:something;
       """
 
 
   Scenario: types cannot play entity types
-    Then typeql define; parsing fails
+    Then typeql schema query; parsing fails
       """
       define entity parrot plays person;
       """
 
 
   Scenario: types can not own entity types as keys
-    Then typeql define; fails
+    Then typeql schema query; fails
       """
       define entity passport owns person @key;
       """
 
 
   Scenario: a newly defined entity subtype inherits playable roles from its parent type
-    Given typeql define
+    Given typeql schema query
       """
       define entity child sub person;
       """
@@ -130,7 +130,7 @@ Feature: TypeQL Define Query
 
 
   Scenario: a newly defined entity subtype inherits playable roles from all of its supertypes
-    Given typeql define
+    Given typeql schema query
       """
       define
       entity athlete sub person;
@@ -153,7 +153,7 @@ Feature: TypeQL Define Query
 
 
   Scenario: a newly defined entity subtype inherits attribute ownerships from its parent type
-    Given typeql define
+    Given typeql schema query
       """
       define entity child sub person;
       """
@@ -171,7 +171,7 @@ Feature: TypeQL Define Query
 
 
   Scenario: a newly defined entity subtype inherits attribute ownerships from all of its supertypes
-    Given typeql define
+    Given typeql schema query
       """
       define
       entity athlete sub person;
@@ -194,7 +194,7 @@ Feature: TypeQL Define Query
 
 
   Scenario: a newly defined entity subtype inherits keys from its parent type
-    Given typeql define
+    Given typeql schema query
       """
       define entity child sub person;
       """
@@ -212,7 +212,7 @@ Feature: TypeQL Define Query
 
 
   Scenario: a newly defined entity subtype inherits keys from all of its supertypes
-    Given typeql define
+    Given typeql schema query
       """
       define
       entity athlete sub person;
@@ -235,7 +235,7 @@ Feature: TypeQL Define Query
 
 
   Scenario: defining a playable role is idempotent
-    Given typeql define
+    Given typeql schema query
       """
       define
       entity house plays home-ownership:home, plays home-ownership:home, plays home-ownership:home;
@@ -255,7 +255,7 @@ Feature: TypeQL Define Query
 
 
   Scenario: defining an attribute ownership is idempotent
-    Given typeql define
+    Given typeql schema query
       """
       define
       attribute price value double;
@@ -274,7 +274,7 @@ Feature: TypeQL Define Query
 
 
   Scenario: defining a key ownership is idempotent
-    Given typeql define
+    Given typeql schema query
       """
       define
       attribute address value string;
@@ -293,42 +293,42 @@ Feature: TypeQL Define Query
 
 
   Scenario: defining a type without a kind throws
-    Then typeql define; fails
+    Then typeql schema query; fails
       """
       define flying-spaghetti-monster;
       """
 
 
   Scenario: a type definition must specify a kind
-    Then typeql define; fails
+    Then typeql schema query; fails
       """
       define column;
       """
 
 
   Scenario: an entity type can not have a value type defined
-    Then typeql define; fails
+    Then typeql schema query; fails
       """
       define entity cream value double;
       """
 
 
   Scenario: defining a thing with 'isa' is not possible in a 'define' query
-    Then typeql define; parsing fails
+    Then typeql schema query; parsing fails
       """
       define $p isa person;
       """
 
 
   Scenario: adding an attribute instance to a thing is not possible in a 'define' query
-    Then typeql define; parsing fails
+    Then typeql schema query; parsing fails
       """
       define $p has name "Loch Ness Monster";
       """
 
 
   Scenario: writing a variable in a 'define' is not allowed
-    Then typeql define; parsing fails
+    Then typeql schema query; parsing fails
       """
       define entity $x;
       """
@@ -339,7 +339,7 @@ Feature: TypeQL Define Query
   ##################
 
   Scenario: new relation types can be defined
-    When typeql define
+    When typeql schema query
       """
       define relation pet-ownership relates pet-owner, relates owned-pet;
       """
@@ -356,7 +356,7 @@ Feature: TypeQL Define Query
 
 
   Scenario: a new relation type can be defined as a subtype, creating a new child of its parent type
-    When typeql define
+    When typeql schema query
       """
       define relation fun-employment sub employment, relates employee-having-fun as employee;
       """
@@ -374,7 +374,7 @@ Feature: TypeQL Define Query
 
 
   Scenario: defining a relation type throws on commit if it has no roleplayers and is not abstract
-    Then typeql define
+    Then typeql schema query
       """
       define relation useless-relation;
       """
@@ -382,7 +382,7 @@ Feature: TypeQL Define Query
 
 
   Scenario: a newly defined relation subtype inherits roles from its supertype
-    Given typeql define
+    Given typeql schema query
       """
       define relation part-time-employment sub employment;
       """
@@ -399,7 +399,7 @@ Feature: TypeQL Define Query
       | label:part-time-employment |
 
   Scenario: a newly defined relation subtype inherits roles from all of its supertypes
-    Given typeql define
+    Given typeql schema query
       """
       define
       relation part-time-employment sub employment, relates shift;
@@ -435,7 +435,7 @@ Feature: TypeQL Define Query
 
 
   Scenario: a relation type's role can be specialised in a child relation type using 'as'
-    When typeql define
+    When typeql schema query
       """
       define
         relation parenthood relates parent, relates child;
@@ -467,7 +467,7 @@ Feature: TypeQL Define Query
 
 
   Scenario: when a relation type's role is specialised, it creates a sub-role of the parent role type
-    When typeql define
+    When typeql schema query
       """
       define
       relation parenthood relates parent, relates child;
@@ -490,7 +490,7 @@ Feature: TypeQL Define Query
 
 
   Scenario: a specialised role is no longer associated with the relation type that specialises it
-    Given typeql define
+    Given typeql schema query
       """
       define relation part-time-employment sub employment, relates part-timer as employee;
       """
@@ -507,7 +507,7 @@ Feature: TypeQL Define Query
 
 
   Scenario: when specialising a role that doesn't exist on the parent relation, an error is thrown
-    Then typeql define; fails
+    Then typeql schema query; fails
       """
       define
       relation close-friendship relates close-friend as friend;
@@ -515,7 +515,7 @@ Feature: TypeQL Define Query
 
 
   Scenario: relation subtypes can have roles that their supertypes don't have
-    Given typeql define
+    Given typeql schema query
       """
       define
       entity plane plays pilot-employment:preferred-plane;
@@ -535,7 +535,7 @@ Feature: TypeQL Define Query
 
 
   Scenario Outline: types cannot specialise plays in any <mode>
-    Then typeql define; parsing fails
+    Then typeql schema query; parsing fails
       """
         define
         relation locates relates located;
@@ -551,7 +551,7 @@ Feature: TypeQL Define Query
 
 
   Scenario: a newly defined relation subtype inherits playable roles from its parent type
-    Given typeql define
+    Given typeql schema query
       """
       define relation contract-employment sub employment, relates contractor as employee;
       """
@@ -569,7 +569,7 @@ Feature: TypeQL Define Query
 
 
   Scenario: a newly defined relation subtype inherits playable roles from all of its supertypes
-    Given typeql define
+    Given typeql schema query
       """
       define
       relation transport-employment sub employment, relates transport-worker as employee;
@@ -592,7 +592,7 @@ Feature: TypeQL Define Query
 
 
   Scenario: inherited role types cannot be played via role type aliases
-    Given typeql define; fails
+    Given typeql schema query; fails
       """
       define
       relation part-time-employment sub employment;
@@ -601,7 +601,7 @@ Feature: TypeQL Define Query
 
 
   Scenario: a newly defined relation subtype inherits attribute ownerships from its parent type
-    Given typeql define
+    Given typeql schema query
       """
       define relation contract-employment sub employment, relates contractor as employee;
       """
@@ -619,7 +619,7 @@ Feature: TypeQL Define Query
 
 
   Scenario: a newly defined relation subtype inherits attribute ownerships from all of its supertypes
-    Given typeql define
+    Given typeql schema query
       """
       define
       relation transport-employment sub employment, relates transport-worker as employee;
@@ -642,7 +642,7 @@ Feature: TypeQL Define Query
 
 
   Scenario: a newly defined relation subtype inherits keys from its parent type
-    Given typeql define
+    Given typeql schema query
       """
       define relation contract-employment sub employment, relates contractor as employee;
       """
@@ -660,7 +660,7 @@ Feature: TypeQL Define Query
 
 
   Scenario: a newly defined relation subtype inherits keys from all of its supertypes
-    Given typeql define
+    Given typeql schema query
       """
       define
       relation transport-employment sub employment, relates transport-worker as employee;
@@ -683,7 +683,7 @@ Feature: TypeQL Define Query
 
 
   Scenario: a relation type cannot be defined with no roleplayers even if it is marked as @abstract
-    When typeql define
+    When typeql schema query
       """
       define relation connection @abstract;
       """
@@ -691,7 +691,7 @@ Feature: TypeQL Define Query
 
 
   Scenario: an abstract relation type can be defined with both abstract and concrete role types
-    When typeql define
+    When typeql schema query
       """
       define relation connection @abstract, relates from, relates to @abstract;
       """
@@ -708,7 +708,7 @@ Feature: TypeQL Define Query
 
 
   Scenario: a concrete relation type can be defined with abstract role types
-    When typeql define
+    When typeql schema query
       """
       define relation connection relates from, relates to @abstract;
       """
@@ -716,7 +716,7 @@ Feature: TypeQL Define Query
 
 
   Scenario: when defining a relation type, duplicate 'relates' are idempotent
-    Given typeql define
+    Given typeql schema query
       """
       define
       relation parenthood relates parent, relates child, relates child, relates parent, relates child;
@@ -735,7 +735,7 @@ Feature: TypeQL Define Query
 
 
   Scenario: unrelated relations are allowed to have roles with the same name
-    When typeql define
+    When typeql schema query
       """
       define
       relation ownership relates owner;
@@ -759,7 +759,7 @@ Feature: TypeQL Define Query
   ###################
 
   Scenario Outline: a '<value-type>' attribute type can be defined
-    Given typeql define
+    Given typeql schema query
       """
       define attribute <label> value <value-type>;
       """
@@ -789,7 +789,7 @@ Feature: TypeQL Define Query
 
 
   Scenario: defining an attribute type throws if you don't specify a value type
-    When typeql define
+    When typeql schema query
       """
       define attribute colour;
       """
@@ -797,7 +797,7 @@ Feature: TypeQL Define Query
 
 
   Scenario: defining an abstract attribute type does not throw if you don't specify a value type
-    When typeql define
+    When typeql schema query
       """
       define attribute colour @abstract;
       """
@@ -805,14 +805,14 @@ Feature: TypeQL Define Query
 
 
   Scenario: defining an attribute type throws if the specified value type is not a recognised value type
-    Then typeql define; fails
+    Then typeql schema query; fails
       """
       define attribute colour value rgba;
       """
 
 
   Scenario: a new attribute type can be defined as a subtype of an abstract attribute type
-    When typeql define
+    When typeql schema query
       """
       define
       attribute code @abstract, value string ;
@@ -832,7 +832,7 @@ Feature: TypeQL Define Query
 
 
   Scenario: a newly defined attribute subtype inherits the value type of its parent
-    When typeql define
+    When typeql schema query
       """
       define
       attribute code @abstract, value string;
@@ -851,35 +851,35 @@ Feature: TypeQL Define Query
 
 
   Scenario: defining an attribute subtype throws if it is given a different value type to what its parent has
-    When typeql define
+    When typeql schema query
       """
       define attribute name @abstract; entity person @abstract;
       """
     When transaction commits
 
     When connection open schema transaction for database: typedb
-    Then typeql define; fails
+    Then typeql schema query; fails
       """
       define attribute code-name sub name, value long;
       """
     When transaction closes
 
     When connection open schema transaction for database: typedb
-    When typeql define
+    When typeql schema query
       """
       define attribute code-name sub name; attribute code-name-2 value long;
       """
     When transaction commits
 
     When connection open schema transaction for database: typedb
-    Then typeql define; fails
+    Then typeql schema query; fails
       """
       define attribute code-name value long;
       """
     When transaction closes
 
     When connection open schema transaction for database: typedb
-    Then typeql define; fails
+    Then typeql schema query; fails
       """
       define attribute code-name-2 sub name;
       """
@@ -887,7 +887,7 @@ Feature: TypeQL Define Query
   # TODO: re-enable when fixed (currently gives wrong answer)
   @ignore
   Scenario: a regex constraint can be defined on a 'string' attribute type
-    Given typeql define
+    Given typeql schema query
       """
       define attribute response @regex("^(yes|no|maybe)$"), value string;
       """
@@ -904,14 +904,14 @@ Feature: TypeQL Define Query
 
 
   Scenario: a regex constraint cannot be defined on an attribute type whose value type is anything other than 'string'
-    Then typeql define; fails
+    Then typeql schema query; fails
       """
       define attribute name-in-binary @regex("^(0|1)+$"), value long;
       """
 
 
   Scenario Outline: a type can own a '<value_type>' attribute type
-    When typeql define
+    When typeql schema query
       """
       define
       attribute <label> value <value_type>;
@@ -950,7 +950,7 @@ Feature: TypeQL Define Query
   # TODO: Add tests for structs and their fields
 
   Scenario Outline: can set annotation @<annotation> to entity types
-    Then typeql define
+    Then typeql schema query
       """
       define
       entity player @<annotation>;
@@ -962,7 +962,7 @@ Feature: TypeQL Define Query
 
 
   Scenario Outline: cannot set annotation @<annotation> to entity types
-    Then typeql define; fails
+    Then typeql schema query; fails
       """
       define
       entity player @<annotation>;
@@ -981,7 +981,7 @@ Feature: TypeQL Define Query
 
 
   Scenario Outline: can set annotation @<annotation> to relation types
-    Then typeql define
+    Then typeql schema query
       """
       define
       relation parentship @<annotation>, relates parent;
@@ -994,7 +994,7 @@ Feature: TypeQL Define Query
 
 
   Scenario Outline: cannot set annotation @<annotation> to relation types
-    Then typeql define; fails
+    Then typeql schema query; fails
       """
       define
       relation parentship @<annotation>, relates parent;
@@ -1012,7 +1012,7 @@ Feature: TypeQL Define Query
 
 
   Scenario Outline: can set annotation @<annotation> to attribute types
-    Then typeql define
+    Then typeql schema query
       """
       define
       attribute description @<annotation>, value string;
@@ -1025,7 +1025,7 @@ Feature: TypeQL Define Query
 
 
   Scenario Outline: cannot set annotation @<annotation> to attribute types
-    Then typeql define; fails
+    Then typeql schema query; fails
       """
       define
       attribute description @<annotation>, value string;
@@ -1043,7 +1043,7 @@ Feature: TypeQL Define Query
 
 
   Scenario Outline: can set annotation @<annotation> to relates/role types
-    Then typeql define
+    Then typeql schema query
       """
       define
       relation parentship @abstract, relates parent @<annotation>;
@@ -1056,7 +1056,7 @@ Feature: TypeQL Define Query
 
 
   Scenario Outline: cannot set annotation @<annotation> to relates/role types
-    Then typeql define; fails
+    Then typeql schema query; fails
       """
       define
       relation parentship @abstract, relates parent @<annotation>;
@@ -1074,7 +1074,7 @@ Feature: TypeQL Define Query
 
 
   Scenario Outline: can set annotation @<annotation> to relates/role types lists
-    Then typeql define
+    Then typeql schema query
       """
       define
       relation parentship @abstract, relates parent[] @<annotation>;
@@ -1088,7 +1088,7 @@ Feature: TypeQL Define Query
 
 
   Scenario Outline: cannot set annotation @<annotation> to relates/role types lists
-    Then typeql define; fails
+    Then typeql schema query; fails
       """
       define
       relation parentship @abstract, relates parent[] @<annotation>;
@@ -1105,7 +1105,7 @@ Feature: TypeQL Define Query
 
 
   Scenario Outline: can set annotation @<annotation> to owns
-    Then typeql define
+    Then typeql schema query
       """
       define
       entity player owns name @<annotation>;
@@ -1122,7 +1122,7 @@ Feature: TypeQL Define Query
 
 
   Scenario Outline: cannot set annotation @<annotation> to owns
-    Then typeql define; fails
+    Then typeql schema query; fails
       """
       define
       entity player owns name @<annotation>;
@@ -1136,7 +1136,7 @@ Feature: TypeQL Define Query
 
 
   Scenario Outline: cannot set annotation @<annotation> to owns of attribute type of wrong <value-type>
-    Then typeql define; fails
+    Then typeql schema query; fails
       """
       define
       attribute description<value-type>;
@@ -1206,7 +1206,7 @@ Feature: TypeQL Define Query
 
 
   Scenario Outline: cannot set annotation @values(<arg0>, <arg1>, <arg0>) with duplicated arguments to owns
-    Then typeql define; fails
+    Then typeql schema query; fails
       """
       define
       attribute description, value <value-type>;
@@ -1215,7 +1215,7 @@ Feature: TypeQL Define Query
 
     Given transaction closes
     Given connection open schema transaction for database: typedb
-    Then typeql define; fails
+    Then typeql schema query; fails
       """
       define
       attribute description, value <value-type>;
@@ -1224,7 +1224,7 @@ Feature: TypeQL Define Query
 
     Given transaction closes
     Given connection open schema transaction for database: typedb
-    Then typeql define; fails
+    Then typeql schema query; fails
       """
       define
       attribute description, value <value-type>;
@@ -1244,7 +1244,7 @@ Feature: TypeQL Define Query
 
 
   Scenario Outline: can set annotation @<annotation> to owns lists
-    Then typeql define
+    Then typeql schema query
       """
       define
       entity player owns name[] @<annotation>;
@@ -1262,7 +1262,7 @@ Feature: TypeQL Define Query
 
 
   Scenario Outline: cannot set annotation @<annotation> to owns lists
-    Then typeql define; fails
+    Then typeql schema query; fails
       """
       define
       entity player owns name[] @<annotation>;
@@ -1275,7 +1275,7 @@ Feature: TypeQL Define Query
 
 
   Scenario Outline: can set annotation @<annotation> to plays
-    Then typeql define
+    Then typeql schema query
       """
       define
       entity player plays employment:employee @<annotation>;
@@ -1287,7 +1287,7 @@ Feature: TypeQL Define Query
 
 
   Scenario Outline: cannot set annotation @<annotation> to plays
-    Then typeql define; fails
+    Then typeql schema query; fails
       """
       define
       entity player plays employment:employee @<annotation>;
@@ -1306,7 +1306,7 @@ Feature: TypeQL Define Query
 
 
   Scenario Outline: can set annotation @<annotation> to value types
-    Then typeql define
+    Then typeql schema query
       """
       define
       attribute description value string @<annotation>;
@@ -1320,7 +1320,7 @@ Feature: TypeQL Define Query
 
 
   Scenario Outline: cannot set annotation @<annotation> to wrong value type <value-type>
-    Then typeql define; fails
+    Then typeql schema query; fails
       """
       define
       attribute description value <value-type> @<annotation>;
@@ -1382,7 +1382,7 @@ Feature: TypeQL Define Query
 
 
   Scenario Outline: cannot set annotation @values(<arg0>, <arg1>, <arg0>) with duplicated arguments to value type
-    Then typeql define; fails
+    Then typeql schema query; fails
       """
       define
       attribute description value <value-type> @values(<arg0>, <arg1>, <arg0>);
@@ -1390,7 +1390,7 @@ Feature: TypeQL Define Query
 
     Given transaction closes
     Given connection open schema transaction for database: typedb
-    Then typeql define; fails
+    Then typeql schema query; fails
       """
       define
       attribute description value <value-type> @values(<arg0>, <arg0>, <arg1>);
@@ -1398,7 +1398,7 @@ Feature: TypeQL Define Query
 
     Given transaction closes
     Given connection open schema transaction for database: typedb
-    Then typeql define; fails
+    Then typeql schema query; fails
       """
       define
       attribute description value <value-type> @values(<arg1>, <arg0>, <arg0>);
@@ -1417,7 +1417,7 @@ Feature: TypeQL Define Query
 
 
   Scenario Outline: cannot set annotation @<annotation> to value types
-    Then typeql define; fails
+    Then typeql schema query; fails
       """
       define
       attribute description value string @<annotation>;
@@ -1434,7 +1434,7 @@ Feature: TypeQL Define Query
 
 
   Scenario Outline: cannot set annotation @<annotation> to subs
-    Then typeql define; fails
+    Then typeql schema query; fails
       """
       define
       entity player sub person @<annotation>;
@@ -1457,42 +1457,42 @@ Feature: TypeQL Define Query
 
 
   Scenario Outline: cannot set @abstract annotation with arguments
-    Then typeql define; parsing fails
+    Then typeql schema query; parsing fails
       """
       define
       entity player @abstract(<args>);
       """
 
     Given connection open schema transaction for database: typedb
-    Then typeql define; parsing fails
+    Then typeql schema query; parsing fails
       """
       define
       relation parentship @abstract(<args>), relates parent;
       """
 
     Given connection open schema transaction for database: typedb
-    Then typeql define; parsing fails
+    Then typeql schema query; parsing fails
       """
       define
       attribute characteristics @abstract(<args>);
       """
 
     Given connection open schema transaction for database: typedb
-    Then typeql define; parsing fails
+    Then typeql schema query; parsing fails
       """
       define
       relation parentship relates parent @abstract(<args>);
       """
 
     Given connection open schema transaction for database: typedb
-    Then typeql define; parsing fails
+    Then typeql schema query; parsing fails
       """
       define
       entity player owns name @abstract(<args>);
       """
 
     Given connection open schema transaction for database: typedb
-    Then typeql define; parsing fails
+    Then typeql schema query; parsing fails
       """
       define
       entity player plays employment:employee @abstract(<args>);
@@ -1510,14 +1510,14 @@ Feature: TypeQL Define Query
 
 
   Scenario Outline: cannot set @distinct annotation with arguments
-    Then typeql define; parsing fails
+    Then typeql schema query; parsing fails
       """
       define
       relation parentship relates parent[] @distinct(<args>);
       """
 
     Given connection open schema transaction for database: typedb
-    Then typeql define; parsing fails
+    Then typeql schema query; parsing fails
       """
       define
       entity player owns name[] @distinct(<args>);
@@ -1535,7 +1535,7 @@ Feature: TypeQL Define Query
 
 
   Scenario Outline: cannot set @independent annotation with arguments
-    Then typeql define; parsing fails
+    Then typeql schema query; parsing fails
       """
       define
       attribute characteristics @independent(<args>);
@@ -1553,7 +1553,7 @@ Feature: TypeQL Define Query
 
 
   Scenario Outline: cannot set @unique annotation with arguments
-    Then typeql define; parsing fails
+    Then typeql schema query; parsing fails
       """
       define
       entity player owns name @unique(<args>);
@@ -1571,7 +1571,7 @@ Feature: TypeQL Define Query
 
 
   Scenario Outline: cannot set @key annotation with arguments
-    Then typeql define; parsing fails
+    Then typeql schema query; parsing fails
       """
       define
       entity player owns name @key(<args>);
@@ -1589,21 +1589,21 @@ Feature: TypeQL Define Query
 
 
   Scenario Outline: cannot set @card annotation with invalid arguments <args>
-    Then typeql define; parsing fails
+    Then typeql schema query; parsing fails
       """
       define
       relation parentship relates parent @card(<args>);
       """
 
     Given connection open schema transaction for database: typedb
-    Then typeql define; parsing fails
+    Then typeql schema query; parsing fails
       """
       define
       entity player owns name @card(<args>);
       """
 
     Given connection open schema transaction for database: typedb
-    Then typeql define; parsing fails
+    Then typeql schema query; parsing fails
       """
       define
       entity player plays employment:employee @card(<args>);
@@ -1626,14 +1626,14 @@ Feature: TypeQL Define Query
 
 
   Scenario Outline: cannot set @regex annotation with arguments
-    Then typeql define; parsing fails
+    Then typeql schema query; parsing fails
       """
       define
       attribute characteristics @regex(<args>);
       """
 
     Given connection open schema transaction for database: typedb
-    Then typeql define; parsing fails
+    Then typeql schema query; parsing fails
       """
       define
       entity player owns name @regex(<args>);
@@ -1655,14 +1655,14 @@ Feature: TypeQL Define Query
 
 
   Scenario Outline: cannot set @range annotation with invalid arguments <args>
-    Then typeql define; parsing fails
+    Then typeql schema query; parsing fails
       """
       define
       attribute characteristics @range(<args>);
       """
 
     Given connection open schema transaction for database: typedb
-    Then typeql define; parsing fails
+    Then typeql schema query; parsing fails
       """
       define
       entity player owns name @range(<args>);
@@ -1678,14 +1678,14 @@ Feature: TypeQL Define Query
 
 
   Scenario Outline: cannot set @values annotation with invalid arguments <args>
-    Then typeql define; parsing fails
+    Then typeql schema query; parsing fails
       """
       define
       attribute characteristics @values(<args>);
       """
 
     Given connection open schema transaction for database: typedb
-    Then typeql define; parsing fails
+    Then typeql schema query; parsing fails
       """
       define
       entity player owns name @values(<args>);
@@ -1707,7 +1707,7 @@ Feature: TypeQL Define Query
   ##################
 
   Scenario: an abstract entity type can be defined
-    When typeql define
+    When typeql schema query
       """
       define entity animal @abstract;
       """
@@ -1724,7 +1724,7 @@ Feature: TypeQL Define Query
 
 
   Scenario: a concrete entity type can be defined as a subtype of an abstract entity type
-    When typeql define
+    When typeql schema query
       """
       define
       entity animal @abstract;
@@ -1744,7 +1744,7 @@ Feature: TypeQL Define Query
 
 
   Scenario: an abstract entity type can be defined as a subtype of another abstract entity type
-    When typeql define
+    When typeql schema query
       """
       define
       entity animal @abstract;
@@ -1764,7 +1764,7 @@ Feature: TypeQL Define Query
 
 
   Scenario: an abstract entity type cannot be defined as a subtype of a concrete entity type
-    Then typeql define; fails
+    Then typeql schema query; fails
       """
       define
       entity exception;
@@ -1773,7 +1773,7 @@ Feature: TypeQL Define Query
 
 
   Scenario: an abstract relation type can be defined
-    When typeql define
+    When typeql schema query
       """
       define relation membership @abstract, relates member;
       """
@@ -1790,7 +1790,7 @@ Feature: TypeQL Define Query
 
 
   Scenario: a concrete relation type can be defined as a subtype of an abstract relation type
-    When typeql define
+    When typeql schema query
       """
       define
       relation membership @abstract, relates member;
@@ -1810,7 +1810,7 @@ Feature: TypeQL Define Query
 
 
   Scenario: an abstract relation type can be defined as a subtype of another abstract relation type
-    When typeql define
+    When typeql schema query
       """
       define
       relation requirement @abstract, relates prerequisite, relates outcome;
@@ -1830,7 +1830,7 @@ Feature: TypeQL Define Query
 
 
   Scenario: an abstract relation type cannot be defined as a subtype of a concrete relation type
-    Then typeql define; fails
+    Then typeql schema query; fails
       """
       define
       relation requirement relates prerequisite, relates outcome;
@@ -1839,7 +1839,7 @@ Feature: TypeQL Define Query
 
 
   Scenario: an abstract attribute type can be defined
-    When typeql define
+    When typeql schema query
       """
       define attribute number-of-limbs @abstract, value long;
       """
@@ -1856,7 +1856,7 @@ Feature: TypeQL Define Query
 
 
   Scenario: a concrete attribute type can be defined as a subtype of an abstract attribute type
-    When typeql define
+    When typeql schema query
       """
       define
       attribute number-of-limbs @abstract, value long;
@@ -1876,7 +1876,7 @@ Feature: TypeQL Define Query
 
 
   Scenario: an abstract attribute type can be defined as a subtype of another abstract attribute type
-    When typeql define
+    When typeql schema query
       """
       define
       attribute number-of-limbs @abstract, value long;
@@ -1896,13 +1896,13 @@ Feature: TypeQL Define Query
 
 
   Scenario: defining attribute type hierarchies is idempotent
-    When typeql define
+    When typeql schema query
       """
       define attribute super-name @abstract, value string; attribute location-name sub super-name;
       """
     Then transaction commits
     Then connection open schema transaction for database: typedb
-    Then typeql define
+    Then typeql schema query
       """
       define attribute super-name @abstract, value string; attribute location-name sub super-name;
       """
@@ -1923,7 +1923,7 @@ Feature: TypeQL Define Query
   @ignore
   @ignore-typedb-driver-rust
   Scenario: repeating the term 'abstract' when defining a type causes an error to be thrown
-    Given typeql define; fails
+    Given typeql schema query; fails
       """
       define entity animal @abstract @abstract @abstract;
       """
@@ -1933,7 +1933,7 @@ Feature: TypeQL Define Query
   ##############
 
   Scenario: annotations can be added on subtypes
-    Given typeql define
+    Given typeql schema query
       """
       define
       entity child sub person, owns school-id @unique;
@@ -1943,7 +1943,7 @@ Feature: TypeQL Define Query
 
 
   Scenario: annotations are inherited
-    Given typeql define
+    Given typeql schema query
       """
       define entity child sub person;
       """
@@ -1969,19 +1969,19 @@ Feature: TypeQL Define Query
 
 
   Scenario: redefining inherited annotations throws for types, does not for capabilities
-    Then typeql define
+    Then typeql schema query
       """
       define entity child sub person, owns email @key;
       """
     Then transaction commits
     When connection open schema transaction for database: typedb
-    Then typeql define
+    Then typeql schema query
       """
       define entity child sub person, owns phone-nr @unique;
       """
     Then transaction commits
     When connection open schema transaction for database: typedb
-    Then typeql define
+    Then typeql schema query
       """
       define email @abstract; attribute working-email sub email, value string @regex("^.*@.*$");
       """
@@ -1989,7 +1989,7 @@ Feature: TypeQL Define Query
 
 
   Scenario: type cannot specialise owns
-    Then typeql define; parsing fails
+    Then typeql schema query; parsing fails
       """
       define
       entity person @abstract;
@@ -2000,7 +2000,7 @@ Feature: TypeQL Define Query
 
     # TODO: Should be checked without specialise
 #  Scenario: annotations are inherited through specialises
-#    Given typeql define
+#    Given typeql schema query
 #      """
 #      define
 #      entity person @abstract;
@@ -2018,7 +2018,7 @@ Feature: TypeQL Define Query
 #      | t            | a              |
 #      | label:person | label:phone-nr |
 #      | label:child  | label:mobile   |
-#    Given typeql define
+#    Given typeql schema query
 #      """
 #      define
 #      entity child @abstract;
@@ -2044,7 +2044,7 @@ Feature: TypeQL Define Query
   ###################
 
   Scenario: an existing type can be repeatedly redefined, and it is a no-op
-    When typeql define
+    When typeql schema query
       """
       define
       entity person owns name;
@@ -2062,7 +2062,7 @@ Feature: TypeQL Define Query
 
 
   Scenario: an entity type cannot be changed into a relation type
-    Then typeql define; fails
+    Then typeql schema query; fails
       """
       define
       relation person relates body-part;
@@ -2071,21 +2071,21 @@ Feature: TypeQL Define Query
 
 
   Scenario: a relation type cannot be changed into an attribute type
-    Then typeql define; fails
+    Then typeql schema query; fails
       """
       define attribute employment value string;
       """
 
 
   Scenario: an attribute type cannot be changed into an entity type
-    Then typeql define; fails
+    Then typeql schema query; fails
       """
       define entity name;
       """
 
 
   Scenario: a new attribute ownership can be defined on an existing type
-    When typeql define
+    When typeql schema query
       """
       define employment owns name;
       """
@@ -2103,7 +2103,7 @@ Feature: TypeQL Define Query
 
 
   Scenario: a new playable role can be defined on an existing type
-    When typeql define
+    When typeql schema query
       """
       define employment plays employment:employee;
       """
@@ -2121,7 +2121,7 @@ Feature: TypeQL Define Query
 
 
   Scenario: defining a key on an existing ownership is possible if data already conforms to key requirements
-    Given typeql define
+    Given typeql schema query
       """
       define
       attribute barcode value string;
@@ -2141,7 +2141,7 @@ Feature: TypeQL Define Query
     Given transaction commits
 
     Given connection open schema transaction for database: typedb
-    When typeql define
+    When typeql schema query
       """
       define
       product owns barcode @key;
@@ -2159,7 +2159,7 @@ Feature: TypeQL Define Query
 
 
   Scenario: defining a key on a type throws if existing instances don't have that key
-    Given typeql define
+    Given typeql schema query
       """
       define
       attribute barcode value string;
@@ -2177,7 +2177,7 @@ Feature: TypeQL Define Query
     Given transaction commits
 
     Given connection open schema transaction for database: typedb
-    Then typeql define; fails
+    Then typeql schema query; fails
       """
       define
       product owns barcode @key;
@@ -2185,7 +2185,7 @@ Feature: TypeQL Define Query
 
 
   Scenario: defining a key on a type throws if there is a key collision between two existing instances
-    Given typeql define
+    Given typeql schema query
       """
       define
       attribute barcode value string;
@@ -2203,7 +2203,7 @@ Feature: TypeQL Define Query
     Given transaction commits
 
     Given connection open schema transaction for database: typedb
-    Then typeql define; fails
+    Then typeql schema query; fails
       """
       define
       product owns barcode @key;
@@ -2211,7 +2211,7 @@ Feature: TypeQL Define Query
 
 
   Scenario: a new role can be defined on an existing relation type
-    When typeql define
+    When typeql schema query
       """
       define
       entity company plays employment:employer;
@@ -2230,13 +2230,13 @@ Feature: TypeQL Define Query
 
 
   Scenario: Redefining an attribute type succeeds if and only if the value type remains unchanged
-    Then typeql define; fails
+    Then typeql schema query; fails
       """
       define attribute name value long;
       """
     Given transaction closes
     Given connection open schema transaction for database: typedb
-    When typeql define
+    When typeql schema query
       """
       define attribute name value string;
       """
@@ -2254,7 +2254,7 @@ Feature: TypeQL Define Query
     Given transaction commits
 
     Given connection open schema transaction for database: typedb
-    When typeql define
+    When typeql schema query
       """
       define name value string @regex("^A.*$");
       """
@@ -2281,54 +2281,54 @@ Feature: TypeQL Define Query
     Given transaction commits
 
     Given connection open schema transaction for database: typedb
-    Then typeql define; fails
+    Then typeql schema query; fails
       """
       define name @regex("^A.*$");
       """
 
 
   Scenario: a regex constraint can not be added to an existing attribute type whose value type isn't 'string'
-    Given typeql define
+    Given typeql schema query
       """
       define attribute house-number value long;
       """
     Given transaction commits
 
     Given connection open schema transaction for database: typedb
-    Then typeql define; fails
+    Then typeql schema query; fails
       """
       define house-number @regex("^A.*$");
       """
 
 
   Scenario: related roles cannot be added to existing entity types
-    Then typeql define; fails
+    Then typeql schema query; fails
       """
       define person relates employee;
       """
 
 
   Scenario: related roles cannot be added to existing attribute types
-    Then typeql define; fails
+    Then typeql schema query; fails
       """
       define name relates employee;
       """
 
 
   Scenario: the value type of an existing attribute type is not modifiable through define
-    Then typeql define; fails
+    Then typeql schema query; fails
       """
       define name value long;
       """
     Given transaction closes
     Given connection open schema transaction for database: typedb
-    Then typeql define; fails
+    Then typeql schema query; fails
       """
       define attribute name value long;
       """
 
   Scenario: an attribute ownership can be converted to a key ownership
-    When typeql define
+    When typeql schema query
       """
       define person owns name @key;
       """
@@ -2345,7 +2345,7 @@ Feature: TypeQL Define Query
 
 
   Scenario: an attribute key ownership can be converted to a regular ownership
-    When typeql define
+    When typeql schema query
       """
       define person owns email;
       """
@@ -2367,7 +2367,7 @@ Feature: TypeQL Define Query
 
 
   Scenario: defining a uniqueness on existing ownership is possible if data conforms to uniqueness requirements
-    Given typeql define
+    Given typeql schema query
       """
       define person owns name @card(0..);
       """
@@ -2383,7 +2383,7 @@ Feature: TypeQL Define Query
       """
     Given transaction commits
     Given connection open schema transaction for database: typedb
-    Given typeql define
+    Given typeql schema query
       """
       define person owns name @unique;
       """
@@ -2408,14 +2408,14 @@ Feature: TypeQL Define Query
       """
     Given transaction commits
     Given connection open schema transaction for database: typedb
-    Given typeql define; fails
+    Given typeql schema query; fails
       """
       define person owns name @unique;
       """
 
 
   Scenario: ownership uniqueness can be removed
-    Given typeql define
+    Given typeql schema query
       """
       define person owns phone-nr;
       """
@@ -2442,7 +2442,7 @@ Feature: TypeQL Define Query
     Given transaction commits
     Given connection open schema transaction for database: typedb
     # TODO: Wait for undefine queries to undefine unique!
-    Given typeql define
+    Given typeql schema query
       """
       define person owns email @unique;
       """
@@ -2479,7 +2479,7 @@ Feature: TypeQL Define Query
     Given transaction commits
     Given connection open schema transaction for database: typedb
     # TODO: Wait for undefine queries to undefine unique!
-    Given typeql define
+    Given typeql schema query
       """
       define
       person owns phone-nr @key;
@@ -2502,7 +2502,7 @@ Feature: TypeQL Define Query
       """
     Given transaction commits
     Given connection open schema transaction for database: typedb
-    Then typeql redefine; fails
+    Then typeql schema query; fails
       """
       define
       person owns phone-nr @key;
@@ -2514,7 +2514,7 @@ Feature: TypeQL Define Query
   #############################
 
   Scenario: a concrete entity type can be converted to an abstract entity type
-    When typeql define
+    When typeql schema query
       """
       define person @abstract;
       """
@@ -2531,13 +2531,13 @@ Feature: TypeQL Define Query
 
 
   Scenario: a concrete relation type can be converted to an abstract relation type
-    When typeql define
+    When typeql schema query
       """
       define relation friendship relates friend;
       """
     Then transaction commits
     Given connection open schema transaction for database: typedb
-    When typeql define
+    When typeql schema query
       """
       define friendship @abstract;
       """
@@ -2554,13 +2554,13 @@ Feature: TypeQL Define Query
 
 
   Scenario: a concrete attribute type can be converted to an abstract attribute type
-    When typeql define
+    When typeql schema query
       """
       define attribute age value long;
       """
     Then transaction commits
     Given connection open schema transaction for database: typedb
-    When typeql define
+    When typeql schema query
       """
       define age @abstract;
       """
@@ -2586,7 +2586,7 @@ Feature: TypeQL Define Query
     Given transaction commits
 
     Given connection open schema transaction for database: typedb
-    Then typeql define; fails
+    Then typeql schema query; fails
       """
       define person @abstract;
       """
@@ -2604,7 +2604,7 @@ Feature: TypeQL Define Query
     Given transaction commits
 
     Given connection open schema transaction for database: typedb
-    Then typeql define; fails
+    Then typeql schema query; fails
       """
       define employment @abstract;
       """
@@ -2621,7 +2621,7 @@ Feature: TypeQL Define Query
     Given transaction commits
 
     Given connection open schema transaction for database: typedb
-    Then typeql define; fails
+    Then typeql schema query; fails
       """
       define name @abstract;
       """
@@ -2643,7 +2643,7 @@ Feature: TypeQL Define Query
 
 
   Scenario: an existing entity type cannot be switched to a new supertype through define
-    Given typeql define
+    Given typeql schema query
       """
       define
       entity apple-product;
@@ -2652,7 +2652,7 @@ Feature: TypeQL Define Query
     Given transaction commits
 
     Given connection open schema transaction for database: typedb
-    Then typeql define; fails
+    Then typeql schema query; fails
       """
       define
       entity genius sub apple-product;
@@ -2660,7 +2660,7 @@ Feature: TypeQL Define Query
 
 
   Scenario: an existing relation type cannot be switched to a new supertype through define
-    Given typeql define
+    Given typeql schema query
       """
       define
       relation sabbatical sub employment;
@@ -2669,7 +2669,7 @@ Feature: TypeQL Define Query
     Given transaction commits
 
     Given connection open schema transaction for database: typedb
-    Then typeql define; fails
+    Then typeql schema query; fails
       """
       define
       relation sabbatical sub vacation;
@@ -2677,7 +2677,7 @@ Feature: TypeQL Define Query
 
 
   Scenario: an existing attribute type can be switched to a new supertype with a matching value type
-    Given typeql define
+    Given typeql schema query
       """
       define
       attribute measure @abstract, value double;
@@ -2695,7 +2695,7 @@ Feature: TypeQL Define Query
     Given transaction commits
 
     Given connection open schema transaction for database: typedb
-    When typeql define
+    When typeql schema query
       """
       define
       attribute size value double @abstract;
@@ -2715,7 +2715,7 @@ Feature: TypeQL Define Query
 
 
   Scenario: assigning a supertype without previous supertype succeeds even if they have different attributes + roles, if there are no instances
-    Given typeql define
+    Given typeql schema query
       """
       define
       entity species owns name, plays species-membership:species;
@@ -2727,7 +2727,7 @@ Feature: TypeQL Define Query
     Given transaction commits
 
     Given connection open schema transaction for database: typedb
-    When typeql define
+    When typeql schema query
       """
       define
       entity person sub organism;
@@ -2747,7 +2747,7 @@ Feature: TypeQL Define Query
 
 
   Scenario: assigning a new supertype when having another supertype through define fails without preceding redefine/undefine
-    Given typeql define
+    Given typeql schema query
       """
       define
       entity bird;
@@ -2763,14 +2763,14 @@ Feature: TypeQL Define Query
     Given transaction commits
 
     Given connection open schema transaction for database: typedb
-    Then typeql define; fails
+    Then typeql schema query; fails
       """
       define
       entity animal;
       entity pigeon sub animal;
       """
 
-    Given typeql define
+    Given typeql schema query
       """
       define
       attribute name value string;
@@ -2787,14 +2787,14 @@ Feature: TypeQL Define Query
     Given transaction commits
 
     Given connection open schema transaction for database: typedb
-    Then typeql define; fails
+    Then typeql schema query; fails
       """
       define
       entity animal owns name;
       entity pigeon2 sub animal;
       """
 
-    Given typeql define
+    Given typeql schema query
       """
       define
       entity bird3 plays flying:flier;
@@ -2811,7 +2811,7 @@ Feature: TypeQL Define Query
     Given transaction commits
 
     Given connection open schema transaction for database: typedb
-    Then typeql define; fails
+    Then typeql schema query; fails
       """
       define
       entity animal plays flying:flier;
@@ -2819,7 +2819,7 @@ Feature: TypeQL Define Query
       """
 
   Scenario: assigning a supertype while having another supertype through define fails even if there are no instances
-    Given typeql define
+    Given typeql schema query
       """
       define
       entity person sub organism;
@@ -2832,7 +2832,7 @@ Feature: TypeQL Define Query
     Given transaction commits
 
     Given connection open schema transaction for database: typedb
-    Then typeql define; fails
+    Then typeql schema query; fails
       """
       define
       entity person sub species;
@@ -2866,7 +2866,7 @@ Feature: TypeQL Define Query
 
 
   Scenario: when adding a playable role to an existing type, the change is propagated to its subtypes
-    Given typeql define
+    Given typeql schema query
       """
       define
       relation employment relates employer;
@@ -2888,7 +2888,7 @@ Feature: TypeQL Define Query
 
 
   Scenario: when adding an attribute ownership to an existing type, the change is propagated to its subtypes
-    Given typeql define
+    Given typeql schema query
     """
        define
        entity person owns mobile;
@@ -2911,7 +2911,7 @@ Feature: TypeQL Define Query
 
 
   Scenario: when adding a key ownership to an existing type, the change is propagated to its subtypes
-    Given typeql define
+    Given typeql schema query
       """
       define
       entity child sub person;
@@ -2932,7 +2932,7 @@ Feature: TypeQL Define Query
 
 
   Scenario: when adding a related role to an existing relation type, the change is propagated to all its subtypes
-    Given typeql define
+    Given typeql schema query
       """
       define
       relation part-time-employment sub employment;
@@ -2956,7 +2956,7 @@ Feature: TypeQL Define Query
   ####################
 
   Scenario: uncommitted transaction writes are not persisted
-    When typeql define
+    When typeql schema query
       """
       define entity dog;
       """
@@ -2976,14 +2976,14 @@ Feature: TypeQL Define Query
   ########################
 
   Scenario: a type cannot be a subtype of itself
-    Then typeql define; fails
+    Then typeql schema query; fails
       """
       define dog sub dog;
       """
 
 
   Scenario: a cyclic type hierarchy is not allowed
-    Then typeql define; fails
+    Then typeql schema query; fails
       """
       define
       entity giant sub person;
@@ -2993,7 +2993,7 @@ Feature: TypeQL Define Query
 
 
   Scenario: a relation type can relate to a role that it plays itself
-    When typeql define
+    When typeql schema query
       """
       define
       relation recursive-function relates function, plays recursive-function:function;
@@ -3011,7 +3011,7 @@ Feature: TypeQL Define Query
 
 
   Scenario: two relation types in a type hierarchy can play each other's roles
-    When typeql define
+    When typeql schema query
       """
       define
       relation apple @abstract, relates role1, plays big-apple:role2;
@@ -3025,7 +3025,7 @@ Feature: TypeQL Define Query
   depend on each other, creating a dependency graph, they should all define successfully regardless of
   which variable was picked as the start vertex (#131)
 
-    When typeql define
+    When typeql schema query
       """
       define
 

--- a/query/language/delete.feature
+++ b/query/language/delete.feature
@@ -84,7 +84,7 @@ Feature: TypeQL Delete Query
       """
       match $x isa friendship;
       """
-    Then answer size is: 0
+    Then answer size: 0
     When get answers of typeql read query
       """
       match $x isa name;
@@ -192,7 +192,7 @@ Feature: TypeQL Delete Query
       """
       match $x isa friendship;
       """
-    Then answer size is: 0
+    Then answer size: 0
 
 
   Scenario: an attribute can be deleted using the 'attribute' meta label
@@ -220,7 +220,7 @@ Feature: TypeQL Delete Query
       """
       match $x isa name;
       """
-    Then answer size is: 0
+    Then answer size: 0
 
 
   Scenario: an instance can be deleted using its own type label
@@ -283,7 +283,7 @@ Feature: TypeQL Delete Query
       """
       match $x isa person;
       """
-    Then answer size is: 0
+    Then answer size: 0
 
 
   Scenario: deleting an instance using an unrelated type label throws
@@ -403,7 +403,7 @@ Feature: TypeQL Delete Query
       $r ($x) isa friendship;
 
       """
-    Then answer size is: 0
+    Then answer size: 0
 
 
   ###############
@@ -679,7 +679,7 @@ Feature: TypeQL Delete Query
       """
       match $r (friend: $x, friend: $y) isa friendship;
       """
-    Then answer size is: 0
+    Then answer size: 0
 
     Then typeql delete
       """
@@ -694,7 +694,7 @@ Feature: TypeQL Delete Query
       """
       match $r has email $a, has email $b;
       """
-    Then answer size is: 0
+    Then answer size: 0
 
     Then typeql delete
       """
@@ -711,7 +711,7 @@ Feature: TypeQL Delete Query
       """
       match $x isa person; $y isa person;
       """
-    Then answer size is: 0
+    Then answer size: 0
 
 
   Scenario: when deleting incompatible ownerships or role players, an error is thrown
@@ -782,7 +782,7 @@ Feature: TypeQL Delete Query
       """
       match $r isa friendship;
       """
-    Then answer size is: 0
+    Then answer size: 0
 
 
   Scenario: when the last role player is disassociated from a relation instance, the relation instance gets cleaned up
@@ -814,7 +814,7 @@ Feature: TypeQL Delete Query
       """
       match $r isa friendship;
       """
-    Then answer size is: 0
+    Then answer size: 0
 
 
   Scenario: deleting a role player with a too-specific (downcasting) role throws
@@ -964,7 +964,7 @@ Feature: TypeQL Delete Query
       """
       match $rel (chef: $p) isa ship-crew;
       """
-    Then answer size is: 0
+    Then answer size: 0
 
 
   ########################
@@ -1015,7 +1015,7 @@ Feature: TypeQL Delete Query
       """
       match $x has age 18;
       """
-    Then answer size is: 0
+    Then answer size: 0
 
 
   Scenario: attempting to delete an attribute ownership with a redeclared isa throws
@@ -1135,7 +1135,7 @@ Feature: TypeQL Delete Query
       """
       match $x isa person;
       """
-    Then answer size is: 0
+    Then answer size: 0
 
 
   Scenario: deleting an attribute ownership throws an error when the incorrect direct type is specified
@@ -1202,7 +1202,7 @@ Feature: TypeQL Delete Query
       """
       match $x has duration $d;
       """
-    Then answer size is: 0
+    Then answer size: 0
 
 
   Scenario: deleting the last roleplayer in a relation deletes both the relation and its attribute ownerships
@@ -1250,12 +1250,12 @@ Feature: TypeQL Delete Query
       """
       match $x has duration $d;
       """
-    Then answer size is: 0
+    Then answer size: 0
     When get answers of typeql read query
       """
       match $r isa friendship;
       """
-    Then answer size is: 0
+    Then answer size: 0
 
 
   Scenario: an error is thrown when deleting the ownership of a non-existent attribute
@@ -1395,7 +1395,7 @@ Feature: TypeQL Delete Query
       """
       match $x isa person, has lastname $n;
       """
-    Then answer size is: 0
+    Then answer size: 0
 
 
   ##############

--- a/query/language/delete.feature
+++ b/query/language/delete.feature
@@ -8,13 +8,13 @@ Feature: TypeQL Delete Query
   Background: Open connection and create a simple extensible schema
     Given typedb starts
     Given connection opens with default authentication
-    Given connection has been opened
-    Given connection does not have any database
+    Given connection is open: true
+    Given connection has 0 databases
     Given connection create database: typedb
     Given connection open schema session for database: typedb
     Given session opens transaction of type: write
 
-    Given typeql define
+    Given typeql schema query
       """
       define
       person sub entity,
@@ -328,7 +328,7 @@ Feature: TypeQL Delete Query
     Given connection close all sessions
     Given connection open schema session for database: typedb
     Given session opens transaction of type: write
-    Given typeql define
+    Given typeql schema query
       """
       define
       special-friendship sub friendship;
@@ -821,7 +821,7 @@ Feature: TypeQL Delete Query
     Given connection close all sessions
     Given connection open schema session for database: typedb
     Given session opens transaction of type: write
-    Given typeql define
+    Given typeql schema query
       """
       define
       special-friendship sub friendship,
@@ -870,7 +870,7 @@ Feature: TypeQL Delete Query
     Given connection close all sessions
     Given connection open schema session for database: typedb
     Given session opens transaction of type: write
-    Given typeql define
+    Given typeql schema query
       """
       define
       ship-crew sub relation, relates captain, relates navigator, relates chef;
@@ -922,7 +922,7 @@ Feature: TypeQL Delete Query
     Given connection close all sessions
     Given connection open schema session for database: typedb
     Given session opens transaction of type: write
-    Given typeql define
+    Given typeql schema query
       """
       define
       ship-crew sub relation, relates captain, relates navigator, relates chef, owns ref @key;
@@ -975,7 +975,7 @@ Feature: TypeQL Delete Query
     Given connection close all sessions
     Given connection open schema session for database: typedb
     Given session opens transaction of type: write
-    Given typeql define
+    Given typeql schema query
       """
       define
       age sub attribute, value long;
@@ -1022,7 +1022,7 @@ Feature: TypeQL Delete Query
     Given connection close all sessions
     Given connection open schema session for database: typedb
     Given session opens transaction of type: write
-    Given typeql define
+    Given typeql schema query
       """
       define
       lastname sub attribute, value string;
@@ -1081,7 +1081,7 @@ Feature: TypeQL Delete Query
     Given connection close all sessions
     Given connection open schema session for database: typedb
     Given session opens transaction of type: write
-    Given typeql define
+    Given typeql schema query
       """
       define
       address sub attribute, value string, abstract;
@@ -1160,7 +1160,7 @@ Feature: TypeQL Delete Query
     Given connection close all sessions
     Given connection open schema session for database: typedb
     Given session opens transaction of type: write
-    Given typeql define
+    Given typeql schema query
       """
       define
       duration sub attribute, value long;
@@ -1209,7 +1209,7 @@ Feature: TypeQL Delete Query
     Given connection close all sessions
     Given connection open schema session for database: typedb
     Given session opens transaction of type: write
-    Given typeql define
+    Given typeql schema query
       """
       define
       duration sub attribute, value long;
@@ -1276,7 +1276,7 @@ Feature: TypeQL Delete Query
     Given connection close all sessions
     Given connection open schema session for database: typedb
     Given session opens transaction of type: write
-    Given typeql define
+    Given typeql schema query
       """
       define
       lastname sub attribute, value string;
@@ -1348,7 +1348,7 @@ Feature: TypeQL Delete Query
     Given connection close all sessions
     Given connection open schema session for database: typedb
     Given session opens transaction of type: write
-    Given typeql define
+    Given typeql schema query
       """
       define
       lastname sub attribute, value string;

--- a/query/language/expression.feature
+++ b/query/language/expression.feature
@@ -8,12 +8,12 @@ Feature: TypeQL Get Query with Expressions
   Background: Open connection and create a simple extensible schema
     Given typedb starts
     Given connection opens with default authentication
-    Given connection has been opened
-    Given connection does not have any database
+    Given connection is open: true
+    Given connection has 0 databases
     Given connection create database: typedb
     Given connection open schema transaction for database: typedb
 
-    Given typeql define
+    Given typeql schema query
       """
       define
       person sub entity,

--- a/query/language/fetch.feature
+++ b/query/language/fetch.feature
@@ -8,13 +8,13 @@ Feature: TypeQL Fetch Query
   Background: Open connection and create a simple extensible schema
     Given typedb starts
     Given connection opens with default authentication
-    Given connection has been opened
-    Given connection does not have any database
+    Given connection is open: true
+    Given connection has 0 databases
     Given connection create database: typedb
     Given connection open schema session for database: typedb
     Given session opens transaction of type: write
 
-    Given typeql define
+    Given typeql schema query
       """
       define
       person sub entity,
@@ -261,7 +261,7 @@ Feature: TypeQL Fetch Query
     Given connection close all sessions
     Given connection open schema session for database: typedb
     Given session opens transaction of type: write
-    Given typeql define
+    Given typeql schema query
       """
       define
       rule alice-as-alicia:
@@ -323,7 +323,7 @@ Feature: TypeQL Fetch Query
     Given connection close all sessions
     Given connection open schema session for database: typedb
     Given session opens transaction of type: write
-    Given typeql define
+    Given typeql schema query
       """
       define
       rule alice-as-alicia:
@@ -599,7 +599,7 @@ Feature: TypeQL Fetch Query
     Given connection close all sessions
     Given connection open schema session for database: typedb
     Given session opens transaction of type: write
-    Given typeql define
+    Given typeql schema query
       """
       define
       rule alice-as-alicia:

--- a/query/language/insert.feature
+++ b/query/language/insert.feature
@@ -49,7 +49,7 @@ Feature: TypeQL Insert Query
     Given transaction commits
 
     Given connection open write transaction for database: typedb
-    Given set time-zone is: Europe/London
+    Given set time-zone: Europe/London
 
   ####################
   # INSERTING THINGS #
@@ -142,7 +142,7 @@ Feature: TypeQL Insert Query
       """
       match $x isa dog;
       """
-    Given answer size is: 0
+    Given answer size: 0
     When typeql insert
       """
       insert $x isa dog, has breed "Labrador";
@@ -154,7 +154,7 @@ Feature: TypeQL Insert Query
       """
       match $x isa dog;
       """
-    Then answer size is: 1
+    Then answer size: 1
     Then typeql insert
       """
       insert $x isa dog, has breed "Labrador";
@@ -166,7 +166,7 @@ Feature: TypeQL Insert Query
       """
       match $x isa dog;
       """
-    Then answer size is: 2
+    Then answer size: 2
     Then typeql insert
       """
       insert $x isa dog, has breed "Labrador";
@@ -178,7 +178,7 @@ Feature: TypeQL Insert Query
       """
       match $x isa dog;
       """
-    Then answer size is: 3
+    Then answer size: 3
 
 
   Scenario: an insert can be performed using a direct type specifier, and it functions equivalently to 'isa'
@@ -226,7 +226,7 @@ Feature: TypeQL Insert Query
       """
       match $x isa thing;
       """
-    Given answer size is: 0
+    Given answer size: 0
     When typeql insert
       """
       insert $x isa person, has name "Wilhelmina", has age 25, has ref 0;
@@ -250,7 +250,7 @@ Feature: TypeQL Insert Query
       """
       match $x isa thing;
       """
-    Given answer size is: 0
+    Given answer size: 0
     When typeql insert
       """
       match  ?a = 25;
@@ -283,7 +283,7 @@ Feature: TypeQL Insert Query
       """
       match $x has name "John";
       """
-    Then answer size is: 0
+    Then answer size: 0
 
 
   Scenario: given an attribute with no owners, inserting a thing that owns it results in it having an owner
@@ -363,7 +363,7 @@ Feature: TypeQL Insert Query
       """
       match $p isa dog;
       """
-    Then answer size is: 5
+    Then answer size: 5
     When typeql insert
       """
       match
@@ -378,7 +378,7 @@ Feature: TypeQL Insert Query
       """
       match $p isa dog;
       """
-    Then answer size is: 10
+    Then answer size: 10
 
 
   Scenario Outline: an insert can attach multiple distinct values of the same <type> attribute to a single owner
@@ -467,7 +467,7 @@ get;
       """
       match $p has name "Spiderman";
       """
-    Given answer size is: 0
+    Given answer size: 0
     When typeql insert
       """
       match
@@ -500,7 +500,7 @@ get;
       """
       match $p has name "Spiderman";
       """
-    Given answer size is: 0
+    Given answer size: 0
     When typeql insert
       """
       match
@@ -545,7 +545,7 @@ get;
       """
       match $c has hex-value "#FF0000";
       """
-    Given answer size is: 0
+    Given answer size: 0
     When typeql insert
       """
       match
@@ -590,7 +590,7 @@ get;
       """
       match $c has hex-value "#FF0000";
       """
-    Given answer size is: 0
+    Given answer size: 0
     When typeql insert
       """
       match
@@ -643,7 +643,7 @@ get;
       """
       match $td isa tenure-days;
       """
-    Then answer size is: 0
+    Then answer size: 0
     When typeql insert
       """
       match
@@ -990,7 +990,7 @@ get;
       match $x isa employment, has ref 0;
 
       """
-    Then answer size is: 1
+    Then answer size: 1
 
 
   Scenario: an relation without a role player is deleted on transaction commit
@@ -1007,7 +1007,7 @@ get;
       $x isa employment, has ref 0;
 
       """
-    Then answer size is: 0
+    Then answer size: 0
 
 
   Scenario: when inserting a relation with an unbound variable as a roleplayer, an error is thrown
@@ -1072,7 +1072,7 @@ get;
       """
       match $r isa gym-membership; get $r;
       """
-    Then answer size is: 1
+    Then answer size: 1
 
 
   #######################
@@ -1094,7 +1094,7 @@ get;
       """
       match $x <value> isa <attr>;
       """
-    Given answer size is: 0
+    Given answer size: 0
     When typeql insert
       """
       insert $x <value> isa <attr>, has ref 0;
@@ -1134,7 +1134,7 @@ get;
       """
       match $x <value> isa <attr>;
       """
-    Given answer size is: 0
+    Given answer size: 0
     When typeql insert
       """
       match ?x = <value>;
@@ -1184,7 +1184,7 @@ get;
       """
 
   Scenario: Datetime attribute can be inserted in one timezone and retrieved in another with no change in the value
-    Given set time-zone is: Asia/Calcutta
+    Given set time-zone: Asia/Calcutta
     Given transaction closes
     Given connection open schema transaction for database: typedb
     Given typeql schema query
@@ -1202,7 +1202,7 @@ get;
       $time_date 2023-05-01T00:00:00 isa test_date;
       """
 
-    Given set time-zone is: America/Chicago
+    Given set time-zone: America/Chicago
     Given transaction commits
     Given connection open read transaction for database: typedb
     When get answers of typeql read query
@@ -1257,7 +1257,7 @@ get;
       """
       match $x isa length;
       """
-    Then answer size is: 1
+    Then answer size: 1
     Then uniquely identify answer concepts
       | x                |
       | attr:length:2.0  |
@@ -1295,7 +1295,7 @@ get;
       """
       match $x isa length;
       """
-    Then answer size is: 1
+    Then answer size: 1
     Then uniquely identify answer concepts
       | x                |
       | attr:length:2.0  |
@@ -1326,7 +1326,7 @@ get;
       """
       match $x isa length;
       """
-    Then answer size is: 1
+    Then answer size: 1
 
 
   Scenario Outline: a '<type>' inserted as [<insert>] is retrieved when matching [<match>]
@@ -1858,7 +1858,7 @@ get;
       """
       match $p isa person;
       """
-    Given answer size is: 0
+    Given answer size: 0
     When typeql insert
       """
       match
@@ -1873,7 +1873,7 @@ get;
       """
       match $r isa season-ticket-ownership;
       """
-    Then answer size is: 0
+    Then answer size: 0
 
 
   Scenario: match-inserting only existing entities is a no-op
@@ -2035,7 +2035,7 @@ get;
       """
       match $x isa person;
       """
-    Then answer size is: 1
+    Then answer size: 1
 
 
   Scenario: re-inserting a matched instance as an unrelated type throws an error
@@ -2267,7 +2267,7 @@ get;
       match $x isa name;
       """
     # If the name 'Ganesh' had been materialised, then it would still exist in the knowledge graph.
-    Then answer size is: 0
+    Then answer size: 0
 
   #TODO: Reenable when reasoning can run in a write transaction
   @ignore
@@ -2332,7 +2332,7 @@ get;
       match $x isa person, has score $score;
       """
     # But Freya's ownership of score 10.0 was never materialised and is now gone
-    Then answer size is: 0
+    Then answer size: 0
 
   #TODO: Reenable when rules actually do something
   @ignore
@@ -2412,7 +2412,7 @@ get;
       """
       match $x isa person;
       """
-    Then answer size is: 0
+    Then answer size: 0
     When get answers of typeql read query
       """
       match $x isa name;
@@ -2480,7 +2480,7 @@ get;
       """
       match $x isa employment;
       """
-    Then answer size is: 1
+    Then answer size: 1
     # At this step we materialise the inferred employment because the material employment-contract depends on it.
     When typeql insert
       """
@@ -2506,13 +2506,13 @@ get;
       match $x isa employment;
       """
     # We deleted the rule that infers the employment, but it still exists because it was materialised on match-insert
-    Then answer size is: 1
+    Then answer size: 1
     When get answers of typeql read query
       """
       match (contracted: $x, contract: $y) isa employment-contract;
       """
     # And the inserted relation still exists too
-    Then answer size is: 1
+    Then answer size: 1
 
   #TODO: Reenable when reasoning can run in a write transaction
   @ignore
@@ -2619,7 +2619,7 @@ get;
         $d isa vertex, has index "d";
         $reach ($a, $d) isa reachable;
       """
-    Then answer size is: 1
+    Then answer size: 1
     # On the other hand, the fact that 'c' was reachable from 'a' was not -directly- used; although it was needed
     # in order to infer that (a,d) was reachable, it did not, itself, play a role in any relation that we materialised,
     # so it is now gone.
@@ -2630,7 +2630,7 @@ get;
         $c isa vertex, has index "c";
         $reach ($a, $c) isa reachable;
       """
-    Then answer size is: 0
+    Then answer size: 0
 
 
   Scenario: when matching two disjoint instances of distinct types but only selecting one to insert a pattern, inserts will only happen for the selected instance
@@ -2732,13 +2732,13 @@ get;
       """
       match $x isa person;
       """
-    Then answer size is: 7
+    Then answer size: 7
     When get answers of typeql read query
       """
       match $x isa employment;
       """
     # The original person is still unemployed.
-    Then answer size is: 6
+    Then answer size: 6
 
   ####################
   # TRANSACTIONALITY #
@@ -2761,7 +2761,7 @@ get;
       """
       match $x isa person, has name "Derek";
       """
-    Then answer size is: 0
+    Then answer size: 0
 
 
   Scenario: if any insert in a transaction fails with a semantic error, none of the inserts are performed
@@ -2792,7 +2792,7 @@ get;
       """
       match $x isa person, has name "Derek";
       """
-    Then answer size is: 0
+    Then answer size: 0
 
 
   Scenario: if any insert in a transaction fails with a 'key' violation, none of the inserts are performed
@@ -2812,7 +2812,7 @@ get;
       """
       match $x isa person, has name "Derek";
       """
-    Then answer size is: 0
+    Then answer size: 0
 
 
   ##############

--- a/query/language/insert.feature
+++ b/query/language/insert.feature
@@ -8,12 +8,12 @@ Feature: TypeQL Insert Query
   Background: Open connection and create a simple extensible schema
     Given typedb starts
     Given connection opens with default authentication
-    Given connection has been opened
+    Given connection is open: true
     Given connection reset database: typedb
-#    Given connection does not have any database
+#    Given connection has 0 databases
 #    Given connection create database: typedb
     Given connection open schema transaction for database: typedb
-    Given typeql define
+    Given typeql schema query
       """
       define
 
@@ -129,7 +129,7 @@ Feature: TypeQL Insert Query
   Scenario: when running multiple identical insert queries in series, new things get created each time
     Given transaction closes
     Given connection open schema transaction for database: typedb
-    Given typeql define
+    Given typeql schema query
       """
       define
       attribute breed value string;
@@ -194,7 +194,7 @@ Feature: TypeQL Insert Query
   Scenario: attempting to insert an instance of an abstract type throws an error
     Given transaction closes
     Given connection open schema transaction for database: typedb
-    Given typeql define
+    Given typeql schema query
       """
       define
       entity factory abstract;
@@ -337,7 +337,7 @@ Feature: TypeQL Insert Query
   Scenario: after inserting a new owner for every existing ownership of an attribute, its number of owners doubles
     Given transaction closes
     Given connection open schema transaction for database: typedb
-    Given typeql define
+    Given typeql schema query
       """
       define
       entity dog owns name;
@@ -384,7 +384,7 @@ Feature: TypeQL Insert Query
   Scenario Outline: an insert can attach multiple distinct values of the same <type> attribute to a single owner
     Given transaction closes
     Given connection open schema transaction for database: typedb
-    Given typeql define
+    Given typeql schema query
       """
       define
       attribute <attr> value <type>, owns ref @key;
@@ -523,7 +523,7 @@ get;
   Scenario: when an attribute owns an attribute, an instance of that attribute can be inserted onto it
     Given transaction closes
     Given connection open schema transaction for database: typedb
-    Given typeql define
+    Given typeql schema query
       """
       define
       attribute colour value string, owns hex-value;
@@ -568,7 +568,7 @@ get;
   Scenario: when inserting an additional attribute ownership on an attribute, the owner type can be optionally specified
     Given transaction closes
     Given connection open schema transaction for database: typedb
-    Given typeql define
+    Given typeql schema query
       """
       define
       attribute colour value string, owns hex-value;
@@ -613,7 +613,7 @@ get;
   Scenario: when linking an attribute that doesn't exist yet to a relation, the attribute gets created
     Given transaction closes
     Given connection open schema transaction for database: typedb
-    Given typeql define
+    Given typeql schema query
       """
       define
       relation residence
@@ -668,7 +668,7 @@ get;
   Scenario: an attribute ownership currently inferred by a rule can be explicitly inserted
     Given transaction closes
     Given connection open schema transaction for database: typedb
-    Given typeql define
+    Given typeql schema query
       """
       define
       rule lucy-is-aged-32:
@@ -741,7 +741,7 @@ get;
   Scenario: when inserting a relation that owns an attribute and has an attribute roleplayer, both attributes are created
     Given transaction closes
     Given connection open schema transaction for database: typedb
-    Given typeql define
+    Given typeql schema query
       """
       define
       relation residence
@@ -910,7 +910,7 @@ get;
   Scenario: a roleplayer can be inserted without explicitly specifying a role when the role is inherited
     Given transaction closes
     Given connection open schema transaction for database: typedb
-    Given typeql define
+    Given typeql schema query
       """
       define
       relation part-time-employment sub employment;
@@ -930,7 +930,7 @@ get;
   Scenario: when inserting a roleplayer that can play more than one role, an error is thrown
     Given transaction closes
     Given connection open schema transaction for database: typedb
-    Given typeql define
+    Given typeql schema query
       """
       define
       person plays employment:employer;
@@ -958,7 +958,7 @@ get;
   Scenario: parent types are not necessarily allowed to play the roles that their children play
     Given transaction closes
     Given connection open schema transaction for database: typedb
-    Given typeql define
+    Given typeql schema query
       """
       define
       entity animal;
@@ -1024,7 +1024,7 @@ get;
   Scenario: a relation currently inferred by a rule can be explicitly inserted
     Given transaction closes
     Given connection open schema transaction for database: typedb
-    Given typeql define
+    Given typeql schema query
       """
       define
       relation gym-membership relates member;
@@ -1082,7 +1082,7 @@ get;
   Scenario Outline: inserting an attribute of type '<type>' creates an instance of it
     Given transaction closes
     Given connection open schema transaction for database: typedb
-    Given typeql define
+    Given typeql schema query
       """
       define attribute <attr> value <type>, owns ref @key;
       """
@@ -1122,7 +1122,7 @@ get;
   Scenario Outline: Attributes of type '<type>' can be inserted via value variables
     Given transaction closes
     Given connection open schema transaction for database: typedb
-    Given typeql define
+    Given typeql schema query
       """
       define attribute <attr> value <type>, owns ref @key;
       """
@@ -1163,7 +1163,7 @@ get;
   Scenario: insert a regex attribute throws error if not conforming to regex
     Given transaction closes
     Given connection open schema transaction for database: typedb
-    Given typeql define
+    Given typeql schema query
       """
       define
       entity person
@@ -1187,7 +1187,7 @@ get;
     Given set time-zone is: Asia/Calcutta
     Given transaction closes
     Given connection open schema transaction for database: typedb
-    Given typeql define
+    Given typeql schema query
     """
     define
     attribute test_date value datetime;
@@ -1235,7 +1235,7 @@ get;
   Scenario: inserting two 'double' attribute values with the same integer value creates a single concept
     Given transaction closes
     Given connection open schema transaction for database: typedb
-    Given typeql define
+    Given typeql schema query
       """
       define
       attribute length value double;
@@ -1266,7 +1266,7 @@ get;
   Scenario: inserting the same integer twice as a 'double' in separate transactions creates a single concept
     Given transaction closes
     Given connection open schema transaction for database: typedb
-    Given typeql define
+    Given typeql schema query
       """
       define
       attribute length value double;
@@ -1304,7 +1304,7 @@ get;
   Scenario: inserting attribute values [2] and [2.0] with the same attribute type creates a single concept
     Given transaction closes
     Given connection open schema transaction for database: typedb
-    Given typeql define
+    Given typeql schema query
       """
       define
       attribute length value double;
@@ -1332,7 +1332,7 @@ get;
   Scenario Outline: a '<type>' inserted as [<insert>] is retrieved when matching [<match>]
     Given transaction closes
     Given connection open schema transaction for database: typedb
-    Given typeql define
+    Given typeql schema query
       """
       define attribute <attr> value <type>, owns ref @key;
       """
@@ -1375,7 +1375,7 @@ get;
   Scenario Outline: inserting [<value>] as a '<type>' throws an error
     Given transaction closes
     Given connection open schema transaction for database: typedb
-    Given typeql define
+    Given typeql schema query
       """
       define attribute <attr> value <type>, owns ref @key;
       """
@@ -1499,7 +1499,7 @@ get;
   Scenario: instances of an inherited key attribute don't have to be unique among instances of a type and its subtypes
     Given transaction closes
     Given connection open schema transaction for database: typedb
-    Given typeql define
+    Given typeql schema query
       """
       define
       attribute ref value long;
@@ -1535,7 +1535,7 @@ get;
   Scenario: instances of an inherited key attribute don't have to be unique among its subtypes
     Given transaction closes
     Given connection open schema transaction for database: typedb
-    Given typeql define
+    Given typeql schema query
       """
       define
       attribute ref value long;
@@ -1561,7 +1561,7 @@ get;
   Scenario: an error is thrown when inserting a second key attribute on an attribute that already has one
     Given transaction closes
     Given connection open schema transaction for database: typedb
-    Given typeql define
+    Given typeql schema query
       """
       define
       name owns ref @key;
@@ -1642,7 +1642,7 @@ get;
     Given transaction closes
     Given connection open schema transaction for database: typedb
 
-    Given typeql define
+    Given typeql schema query
       """
       define
       entity child sub person;
@@ -1665,7 +1665,7 @@ get;
   Scenario: specialised uniqueness is respected
     Given transaction closes
     Given connection open schema transaction for database: typedb
-    Given typeql define
+    Given typeql schema query
       """
       define
       entity person abstract;
@@ -1693,7 +1693,7 @@ get;
   Scenario: instances of an inherited unique attribute don't have to be unique among instances of the type and its subtypes
     Given transaction closes
     Given connection open schema transaction for database: typedb
-    Given typeql define
+    Given typeql schema query
       """
       define
       entity child sub person;
@@ -1735,7 +1735,7 @@ get;
   Scenario: match-insert triggers one insert per answer of the match clause
     Given transaction closes
     Given connection open schema transaction for database: typedb
-    Given typeql define
+    Given typeql schema query
       """
       define
       entity language owns name, owns is-cool, owns ref @key;
@@ -1800,7 +1800,7 @@ get;
   Scenario: match-insert can take an attribute's value and copy it to an attribute of a different type
     Given transaction closes
     Given connection open schema transaction for database: typedb
-    Given typeql define
+    Given typeql schema query
       """
       define
       attribute height value long;
@@ -1844,7 +1844,7 @@ get;
   Scenario: if match-insert matches nothing, then nothing is inserted
     Given transaction closes
     Given connection open schema transaction for database: typedb
-    Given typeql define
+    Given typeql schema query
       """
       define
       relation season-ticket-ownership relates holder;
@@ -2059,7 +2059,7 @@ get;
   Scenario: inserting a new type on an existing instance that is a subtype of its existing type throws
     Given transaction closes
     Given connection open schema transaction for database: typedb
-    Given typeql define
+    Given typeql schema query
       """
       define entity child sub person;
       """
@@ -2085,7 +2085,7 @@ get;
   Scenario: inserting a new type on an existing instance that is a supertype of its existing type throws
     Given transaction closes
     Given connection open schema transaction for database: typedb
-    Given typeql define
+    Given typeql schema query
       """
       define entity child sub person;
       """
@@ -2111,7 +2111,7 @@ get;
   Scenario: inserting a new type on an existing instance that is unrelated to its existing type throws
     Given transaction closes
     Given connection open schema transaction for database: typedb
-    Given typeql define
+    Given typeql schema query
       """
       define
         entity car;
@@ -2192,7 +2192,7 @@ get;
   Scenario: variable types in inserts cannot use aliased role types
     Given transaction closes
     Given connection open schema transaction for database: typedb
-    Given typeql define
+    Given typeql schema query
       """
       define
       relation part-time-employment sub employment;
@@ -2220,7 +2220,7 @@ get;
   Scenario: when inserting a thing that has inferred concepts, those concepts are not automatically materialised
     Given transaction closes
     Given connection open schema transaction for database: typedb
-    Given typeql define
+    Given typeql schema query
       """
       define
       person owns score;
@@ -2274,7 +2274,7 @@ get;
   Scenario: when inserting a thing with an inferred attribute ownership, the ownership is not automatically persisted
     Given transaction closes
     Given connection open schema transaction for database: typedb
-    Given typeql define
+    Given typeql schema query
       """
       define
       person owns score;
@@ -2342,7 +2342,7 @@ get;
 
     Given transaction closes
     Given connection open schema transaction for database: typedb
-    Given typeql define
+    Given typeql schema query
       """
       define
 
@@ -2435,7 +2435,7 @@ get;
   Scenario: when inserting things connected to an inferred relation, the inferred relation gets materialised
     Given transaction closes
     Given connection open schema transaction for database: typedb
-    Given typeql undefine
+    Given typeql schema query
       """
       undefine
       employment owns ref;
@@ -2443,7 +2443,7 @@ get;
     Then transaction commits
 
     When connection open schema transaction for database: typedb
-    Given typeql define
+    Given typeql schema query
       """
       define
 
@@ -2493,7 +2493,7 @@ get;
     Then transaction commits
 
     When connection open schema transaction for database: typedb
-    When typeql undefine
+    When typeql schema query
       """
       undefine
       rule henry-is-employed;
@@ -2519,7 +2519,7 @@ get;
   Scenario: when inserting things connected to a chain of inferred concepts, the whole chain is materialised
     Given transaction closes
     Given connection open schema transaction for database: typedb
-    Given typeql define
+    Given typeql schema query
       """
       define
 
@@ -2636,7 +2636,7 @@ get;
   Scenario: when matching two disjoint instances of distinct types but only selecting one to insert a pattern, inserts will only happen for the selected instance
     Given transaction closes
     Given connection open schema transaction for database: typedb
-    Given typeql undefine
+    Given typeql schema query
       """
       undefine
       person owns ref;
@@ -2767,7 +2767,7 @@ get;
   Scenario: if any insert in a transaction fails with a semantic error, none of the inserts are performed
     Given transaction closes
     Given connection open schema transaction for database: typedb
-    Given typeql define
+    Given typeql schema query
       """
       define
       attribute capacity value long;
@@ -2822,7 +2822,7 @@ get;
   Scenario: the 'iid' property is used internally by TypeDB and cannot be manually assigned
     Given transaction closes
     Given connection open schema transaction for database: typedb
-    Given typeql define
+    Given typeql schema query
       """
       define
       entity bird;

--- a/query/language/match.feature
+++ b/query/language/match.feature
@@ -8,12 +8,12 @@ Feature: TypeQL Match Clause
   Background: Open connection and create a simple extensible schema
     Given typedb starts
     Given connection opens with default authentication
-    Given connection has been opened
-    Given connection does not have any database
+    Given connection is open: true
+    Given connection has 0 databases
     Given connection create database: typedb
     Given connection open schema transaction for database: typedb
 
-    Given typeql define
+    Given typeql schema query
       """
       define
       entity person
@@ -49,7 +49,7 @@ Feature: TypeQL Match Clause
   ##################
 
   Scenario: 'label' matches only the specified type, and does not match subtypes
-    Given typeql define
+    Given typeql schema query
       """
       define
       entity writer sub person;
@@ -68,7 +68,7 @@ Feature: TypeQL Match Clause
 
 
   Scenario: 'sub' can be used to match the specified type and all its subtypes, including indirect subtypes
-    Given typeql define
+    Given typeql schema query
       """
       define
       entity writer sub person;
@@ -89,7 +89,7 @@ Feature: TypeQL Match Clause
 
 
   Scenario: 'sub' can be used to match the specified type and all its supertypes, including indirect supertypes
-    Given typeql define
+    Given typeql schema query
       """
       define
       entity writer sub person;
@@ -109,7 +109,7 @@ Feature: TypeQL Match Clause
 
 
   Scenario: 'sub' can be used to retrieve all instances of types that are subtypes of a given type
-    Given typeql define
+    Given typeql schema query
       """
       define
 
@@ -166,7 +166,7 @@ Feature: TypeQL Match Clause
 
 
   Scenario: 'sub!' matches the type's direct subtypes
-    Given typeql define
+    Given typeql schema query
       """
       define
       entity writer sub person;
@@ -188,7 +188,7 @@ Feature: TypeQL Match Clause
 
 
   Scenario: 'sub!' can be used to match a type's direct supertype
-    Given typeql define
+    Given typeql schema query
       """
       define
       entity writer sub person;
@@ -209,7 +209,7 @@ Feature: TypeQL Match Clause
   @ignore
   # TODO this does not work on types anymore - types cannot be specified by IID
   Scenario: subtype hierarchy satisfies transitive sub assertions
-    Given typeql define
+    Given typeql schema query
       """
       define
       entity sub1;
@@ -246,7 +246,7 @@ Feature: TypeQL Match Clause
 
 
   Scenario: 'owns' does not match types that own only a subtype of the specified attribute type
-    Given typeql define
+    Given typeql schema query
       """
       define
       attribute general-name @abstract, value string;
@@ -267,7 +267,7 @@ Feature: TypeQL Match Clause
 
 
   Scenario: 'owns' does not match types that own only a supertype of the specified attribute type
-    Given typeql define
+    Given typeql schema query
       """
       define
       attribute general-name @abstract, value string;
@@ -338,7 +338,7 @@ Feature: TypeQL Match Clause
 
 
   Scenario: inherited 'owns' annotations are queryable
-    Given typeql define
+    Given typeql schema query
       """
       define entity child sub person;
       """
@@ -386,7 +386,7 @@ Feature: TypeQL Match Clause
 
 
   Scenario: 'owns' can be used to retrieve all instances of types that can own a given attribute type
-    Given typeql define
+    Given typeql schema query
       """
       define
       employment owns name;
@@ -430,7 +430,7 @@ Feature: TypeQL Match Clause
 
 
   Scenario: 'plays' does not match types that only play a subrole of the specified role
-    Given typeql define
+    Given typeql schema query
       """
       define
       relation close-friendship sub friendship, relates close-friend as friend;
@@ -449,7 +449,7 @@ Feature: TypeQL Match Clause
 
 
   Scenario: inherited role types cannot be be matched via role type alias
-    Given typeql define
+    Given typeql schema query
       """
       define
       relation close-friendship sub friendship;
@@ -464,7 +464,7 @@ Feature: TypeQL Match Clause
 
 
   Scenario: 'plays' does not match types that only play a super-role of the specified role
-    Given typeql define
+    Given typeql schema query
       """
       define
       relation close-friendship sub friendship, relates close-friend as friend;
@@ -494,7 +494,7 @@ Feature: TypeQL Match Clause
 
 
   Scenario: 'plays' can be used to retrieve all instances of types that can play a specific role
-    Given typeql define
+    Given typeql schema query
       """
       define
       entity dog
@@ -527,7 +527,7 @@ Feature: TypeQL Match Clause
 
 
   Scenario: 'owns @key' matches types that own the specified attribute type as a key
-    Given typeql define
+    Given typeql schema query
       """
       define
       attribute breed value string;
@@ -557,7 +557,7 @@ Feature: TypeQL Match Clause
 
 
   Scenario: 'owns' without '@key' matches all types that own the specified attribute type, even if they use it as a key
-    Given typeql define
+    Given typeql schema query
       """
       define
       attribute breed value string;
@@ -589,7 +589,7 @@ Feature: TypeQL Match Clause
   # TODO cannot currently query for schema with 'as'
   @ignore
   Scenario: 'relates' with 'as' matches relation types that specialise the specified roleplayer
-    Given typeql define
+    Given typeql schema query
       """
       define
       relation close-friendship sub friendship, relates close-friend as friend;
@@ -608,7 +608,7 @@ Feature: TypeQL Match Clause
 
 
   Scenario: 'relates' without 'as' matches relation types that specialise the specified roleplayer
-    Given typeql define
+    Given typeql schema query
       """
       define
       relation close-friendship sub friendship, relates close-friend as friend;
@@ -679,7 +679,7 @@ Feature: TypeQL Match Clause
       | attr:ref:1 | label:ref       |
 
   Scenario: 'isa' matches things of the specified type and all its subtypes
-    Given typeql define
+    Given typeql schema query
       """
       define
       entity writer sub person;
@@ -712,7 +712,7 @@ Feature: TypeQL Match Clause
 
 
   Scenario: 'isa!' only matches things of the specified type, and does not match subtypes
-    Given typeql define
+    Given typeql schema query
       """
       define
       entity writer sub person;
@@ -743,7 +743,7 @@ Feature: TypeQL Match Clause
 
 
   Scenario: 'isa' matches no answers if the type tree is fully abstract
-    Given typeql define
+    Given typeql schema query
       """
       define
       entity person @abstract;
@@ -784,7 +784,7 @@ Feature: TypeQL Match Clause
 
 
   Scenario: 'iid' for a variable of a different type finds no answers
-    Given typeql define
+    Given typeql schema query
       """
       define
       entity shop owns address;
@@ -964,7 +964,7 @@ Feature: TypeQL Match Clause
 
 
   Scenario: repeated role players are retrieved singly when queried doubly
-    Given typeql define
+    Given typeql schema query
       """
       define
       entity some-entity plays symmetric:player, owns ref @key;
@@ -990,7 +990,7 @@ Feature: TypeQL Match Clause
 
 
   Scenario: repeated role players are retrieved singly when queried singly
-    Given typeql define
+    Given typeql schema query
       """
       define
       entity some-entity plays symmetric:player, owns ref @key;
@@ -1038,7 +1038,7 @@ Feature: TypeQL Match Clause
 
   @ignore
   Scenario: A relation can play a role in itself
-    Given typeql define
+    Given typeql schema query
       """
       define
       relation comparator
@@ -1064,7 +1064,7 @@ Feature: TypeQL Match Clause
 
   @ignore
   Scenario: A relation can play a role in itself and have additional roleplayers
-    Given typeql define
+    Given typeql schema query
       """
       define
       relation comparator
@@ -1114,7 +1114,7 @@ Feature: TypeQL Match Clause
 
 
   Scenario: matching a chain of relations only returns answers if there is a chain of the required length
-    Given typeql define
+    Given typeql schema query
       """
       define
 
@@ -1164,7 +1164,7 @@ Feature: TypeQL Match Clause
 
 
   Scenario: when multiple relation instances exist with the same roleplayer, matching that player returns just 1 answer
-    Given typeql define
+    Given typeql schema query
       """
       define
       relation residency
@@ -1262,7 +1262,7 @@ Feature: TypeQL Match Clause
 
 
   Scenario: Relations can be queried with pairings of relation and role types that are not directly related to each other
-    Given typeql define
+    Given typeql schema query
       """
       define
       person plays marriage:spouse, plays hetero-marriage:husband, plays hetero-marriage:wife;
@@ -1348,7 +1348,7 @@ Feature: TypeQL Match Clause
 
 
   Scenario: When some relations do not satisfy the query, the correct ones are still found
-    Given typeql define
+    Given typeql schema query
       """
       define
       entity car plays ownership:owned, owns ref @key;
@@ -1386,7 +1386,7 @@ Feature: TypeQL Match Clause
   ##############
 
   Scenario Outline: '<type>' attributes can be matched by value
-    Given typeql define
+    Given typeql schema query
       """
       define attribute <attr> @independent, value <type>;
       """
@@ -1423,7 +1423,7 @@ Feature: TypeQL Match Clause
 
 
   Scenario Outline: when matching a '<type>' attribute by a value that doesn't exist, an empty answer is returned
-    Given typeql define
+    Given typeql schema query
       """
       define attribute <attr> value <type>;
       """
@@ -1584,7 +1584,7 @@ Feature: TypeQL Match Clause
 
 
   Scenario: using the 'attribute' meta label, 'has' can match things that own any attribute with a specified value
-    Given typeql define
+    Given typeql schema query
       """
       define
       attribute shoe-size value long;
@@ -1614,7 +1614,7 @@ Feature: TypeQL Match Clause
 
 
   Scenario: when an attribute instance is fully specified, 'has' matches its owners
-    Given typeql define
+    Given typeql schema query
       """
       define
       friendship owns age;
@@ -1644,7 +1644,7 @@ Feature: TypeQL Match Clause
 
 
   Scenario: 'has' matches an attribute's owner even if it owns more attributes of the same type
-    Given typeql define
+    Given typeql schema query
       """
       define
       attribute lucky-number value long;
@@ -1700,7 +1700,7 @@ Feature: TypeQL Match Clause
   ##############################
 
   Scenario: when things own attributes of different types but the same value, they match by equality
-    Given typeql define
+    Given typeql schema query
       """
       define
       attribute start-date value date;
@@ -1826,7 +1826,7 @@ Feature: TypeQL Match Clause
 
 
   Scenario: value comparisons can be performed between a 'double' and a 'long'
-    Given typeql define
+    Given typeql schema query
       """
       define
       attribute house-number value long;
@@ -1898,7 +1898,7 @@ Feature: TypeQL Match Clause
 
 
   Scenario: when a thing owns multiple attributes of the same type, a value comparison matches if any value matches
-    Given typeql define
+    Given typeql schema query
       """
       define
       attribute lucky-number value long;
@@ -1952,7 +1952,7 @@ Feature: TypeQL Match Clause
 
 
   Scenario: when the answers of a value comparison include both a 'double' and a 'long', both answers are returned
-    Given typeql define
+    Given typeql schema query
       """
       define
       attribute length value double;
@@ -2184,7 +2184,7 @@ Feature: TypeQL Match Clause
 
 
   Scenario: variable role types with relations playing roles
-    Given typeql define
+    Given typeql schema query
       """
       define
         relation parent relates nested, owns id;
@@ -2305,7 +2305,7 @@ Feature: TypeQL Match Clause
   #######################
 
   Scenario: string attribute values can be non-ascii
-    Given typeql define
+    Given typeql schema query
       """
       define
       person owns favorite-phrase;
@@ -2357,7 +2357,7 @@ Feature: TypeQL Match Clause
 
 
   Scenario: type labels can be non-ascii
-    Given typeql define
+    Given typeql schema query
       """
       define
       entity 人 owns name, owns ref @key; entity אדם owns name, owns ref @key;
@@ -2430,7 +2430,7 @@ Feature: TypeQL Match Clause
 
 
   Scenario: labels and variables have different identifier formats
-    Given typeql define; parsing fails
+    Given typeql schema query; parsing fails
       """
       define
       entity 0_leading_digit_fails;
@@ -2445,7 +2445,7 @@ Feature: TypeQL Match Clause
     Given transaction commits
 
     Given connection open schema transaction for database: typedb
-    Given typeql define; parsing fails
+    Given typeql schema query; parsing fails
       """
       define
       entity _leading_connector_disallowed;
@@ -2459,7 +2459,7 @@ Feature: TypeQL Match Clause
       """
 
     Given connection open schema transaction for database: typedb
-    Given typeql define
+    Given typeql schema query
       """
       define
       entity following_connectors-and-digits-1-2-3-allowed;

--- a/query/language/match.feature
+++ b/query/language/match.feature
@@ -647,7 +647,7 @@ Feature: TypeQL Match Clause
         $x iid 0x83cb2;
         $y iid 0x4ba92;
       """
-    Then answer size is: 0
+    Then answer size: 0
 
 
   ##########
@@ -758,7 +758,7 @@ Feature: TypeQL Match Clause
       """
       match $x isa person;
       """
-    Then answer size is: 0
+    Then answer size: 0
 
 
   Scenario: 'iid' matches the instance with the specified internal iid
@@ -811,7 +811,7 @@ Feature: TypeQL Match Clause
       """
       match $x iid <answer.x.iid>; $x isa grocery, has address "123 street";
       """
-    Then answer size is: 0
+    Then answer size: 0
 
 
   Scenario: match returns an empty answer if there are no matches
@@ -819,7 +819,7 @@ Feature: TypeQL Match Clause
       """
       match $x isa person, has name "Anonymous Coward";
       """
-    Then answer size is: 0
+    Then answer size: 0
 
 
   Scenario: when matching by a type whose label doesn't exist, an error is thrown
@@ -1060,7 +1060,7 @@ Feature: TypeQL Match Clause
       """
       match $rlinks (compared:$r), isa comparator;
       """
-    Then answer size is: 1
+    Then answer size: 1
 
   @ignore
   Scenario: A relation can play a role in itself and have additional roleplayers
@@ -1089,7 +1089,7 @@ Feature: TypeQL Match Clause
       """
       match $rlinks (compared: $v, compared:$r), isa comparator;
       """
-    Then answer size is: 1
+    Then answer size: 1
 
 
   Scenario: relations between distinct concepts are not retrieved when matching concepts that relate to themselves
@@ -1110,7 +1110,7 @@ Feature: TypeQL Match Clause
       """
       match (friend: $x, friend: $x) isa friendship;
       """
-    Then answer size is: 0
+    Then answer size: 0
 
 
   Scenario: matching a chain of relations only returns answers if there is a chain of the required length
@@ -1160,7 +1160,7 @@ Feature: TypeQL Match Clause
         (sender: $b, recipient: $c) isa gift-delivery;
         (sender: $c, recipient: $d) isa gift-delivery;
       """
-    Then answer size is: 0
+    Then answer size: 0
 
 
   Scenario: when multiple relation instances exist with the same roleplayer, matching that player returns just 1 answer
@@ -1288,7 +1288,7 @@ Feature: TypeQL Match Clause
       """
       match $m links (wife: $x, husband: $y), isa hetero-marriage;
       """
-    Then answer size is: 1
+    Then answer size: 1
     Then typeql read query; fails
       """
       match $m links (wife: $x, husband: $y), isa civil-marriage;
@@ -1299,52 +1299,52 @@ Feature: TypeQL Match Clause
       """
       match $m links (wife: $x, husband: $y), isa marriage;
       """
-    Then answer size is: 1
+    Then answer size: 1
     When get answers of typeql read query
       """
       match $m links (wife: $x, husband: $y);
       """
-    Then answer size is: 1
+    Then answer size: 1
     When get answers of typeql read query
       """
       match $m links (spouse: $x, spouse: $y), isa hetero-marriage;
       """
-    Then answer size is: 2
+    Then answer size: 2
     When get answers of typeql read query
       """
       match $m links (spouse: $x, spouse: $y), isa civil-marriage;
       """
-    Then answer size is: 2
+    Then answer size: 2
     When get answers of typeql read query
       """
       match $m links (spouse: $x, spouse: $y), isa marriage;
       """
-    Then answer size is: 4
+    Then answer size: 4
     When get answers of typeql read query
       """
       match $m links (spouse: $x, spouse: $y);
       """
-    Then answer size is: 4
+    Then answer size: 4
     When get answers of typeql read query
       """
       match $m links (role: $x, role: $y), isa hetero-marriage;
       """
-    Then answer size is: 2
+    Then answer size: 2
     When get answers of typeql read query
       """
       match $m links (role: $x, role: $y), isa civil-marriage;
       """
-    Then answer size is: 2
+    Then answer size: 2
     When get answers of typeql read query
       """
       match $m links (role: $x, role: $y), isa marriage;
       """
-    Then answer size is: 4
+    Then answer size: 4
     When get answers of typeql read query
       """
       match $m links (role: $x, role: $y);
       """
-    Then answer size is: 4
+    Then answer size: 4
 
 
   Scenario: When some relations do not satisfy the query, the correct ones are still found
@@ -1379,7 +1379,7 @@ Feature: TypeQL Match Clause
     """
     match $r links (owner: $x), isa ownership, has is-insured true; $x isa person;
     """
-    Then answer size is: 1
+    Then answer size: 1
 
   ##############
   # ATTRIBUTES #
@@ -1434,7 +1434,7 @@ Feature: TypeQL Match Clause
       """
       match $a <value> isa <attr>;
       """
-    Then answer size is: 0
+    Then answer size: 0
 
     Examples:
       | attr        | type     | value      |
@@ -1524,12 +1524,12 @@ Feature: TypeQL Match Clause
       """
       match $x has name $y; $x iid 0x83cb2;
       """
-    Then answer size is: 0
+    Then answer size: 0
     When get answers of typeql read query
       """
       match $x has name $y; $y iid 0x83cb2;
       """
-    Then answer size is: 0
+    Then answer size: 0
 
   # TODO: this test uses attributes, but is ultimately testing the traversal structure,
   #       such that match query does not throw. Perhaps we should introduce a new feature file
@@ -1726,7 +1726,7 @@ Feature: TypeQL Match Clause
         $x isa person, has graduation-date $date;
         $r links (employee: $x), isa employment, has start-date == $date;
       """
-    Then answer size is: 1
+    Then answer size: 1
     Then uniquely identify answer concepts
       | x         | r         | date                            |
       | key:ref:0 | key:ref:1 | attr:graduation-date:2009-07-16 |
@@ -1850,42 +1850,42 @@ Feature: TypeQL Match Clause
         $x isa house-number;
         $x == 1.0;
       """
-    Then answer size is: 1
+    Then answer size: 1
     When get answers of typeql read query
       """
       match
         $x isa length;
         $x == 2;
       """
-    Then answer size is: 1
+    Then answer size: 1
     When get answers of typeql read query
       """
       match
         $x isa house-number;
         $x 1.0;
       """
-    Then answer size is: 1
+    Then answer size: 1
     When get answers of typeql read query
       """
       match
         $x isa length;
         $x 2;
       """
-    Then answer size is: 1
+    Then answer size: 1
     When get answers of typeql read query
       """
       match
         $x isa $a;
         $x >= 1;
       """
-    Then answer size is: 2
+    Then answer size: 2
     When get answers of typeql read query
       """
       match
         $x isa $a;
         $x < 2.0;
       """
-    Then answer size is: 1
+    Then answer size: 1
 
     When get answers of typeql read query
       """
@@ -1894,7 +1894,7 @@ Feature: TypeQL Match Clause
         $y isa length;
         $x < $y;
       """
-    Then answer size is: 1
+    Then answer size: 1
 
 
   Scenario: when a thing owns multiple attributes of the same type, a value comparison matches if any value matches
@@ -2001,7 +2001,7 @@ Feature: TypeQL Match Clause
         $y isa person;
         not { $x is $y; };
       """
-    Then answer size is: 0
+    Then answer size: 0
 
 
   Scenario: concept comparison of unbound variables throws an error
@@ -2054,12 +2054,12 @@ Feature: TypeQL Match Clause
       """
       match $x isa $t; { $t label person; } or { $t label company; };
       """
-    Then answer size is: 0
+    Then answer size: 0
     When get answers of typeql read query
       """
       match $x isa $t; { $t label person; } or { $t label company; };
       """
-    Then answer size is: 0
+    Then answer size: 0
 
 
   Scenario: negations can be applied to filtered variables
@@ -2129,17 +2129,17 @@ Feature: TypeQL Match Clause
       """
       match entity $t; $x isa $t;
       """
-    Given answer size is: 2
+    Given answer size: 2
     Given get answers of typeql read query
       """
       match relation $t; $x isa $t;
       """
-    Given answer size is: 1
+    Given answer size: 1
     Given get answers of typeql read query
       """
       match attribute $t; $x isa $t;
       """
-    Given answer size is: 5
+    Given answer size: 5
     When get answers of typeql read query
       """
       match $x isa $type;
@@ -2147,7 +2147,7 @@ Feature: TypeQL Match Clause
     # 2 entities x 1 type {person}
     # 1 relation x 1 type {friendship}
     # 5 attributes x 1 type {ref/name}
-    Then answer size is: 8
+    Then answer size: 8
 
 
   Scenario: all relations and their types can be retrieved
@@ -2168,19 +2168,19 @@ Feature: TypeQL Match Clause
       """
       match relation $t; $r isa $t;
       """
-    Given answer size is: 1
+    Given answer size: 1
     Given get answers of typeql read query
       """
       match ($x, $y);
       """
     # 2 permutations of the roleplayers
-    Given answer size is: 2
+    Given answer size: 2
     When get answers of typeql read query
       """
       match ($x, $y) isa $type;
       """
     # 2 permutations of the roleplayers
-    Then answer size is: 2
+    Then answer size: 2
 
 
   Scenario: variable role types with relations playing roles
@@ -2222,7 +2222,7 @@ Feature: TypeQL Match Clause
         not { $role-nested sub! $r; };
         not { $role-player sub! $r; };
       """
-    Then answer size is: 1
+    Then answer size: 1
 
     When get answers of typeql read query
       """
@@ -2236,7 +2236,7 @@ Feature: TypeQL Match Clause
         not { $role-nested sub! $r; };
         not { $role-player sub! $r; };
       """
-    Then answer size is: 1
+    Then answer size: 1
 
 
   #######################
@@ -2353,7 +2353,7 @@ Feature: TypeQL Match Clause
       """
       match $x isa person, has favorite-phrase "请给我一";
       """
-    Then answer size is: 0
+    Then answer size: 0
 
 
   Scenario: type labels can be non-ascii

--- a/query/language/modifiers.feature
+++ b/query/language/modifiers.feature
@@ -326,7 +326,7 @@ Feature: TypeQL Query Modifiers
       sort $y asc;
       limit 0;
       """
-    Then answer size is: 0
+    Then answer size: 0
 
 
   Scenario: when the offset is outside the bounds of the matched answer set, an empty answer set is returned
@@ -348,7 +348,7 @@ Feature: TypeQL Query Modifiers
       sort $y asc;
       offset 5;
       """
-    Then answer size is: 0
+    Then answer size: 0
 
 
   Scenario: string sorting is case-sensitive

--- a/query/language/modifiers.feature
+++ b/query/language/modifiers.feature
@@ -7,11 +7,11 @@ Feature: TypeQL Query Modifiers
   Background: Open connection and create a simple extensible schema
     Given typedb starts
     Given connection opens with default authentication
-    Given connection has been opened
+    Given connection is open: true
     Given connection reset database: typedb
     Given connection open schema transaction for database: typedb
 
-    Given typeql define
+    Given typeql schema query
       """
       define
       entity person,
@@ -47,7 +47,7 @@ Feature: TypeQL Query Modifiers
 
   Scenario Outline: the answers of a match can be sorted by an attribute of type '<type>'
     Given connection open schema transaction for database: typedb
-    Given typeql define
+    Given typeql schema query
       """
       define
       attribute <attr> @independent, value <type>;
@@ -457,7 +457,7 @@ Feature: TypeQL Query Modifiers
 
   Scenario Outline: sorting and query predicates agree for type '<type>'
     Given connection open schema transaction for database: typedb
-    Given typeql define
+    Given typeql schema query
       """
       define
       attribute <attr> @independent, value <type>;
@@ -565,7 +565,7 @@ Feature: TypeQL Query Modifiers
 
   Scenario Outline: sorting and query predicates produce order ignoring types
     Given connection open schema transaction for database: typedb
-    Given typeql define
+    Given typeql schema query
       """
       define
       attribute <firstAttr>, value <firstType>;

--- a/query/language/pipelines.feature
+++ b/query/language/pipelines.feature
@@ -8,10 +8,10 @@ Feature: TypeQL pipelines
   Background: Open connection and create a simple extensible schema
     Given typedb starts
     Given connection opens with default authentication
-    Given connection has been opened
+    Given connection is open: true
     Given connection reset database: typedb
     Given connection open schema transaction for database: typedb
-    Given typeql define
+    Given typeql schema query
       """
       define
       entity person owns ref @key,

--- a/query/language/redefine.feature
+++ b/query/language/redefine.feature
@@ -8,11 +8,11 @@ Feature: TypeQL Redefine Query
   Background: Open connection and create a simple extensible schema
     Given typedb starts
     Given connection opens with default authentication
-    Given connection has been opened
+    Given connection is open: true
     Given connection reset database: typedb
     Given connection open schema transaction for database: typedb
 
-    Given typeql define
+    Given typeql schema query
       """
       define
       entity person plays employment:employee, plays income:earner, owns name @card(0..) @regex("^.*$"), owns email @key, owns phone-nr @unique;
@@ -45,61 +45,61 @@ Feature: TypeQL Redefine Query
   ################
 
   Scenario: entity types cannot be redefined
-    Then typeql redefine; parsing fails
+    Then typeql schema query; parsing fails
       """
       redefine entity person;
       """
 
 
   Scenario: redefine parsing fails if multiple statements for entity type
-    Then typeql redefine; parsing fails
+    Then typeql schema query; parsing fails
       """
       redefine entity person plays employment:employee, plays income:earner, owns name @card(0..) @regex("^.*$"), owns email @key, owns phone-nr @unique;
       """
 
     Given connection open schema transaction for database: typedb
-    Then typeql redefine; parsing fails
+    Then typeql schema query; parsing fails
       """
       redefine entity person owns phone-nr @unique, owns name @regex("^.*$") @card(0..), plays income:earner, owns email @key, plays employment:employee;
       """
 
     Given connection open schema transaction for database: typedb
-    Then typeql redefine; parsing fails
+    Then typeql schema query; parsing fails
       """
       redefine entity person owns phone-nr @unique, owns name @regex("^.*$");
       """
 
 
   Scenario: redefine fails if nothing is redefined for entity type
-    Then typeql redefine; fails
+    Then typeql schema query; fails
       """
       redefine entity person plays employment:employee;
       """
     Given transaction closes
 
     Given connection open schema transaction for database: typedb
-    Then typeql redefine; fails
+    Then typeql schema query; fails
       """
       redefine entity person owns name @regex("^.*$") @card(0..);
       """
     Given transaction closes
 
     Given connection open schema transaction for database: typedb
-    Then typeql redefine; fails
+    Then typeql schema query; fails
       """
       redefine entity person plays income:earner;
       """
     Given transaction closes
 
     Given connection open schema transaction for database: typedb
-    Then typeql redefine; fails
+    Then typeql schema query; fails
       """
       redefine entity child sub empty-entity;
       """
 
 
   Scenario: can redefine entity type's sub
-    When typeql redefine
+    When typeql schema query
       """
       redefine entity child sub person;
       """
@@ -125,7 +125,7 @@ Feature: TypeQL Redefine Query
       | x            |
       | label:person |
 
-    When typeql redefine
+    When typeql schema query
       """
       redefine entity child sub person;
       """
@@ -143,7 +143,7 @@ Feature: TypeQL Redefine Query
 
 
   Scenario: a redefined entity subtype inherits attribute ownerships from its parent type
-    Given typeql redefine
+    Given typeql schema query
       """
       redefine entity child sub person;
       """
@@ -161,28 +161,28 @@ Feature: TypeQL Redefine Query
 
 
   Scenario: cannot redefine entity types' relates
-    Then typeql redefine; fails
+    Then typeql schema query; fails
       """
       redefine entity child relates employee;
       """
     Given transaction closes
 
     Given connection open schema transaction for database: typedb
-    Then typeql redefine; fails
+    Then typeql schema query; fails
       """
       redefine entity child relates employee[];
       """
 
 
   Scenario: can redefine entity type's owns ordering
-    Then typeql define; fails
+    Then typeql schema query; fails
       """
       define entity person owns name[];
       """
     Given transaction closes
 
     When connection open schema transaction for database: typedb
-    When typeql redefine
+    When typeql schema query
       """
       redefine entity person owns name[];
       """
@@ -199,7 +199,7 @@ Feature: TypeQL Redefine Query
     When transaction closes
 
     When connection open schema transaction for database: typedb
-    When typeql redefine
+    When typeql schema query
       """
       redefine entity person owns name;
       """
@@ -216,18 +216,18 @@ Feature: TypeQL Redefine Query
 
 
   Scenario: cannot redefine entity type's owns both ordering and annotation
-    When typeql redefine; fails
+    When typeql schema query; fails
       """
       redefine entity person owns name[] @card(0..1);
       """
 
 
   Scenario: redefining an entity type without a kind is acceptable
-    When typeql define
+    When typeql schema query
       """
       define entity flying-spaghetti-monster owns name @regex("Spaghett.*");
       """
-    Then typeql redefine
+    Then typeql schema query
       """
       redefine flying-spaghetti-monster owns name @regex("Mr. Spaghett.*");
       """
@@ -235,11 +235,11 @@ Feature: TypeQL Redefine Query
 
 
   Scenario: defining an entity type with a kind is acceptable
-    When typeql define
+    When typeql schema query
       """
       define entity flying-spaghetti-monster owns name @regex("Spaghett.*");
       """
-    Then typeql redefine
+    Then typeql schema query
       """
       redefine entity flying-spaghetti-monster owns name @regex("Mr. Spaghett.*");
       """
@@ -247,28 +247,28 @@ Feature: TypeQL Redefine Query
 
 
   Scenario: an entity type can not have a value type redefined
-    Then typeql redefine; fails
+    Then typeql schema query; fails
       """
       redefine entity person value double;
       """
 
 
   Scenario: redefining a thing with 'isa' is not possible in a 'redefine' query
-    Then typeql redefine; parsing fails
+    Then typeql schema query; parsing fails
       """
       redefine $p isa person;
       """
 
 
   Scenario: adding an attribute instance to a thing is not possible in a 'redefine' query
-    Then typeql redefine; parsing fails
+    Then typeql schema query; parsing fails
       """
       redefine $p has name "Loch Ness Monster";
       """
 
 
   Scenario: writing an entity variable in a 'redefine' is not allowed
-    Then typeql redefine; parsing fails
+    Then typeql schema query; parsing fails
       """
       redefine entity $x;
       """
@@ -279,67 +279,67 @@ Feature: TypeQL Redefine Query
   ##################
 
   Scenario: relation types cannot be redefined
-    Then typeql redefine; parsing fails
+    Then typeql schema query; parsing fails
       """
       redefine relation employment;
       """
 
 
   Scenario: redefine parsing fails if multiple statements for relation type
-    Then typeql redefine; parsing fails
+    Then typeql schema query; parsing fails
       """
       redefine relation employment relates employee @card(1..), plays income:source, owns start-date @card(0..), owns employment-reference-code @key;
       """
 
     Given connection open schema transaction for database: typedb
-    Then typeql redefine; parsing fails
+    Then typeql schema query; parsing fails
       """
       redefine relation employment plays income:source, relates employee @card(1..), owns employment-reference-code @key, owns start-date @card(0..);
       """
 
     Given connection open schema transaction for database: typedb
-    Then typeql redefine; parsing fails
+    Then typeql schema query; parsing fails
       """
       redefine relation part-time-employment sub empty-relation, relates part-time-role;
       """
 
     Given connection open schema transaction for database: typedb
-    Then typeql redefine; parsing fails
+    Then typeql schema query; parsing fails
       """
       redefine relation part-time-employment relates part-time-role, sub empty-relation;
       """
 
 
   Scenario: redefine fails if nothing is redefined for relation type
-    Then typeql redefine; fails
+    Then typeql schema query; fails
       """
       redefine relation employment relates employee @card(1..);
       """
     Given transaction closes
 
     Given connection open schema transaction for database: typedb
-    Then typeql redefine; fails
+    Then typeql schema query; fails
       """
       redefine relation employment plays income:source;
       """
     Given transaction closes
 
     Given connection open schema transaction for database: typedb
-    Then typeql redefine; fails
+    Then typeql schema query; fails
       """
       redefine relation part-time-employment sub empty-relation;
       """
     Given transaction closes
 
     Given connection open schema transaction for database: typedb
-    Then typeql redefine; fails
+    Then typeql schema query; fails
       """
       redefine relation part-time-employment relates part-time-role;
       """
 
 
   Scenario: can redefine relation type's sub
-    When typeql redefine
+    When typeql schema query
       """
       redefine relation part-time-employment sub employment;
       """
@@ -365,7 +365,7 @@ Feature: TypeQL Redefine Query
       | x                |
       | label:employment |
 
-    When typeql define
+    When typeql schema query
       """
       redefine relation part-time-employment sub employment;
       """
@@ -383,7 +383,7 @@ Feature: TypeQL Redefine Query
 
 
   Scenario: a redefined relation subtype inherits attribute ownerships from its parent type
-    Given typeql define
+    Given typeql schema query
       """
       redefine relation part-time-employment sub employment;
       """
@@ -401,14 +401,14 @@ Feature: TypeQL Redefine Query
 
 
   Scenario: can redefine relation type's relates ordering
-    Then typeql define; fails
+    Then typeql schema query; fails
       """
       define relation employment relates employee[];
       """
     Given transaction closes
 
     When connection open schema transaction for database: typedb
-    When typeql redefine
+    When typeql schema query
       """
       redefine relation employment relates employee[];
       """
@@ -425,7 +425,7 @@ Feature: TypeQL Redefine Query
     When transaction closes
 
     When connection open schema transaction for database: typedb
-    When typeql redefine
+    When typeql schema query
       """
       redefine relation employment relates employee;
       """
@@ -442,21 +442,21 @@ Feature: TypeQL Redefine Query
 
 
   Scenario: cannot redefine relation type's relates both ordering and annotation
-    When typeql redefine; fails
+    When typeql schema query; fails
       """
       redefine employment relates employee[] @card(1..5);
       """
 
 
   Scenario: can redefine relation type's owns ordering
-    Then typeql define; fails
+    Then typeql schema query; fails
       """
       define relation employment owns start-date[];
       """
     Given transaction closes
 
     When connection open schema transaction for database: typedb
-    When typeql redefine
+    When typeql schema query
       """
       redefine relation employment owns start-date[];
       """
@@ -473,7 +473,7 @@ Feature: TypeQL Redefine Query
     When transaction closes
 
     When connection open schema transaction for database: typedb
-    When typeql redefine
+    When typeql schema query
       """
       redefine relation employment owns start-date;
       """
@@ -490,18 +490,18 @@ Feature: TypeQL Redefine Query
 
 
   Scenario: cannot redefine relation type's owns both ordering and annotation
-    When typeql redefine; fails
+    When typeql schema query; fails
       """
       redefine employment owns start-date[] @card(0..1);
       """
 
 
   Scenario: redefining a relation type without a kind is acceptable
-    When typeql define
+    When typeql schema query
       """
       define relation family relates children @card(0..5);
       """
-    Then typeql redefine
+    Then typeql schema query
       """
       redefine family relates children @card(0..);
       """
@@ -509,11 +509,11 @@ Feature: TypeQL Redefine Query
 
 
   Scenario: defining a relation type with a kind is acceptable
-    When typeql define
+    When typeql schema query
       """
       define relation family relates children @card(0..5);
       """
-    Then typeql redefine
+    Then typeql schema query
       """
       redefine relation family relates children @card(0..);
       """
@@ -521,7 +521,7 @@ Feature: TypeQL Redefine Query
 
 
   Scenario: writing a relation variable in a 'redefine' is not allowed
-    Then typeql redefine; parsing fails
+    Then typeql schema query; parsing fails
       """
       redefine relation $x;
       """
@@ -532,20 +532,20 @@ Feature: TypeQL Redefine Query
   ###################
 
   Scenario: attribute types cannot be redefined
-    Then typeql redefine; parsing fails
+    Then typeql schema query; parsing fails
       """
       redefine attribute name;
       """
 
 
   Scenario: redefine parsing fails if multiple statements for attribute type
-    Then typeql redefine; parsing fails
+    Then typeql schema query; parsing fails
       """
       redefine attribute email @independent, value string @regex("^.*@.*$") @range("A".."zzzzzzzzzzzzzzzzzzzzzzzzzz");
       """
 
     Given connection open schema transaction for database: typedb
-    Then typeql redefine; parsing fails
+    Then typeql schema query; parsing fails
       """
       redefine
       attribute email @independent, value string @range("A".."zzzzzzzzzzzzzzzzzzzzzzzzzz") @regex("^.*@.*$");
@@ -553,14 +553,14 @@ Feature: TypeQL Redefine Query
 
 
   Scenario: redefine fails if nothing is redefined for attribute type
-    Then typeql redefine; fails
+    Then typeql schema query; fails
       """
       redefine attribute email @independent;
       """
     Given transaction closes
 
     Given connection open schema transaction for database: typedb
-    Then typeql redefine; fails
+    Then typeql schema query; fails
       """
       redefine
       attribute email value string @range("A".."zzzzzzzzzzzzzzzzzzzzzzzzzz") @regex("^.*@.*$");
@@ -568,7 +568,7 @@ Feature: TypeQL Redefine Query
     Given transaction closes
 
     Given connection open schema transaction for database: typedb
-    Then typeql redefine; fails
+    Then typeql schema query; fails
       """
       redefine
       attribute email value string @regex("^.*@.*$") @range("A".."zzzzzzzzzzzzzzzzzzzzzzzzzz");
@@ -576,14 +576,14 @@ Feature: TypeQL Redefine Query
 
 
   Scenario Outline: attribute types' value type can be redefined from '<value-type-1>' to '<value-type-2>'
-    Given typeql define
+    Given typeql schema query
       """
       define attribute <label> value <value-type-1>;
       """
     Given transaction commits
 
     Given connection open schema transaction for database: typedb
-    Given typeql redefine
+    Given typeql schema query
       """
       redefine attribute <label> value <value-type-2>;
       """
@@ -613,11 +613,11 @@ Feature: TypeQL Redefine Query
 
 
   Scenario: an attribute type can be redefined as a subtype of an abstract attribute type
-    When typeql define
+    When typeql schema query
       """
         define attribute data @abstract;
       """
-    When typeql redefine
+    When typeql schema query
       """
       redefine attribute long-data sub data;
       """
@@ -635,7 +635,7 @@ Feature: TypeQL Redefine Query
 
 
   Scenario: a redefined attribute subtype inherits the value type of its parent
-    When typeql redefine
+    When typeql schema query
       """
       redefine empty-sub-data sub abstract-decimal-data;
       """
@@ -652,18 +652,18 @@ Feature: TypeQL Redefine Query
 
 
   Scenario: redefining an attribute subtype throws if it is given a different value type to what its parent has
-    Then typeql redefine; fails
+    Then typeql schema query; fails
       """
       redefine attribute long-data sub abstract-decimal-data;
       """
 
 
   Scenario: redefining an attribute type without a kind is acceptable
-    When typeql define
+    When typeql schema query
       """
       define attribute id value string;
       """
-    Then typeql redefine
+    Then typeql schema query
       """
       redefine attribute id value long;
       """
@@ -671,11 +671,11 @@ Feature: TypeQL Redefine Query
 
 
   Scenario: defining an attribute type with a kind is acceptable
-    When typeql define
+    When typeql schema query
       """
       define attribute id value string;
       """
-    Then typeql redefine
+    Then typeql schema query
       """
       redefine id value long;
       """
@@ -683,20 +683,20 @@ Feature: TypeQL Redefine Query
 
 
   Scenario: writing an attribute variable in a 'redefine' is not allowed
-    Then typeql redefine; parsing fails
+    Then typeql schema query; parsing fails
       """
       redefine attribute $x;
       """
 
 
   Scenario: the value type of an existing attribute type is modifiable through redefine
-    Then typeql redefine
+    Then typeql schema query
       """
       redefine phone-nr value long;
       """
     Then transaction commits
     Given connection open schema transaction for database: typedb
-    Then typeql redefine
+    Then typeql schema query
       """
       redefine attribute phone-nr value string;
       """
@@ -708,14 +708,14 @@ Feature: TypeQL Redefine Query
   ###############
 
   Scenario Outline: cannot redefine annotation @<annotation> for entity types
-    When typeql define
+    When typeql schema query
       """
       define entity player;
       """
     When transaction commits
 
     Given connection open schema transaction for database: typedb
-    Then typeql define<define-fail>
+    Then typeql schema query<define-fail>
       """
       define
       entity player @<annotation>;
@@ -723,7 +723,7 @@ Feature: TypeQL Redefine Query
     When transaction <define-tx-action>
 
     Given connection open schema transaction for database: typedb
-    Then typeql redefine<redefine-fail>
+    Then typeql schema query<redefine-fail>
       """
       redefine
       entity player @<annotation-2>;
@@ -747,7 +747,7 @@ Feature: TypeQL Redefine Query
 
 
   Scenario Outline: cannot redefine annotation @<annotation> for relation types
-    When typeql define
+    When typeql schema query
       """
       define
       relation parentship relates parent;
@@ -755,7 +755,7 @@ Feature: TypeQL Redefine Query
     When transaction commits
 
     Given connection open schema transaction for database: typedb
-    When typeql define<define-fail>
+    When typeql schema query<define-fail>
       """
       define
       relation parentship @<annotation>;
@@ -763,7 +763,7 @@ Feature: TypeQL Redefine Query
     When transaction <define-tx-action>
 
     Given connection open schema transaction for database: typedb
-    Then typeql redefine<redefine-fail>
+    Then typeql schema query<redefine-fail>
       """
       redefine
       relation parentship @<annotation-2>;
@@ -787,7 +787,7 @@ Feature: TypeQL Redefine Query
 
 
   Scenario Outline: can redefine annotation @<annotation> for attribute types
-    When typeql define
+    When typeql schema query
       """
       define
       attribute description value string;
@@ -795,7 +795,7 @@ Feature: TypeQL Redefine Query
     When transaction commits
 
     Given connection open schema transaction for database: typedb
-    Then typeql define<define-fail>
+    Then typeql schema query<define-fail>
       """
       define
       attribute description @<annotation>;
@@ -803,7 +803,7 @@ Feature: TypeQL Redefine Query
     When transaction <define-tx-action>
 
     Given connection open schema transaction for database: typedb
-    Then typeql redefine<redefine-fail>
+    Then typeql schema query<redefine-fail>
       """
       redefine
       attribute description @<annotation-2>;
@@ -828,7 +828,7 @@ Feature: TypeQL Redefine Query
 
 
   Scenario Outline: cannot redefine annotation @<annotation> for relates/role types
-    When typeql define
+    When typeql schema query
       """
       define
       relation parentship @abstract, relates parent;
@@ -836,7 +836,7 @@ Feature: TypeQL Redefine Query
     When transaction commits
 
     Given connection open schema transaction for database: typedb
-    Then typeql define<define-fail>
+    Then typeql schema query<define-fail>
       """
       define
       relation parentship @abstract, relates parent @<annotation>;
@@ -844,7 +844,7 @@ Feature: TypeQL Redefine Query
     When transaction <define-tx-action>
 
     Given connection open schema transaction for database: typedb
-    Then typeql redefine<redefine-fail>
+    Then typeql schema query<redefine-fail>
       """
       redefine
       relation parentship relates parent @<annotation-2>;
@@ -868,7 +868,7 @@ Feature: TypeQL Redefine Query
 
 
   Scenario Outline: can redefine annotation @<annotation> for relates/role types
-    Then typeql define
+    Then typeql schema query
       """
       define
       relation parentship @abstract, relates parent @<annotation>;
@@ -876,7 +876,7 @@ Feature: TypeQL Redefine Query
     When transaction commits
 
     Given connection open schema transaction for database: typedb
-    Then typeql redefine
+    Then typeql schema query
       """
       redefine
       relation parentship relates parent @<annotation-2>;
@@ -888,7 +888,7 @@ Feature: TypeQL Redefine Query
 
 
   Scenario Outline: cannot redefine annotation @<annotation> to relates/role types lists
-    When typeql define
+    When typeql schema query
       """
       define
       relation parentship @abstract, relates parent[];
@@ -896,7 +896,7 @@ Feature: TypeQL Redefine Query
     When transaction commits
 
     Given connection open schema transaction for database: typedb
-    Then typeql define<define-fail>
+    Then typeql schema query<define-fail>
       """
       define
       relation parentship @abstract, relates parent[] @<annotation>;
@@ -904,7 +904,7 @@ Feature: TypeQL Redefine Query
     When transaction <define-tx-action>
 
     Given connection open schema transaction for database: typedb
-    Then typeql redefine<redefine-fail>
+    Then typeql schema query<redefine-fail>
       """
       redefine
       relation parentship relates parent[] @<annotation-2>;
@@ -928,7 +928,7 @@ Feature: TypeQL Redefine Query
 
 
   Scenario Outline: can redefine annotation @<annotation> for relates/role types lists
-    Then typeql define
+    Then typeql schema query
       """
       define
       relation parentship @abstract, relates parent[] @<annotation>;
@@ -936,7 +936,7 @@ Feature: TypeQL Redefine Query
     When transaction commits
 
     Given connection open schema transaction for database: typedb
-    Then typeql redefine
+    Then typeql schema query
       """
       redefine
       relation parentship relates parent[] @<annotation-2>;
@@ -948,7 +948,7 @@ Feature: TypeQL Redefine Query
 
 
   Scenario Outline: cannot redefine annotation @<annotation> for owns
-    When typeql define
+    When typeql schema query
       """
       define
       entity player owns name;
@@ -956,7 +956,7 @@ Feature: TypeQL Redefine Query
     When transaction commits
 
     Given connection open schema transaction for database: typedb
-    Then typeql define<define-fail>
+    Then typeql schema query<define-fail>
       """
       define
       entity player owns name @<annotation>;
@@ -964,7 +964,7 @@ Feature: TypeQL Redefine Query
     When transaction <define-tx-action>
 
     Given connection open schema transaction for database: typedb
-    Then typeql redefine<redefine-fail>
+    Then typeql schema query<redefine-fail>
       """
       redefine
       entity player owns name @<annotation-2>;
@@ -985,7 +985,7 @@ Feature: TypeQL Redefine Query
 
 
   Scenario Outline: can redefine annotation @<annotation> for owns
-    Then typeql define
+    Then typeql schema query
       """
       define
       entity player owns name @<annotation>;
@@ -993,7 +993,7 @@ Feature: TypeQL Redefine Query
     When transaction commits
 
     Given connection open schema transaction for database: typedb
-    Then typeql redefine
+    Then typeql schema query
       """
       redefine
       entity player owns name @<annotation-2>;
@@ -1008,7 +1008,7 @@ Feature: TypeQL Redefine Query
 
 
   Scenario Outline: cannot redefine annotation @<annotation> for owns lists
-    When typeql define
+    When typeql schema query
       """
       define
       entity player owns name[];
@@ -1016,7 +1016,7 @@ Feature: TypeQL Redefine Query
     When transaction commits
 
     Given connection open schema transaction for database: typedb
-    Then typeql define<define-fail>
+    Then typeql schema query<define-fail>
       """
       define
       entity player owns name[] @<annotation>;
@@ -1024,7 +1024,7 @@ Feature: TypeQL Redefine Query
     When transaction <define-tx-action>
 
     Given connection open schema transaction for database: typedb
-    Then typeql redefine<redefine-fail>
+    Then typeql schema query<redefine-fail>
       """
       redefine
       entity player owns name[] @<annotation-2>;
@@ -1045,7 +1045,7 @@ Feature: TypeQL Redefine Query
 
 
   Scenario Outline: can redefine annotation @<annotation> for owns lists
-    Then typeql define
+    Then typeql schema query
       """
       define
       entity player owns name[] @<annotation>;
@@ -1053,7 +1053,7 @@ Feature: TypeQL Redefine Query
     When transaction commits
 
     Given connection open schema transaction for database: typedb
-    Then typeql redefine
+    Then typeql schema query
       """
       redefine
       entity player owns name[] @<annotation-2>;
@@ -1068,7 +1068,7 @@ Feature: TypeQL Redefine Query
 
 
   Scenario Outline: cannot redefine annotation @<annotation> for plays
-    When typeql define
+    When typeql schema query
       """
       define
       entity player plays employment:employee;
@@ -1076,7 +1076,7 @@ Feature: TypeQL Redefine Query
     When transaction commits
 
     Given connection open schema transaction for database: typedb
-    Then typeql define<define-fail>
+    Then typeql schema query<define-fail>
       """
       define
       entity player plays employment:employee @<annotation>;
@@ -1084,7 +1084,7 @@ Feature: TypeQL Redefine Query
     When transaction <define-tx-action>
 
     Given connection open schema transaction for database: typedb
-    Then typeql redefine<redefine-fail>
+    Then typeql schema query<redefine-fail>
       """
       redefine
       entity player plays employment:employee @<annotation-2>;
@@ -1108,7 +1108,7 @@ Feature: TypeQL Redefine Query
 
 
   Scenario Outline: can redefine annotation @<annotation> for plays
-    Then typeql define
+    Then typeql schema query
       """
       define
       entity player plays employment:employee @<annotation>;
@@ -1116,7 +1116,7 @@ Feature: TypeQL Redefine Query
     When transaction commits
 
     Given connection open schema transaction for database: typedb
-    Then typeql redefine
+    Then typeql schema query
       """
       redefine
       entity player plays employment:employee @<annotation-2>;
@@ -1128,7 +1128,7 @@ Feature: TypeQL Redefine Query
 
 
   Scenario Outline: cannot redefine annotation @<annotation> for value types
-    When typeql define
+    When typeql schema query
       """
       define
       attribute description value string;
@@ -1136,7 +1136,7 @@ Feature: TypeQL Redefine Query
     When transaction commits
 
     Given connection open schema transaction for database: typedb
-    Then typeql define<define-fail>
+    Then typeql schema query<define-fail>
       """
       define
       attribute description value string @<annotation>;
@@ -1144,7 +1144,7 @@ Feature: TypeQL Redefine Query
     When transaction <define-tx-action>
 
     Given connection open schema transaction for database: typedb
-    Then typeql redefine<redefine-fail>
+    Then typeql schema query<redefine-fail>
       """
       redefine
       attribute description value string @<annotation-2>;
@@ -1166,7 +1166,7 @@ Feature: TypeQL Redefine Query
 
 
   Scenario Outline: can redefine annotation @<annotation> for value types
-    Then typeql define
+    Then typeql schema query
       """
       define
       attribute description value string @<annotation>;
@@ -1174,7 +1174,7 @@ Feature: TypeQL Redefine Query
     When transaction commits
 
     Given connection open schema transaction for database: typedb
-    Then typeql redefine
+    Then typeql schema query
       """
       redefine
       attribute description value string @<annotation-2>;
@@ -1188,18 +1188,18 @@ Feature: TypeQL Redefine Query
 
 
   Scenario: cannot redefine multiple annotations in one query
-    Then typeql redefine; fails
+    Then typeql schema query; fails
       """
       redefine entity person owns name @card(0..1) @regex("^[a-zA-Z]+$");
       """
     When transaction closes
 
     When connection open schema transaction for database: typedb
-    Then typeql redefine
+    Then typeql schema query
       """
       redefine entity person owns name @regex("^[a-zA-Z]+$");
       """
-    Then typeql redefine
+    Then typeql schema query
       """
       redefine entity person owns name @card(0..1);
       """
@@ -1211,7 +1211,7 @@ Feature: TypeQL Redefine Query
   ######################
 
   Scenario: an existing entity type can be switched to a new supertype
-    Given typeql define
+    Given typeql schema query
       """
       define
       entity apple-product;
@@ -1220,7 +1220,7 @@ Feature: TypeQL Redefine Query
     Given transaction commits
 
     Given connection open schema transaction for database: typedb
-    When typeql redefine
+    When typeql schema query
       """
       redefine
       entity genius sub apple-product;
@@ -1239,7 +1239,7 @@ Feature: TypeQL Redefine Query
 
 
   Scenario: an existing relation type can be switched to a new supertype
-    Given typeql define
+    Given typeql schema query
       """
       define
       relation sabbatical sub employment;
@@ -1248,7 +1248,7 @@ Feature: TypeQL Redefine Query
     Given transaction commits
 
     Given connection open schema transaction for database: typedb
-    When typeql redefine
+    When typeql schema query
       """
       redefine
       relation sabbatical sub vacation;
@@ -1267,7 +1267,7 @@ Feature: TypeQL Redefine Query
 
 
   Scenario: assigning a supertype while having another supertype succeeds even if they have different attributes + roles, if there are no instances
-    Given typeql define
+    Given typeql schema query
       """
       define
       entity creature sub species;
@@ -1280,7 +1280,7 @@ Feature: TypeQL Redefine Query
     Given transaction commits
 
     Given connection open schema transaction for database: typedb
-    When typeql define
+    When typeql schema query
       """
       redefine
       entity creature sub organism;
@@ -1300,7 +1300,7 @@ Feature: TypeQL Redefine Query
 
 
   Scenario: assigning a new supertype when having other sub succeeds even with existing data if the supertypes have no properties
-    Given typeql define
+    Given typeql schema query
       """
       define
       entity bird;
@@ -1316,12 +1316,12 @@ Feature: TypeQL Redefine Query
     Given transaction commits
 
     Given connection open schema transaction for database: typedb
-    When typeql define
+    When typeql schema query
       """
       define
       entity animal;
       """
-    When typeql redefine
+    When typeql schema query
       """
       redefine
       entity pigeon sub animal;
@@ -1339,7 +1339,7 @@ Feature: TypeQL Redefine Query
 
 
   Scenario: assigning a new supertype when having other sub succeeds with existing data if the supertypes play the same roles
-    Given typeql define
+    Given typeql schema query
       """
       define
       entity bird plays flying:flier;
@@ -1356,12 +1356,12 @@ Feature: TypeQL Redefine Query
     Given transaction commits
 
     Given connection open schema transaction for database: typedb
-    When typeql define
+    When typeql schema query
       """
       define
       entity animal plays flying:flier;
       """
-    When typeql redefine
+    When typeql schema query
       """
       redefine
       entity pigeon sub animal;
@@ -1379,7 +1379,7 @@ Feature: TypeQL Redefine Query
 
 
   Scenario: assigning a new supertype when having other sub succeeds with existing data if the supertypes have the same attributes
-    Given typeql define
+    Given typeql schema query
       """
       define
       attribute name value string;
@@ -1396,7 +1396,7 @@ Feature: TypeQL Redefine Query
     Given transaction commits
 
     Given connection open schema transaction for database: typedb
-    When typeql define
+    When typeql schema query
       """
       define
       entity animal owns name;
@@ -1404,7 +1404,7 @@ Feature: TypeQL Redefine Query
     Then transaction commits
 
     Given connection open schema transaction for database: typedb
-    When typeql redefine
+    When typeql schema query
       """
       redefine
       entity pigeon sub animal;

--- a/query/language/redefine.feature
+++ b/query/language/redefine.feature
@@ -597,7 +597,7 @@ Feature: TypeQL Redefine Query
         attribute $x;
 
       """
-    Then answer size is: 1
+    Then answer size: 1
 
     Examples:
       | value-type-1 | value-type-2 | label              |

--- a/query/language/reduce.feature
+++ b/query/language/reduce.feature
@@ -65,7 +65,7 @@ Feature: TypeQL Reduce Queries
         $y isa name;
         $f isa friendship;
       """
-    Then answer size is: 9
+    Then answer size: 9
     When get answers of typeql read query
       """
       match
@@ -82,7 +82,7 @@ Feature: TypeQL Reduce Queries
         $y isa name;
         $f isa friendship, links (friend: $x);
       """
-    Then answer size is: 6
+    Then answer size: 6
     When get answers of typeql read query
       """
       match
@@ -260,7 +260,7 @@ Feature: TypeQL Reduce Queries
       """
       match $x isa person, has age $y;
       """
-    Then answer size is: 3
+    Then answer size: 3
     When get answers of typeql read query
       """
       match $x isa person, has age $y;

--- a/query/language/reduce.feature
+++ b/query/language/reduce.feature
@@ -8,11 +8,11 @@ Feature: TypeQL Reduce Queries
   Background: Open connection and create a simple extensible schema
     Given typedb starts
     Given connection opens with default authentication
-    Given connection has been opened
+    Given connection is open: true
     Given connection reset database: typedb
     Given connection open schema transaction for database: typedb
 
-    Given typeql define
+    Given typeql schema query
       """
       define
       entity person
@@ -115,7 +115,7 @@ Feature: TypeQL Reduce Queries
 
   Scenario Outline: the <reduction> of an answer set of '<type>' values can be retrieved
     Given connection open schema transaction for database: typedb
-    Given typeql define
+    Given typeql schema query
       """
       define
       attribute <attr>, value <type>;
@@ -149,7 +149,7 @@ Feature: TypeQL Reduce Queries
 
   Scenario Outline: the <reduction> of an answer set of '<type>' must be assigned to an optional variable
     Given connection open schema transaction for database: typedb
-    Given typeql define
+    Given typeql schema query
       """
       define
       attribute <attr>, value <type>;
@@ -189,7 +189,7 @@ Feature: TypeQL Reduce Queries
 
   Scenario: the sample standard deviation can be retrieved for an answer set of 'double' values
     Given connection open schema transaction for database: typedb
-    Given typeql define
+    Given typeql schema query
       """
       define
       attribute weight, value double;
@@ -297,7 +297,7 @@ Feature: TypeQL Reduce Queries
 
   Scenario Outline: when an answer set is empty, calling '<reduction>' on it returns an empty answer
     Given connection open schema transaction for database: typedb
-    Given typeql define
+    Given typeql schema query
       """
       define
       attribute income value double;
@@ -368,7 +368,7 @@ Feature: TypeQL Reduce Queries
 
   Scenario Outline: an error is thrown when getting the '<reduction>' of attributes that have the inapplicable type, '<type>'
     Given connection open schema transaction for database: typedb
-    Given typeql define
+    Given typeql schema query
       """
       define
       attribute <attr> value <type>;
@@ -399,7 +399,7 @@ Feature: TypeQL Reduce Queries
 
   Scenario Outline: an error is thrown when getting the fallible '<reduction>' of attributes that have the inapplicable type, '<type>'
     Given connection open schema transaction for database: typedb
-    Given typeql define
+    Given typeql schema query
       """
       define
       attribute <attr> value <type>;
@@ -616,7 +616,7 @@ Feature: TypeQL Reduce Queries
 
   Scenario: Grouped standard deviation of one value returns an empty group value
     Given connection open schema transaction for database: typedb
-    Given typeql define
+    Given typeql schema query
       """
       define
       attribute income value double;

--- a/query/language/rule-validation.feature
+++ b/query/language/rule-validation.feature
@@ -7,12 +7,12 @@ Feature: TypeQL Rule Validation
   Background: Initialise a session and transaction for each scenario
     Given typedb starts
     Given connection opens with default authentication
-    Given connection has been opened
-    Given connection does not have any database
+    Given connection is open: true
+    Given connection has 0 databases
     Given connection create database: typedb
     Given connection open schema session for database: typedb
     Given session opens transaction of type: write
-    Given typeql define
+    Given typeql schema query
       """
       define
       person sub entity,
@@ -33,7 +33,7 @@ Feature: TypeQL Rule Validation
   # Note: These tests verify only the ability to create rules, and are not concerned with their application.
 
   Scenario: a rule can infer both an attribute and its ownership
-    Given typeql define
+    Given typeql schema query
       """
       define
       
@@ -48,7 +48,7 @@ Feature: TypeQL Rule Validation
 
   # Keys are validated at commit time, so integrity will not be harmed by writing one in a rule.
   Scenario: a rule can infer a 'key'
-    Given typeql define
+    Given typeql schema query
       """
       define
       rule john-smiths-email: when {
@@ -61,7 +61,7 @@ Feature: TypeQL Rule Validation
 
 
   Scenario: when a rule has no 'when' clause, an error is thrown
-    Then typeql define; throws exception
+    Then typeql schema query; throws exception
       """
       define
 
@@ -73,7 +73,7 @@ Feature: TypeQL Rule Validation
 
 
   Scenario: when a rule has no 'then' clause, an error is thrown
-    Then typeql define; throws exception
+    Then typeql schema query; throws exception
       """
       define
 
@@ -84,7 +84,7 @@ Feature: TypeQL Rule Validation
 
 
   Scenario: when a rule's 'when' clause is empty, an error is thrown
-    Then typeql define; throws exception
+    Then typeql schema query; throws exception
       """
       define
 
@@ -97,7 +97,7 @@ Feature: TypeQL Rule Validation
 
 
   Scenario: when a rule's 'then' clause is empty, an error is thrown
-    Then typeql define; throws exception
+    Then typeql schema query; throws exception
       """
       define
 
@@ -109,7 +109,7 @@ Feature: TypeQL Rule Validation
 
 
   Scenario: a rule can have negation in its 'when' clause
-    Given typeql define
+    Given typeql schema query
       """
       define
       only-child sub attribute, value boolean;
@@ -128,7 +128,7 @@ Feature: TypeQL Rule Validation
 
 
   Scenario: when a rule has a negation block whose pattern variables are all unbound outside it, an error is thrown
-    Then typeql define; throws exception
+    Then typeql schema query; throws exception
       """
       define
       has-robert sub attribute, value boolean;
@@ -145,7 +145,7 @@ Feature: TypeQL Rule Validation
 
 
   Scenario: when a rule has nested negation, an error is thrown
-    Then typeql define; throws exception
+    Then typeql schema query; throws exception
       """
       define
       rule unemployed-robert-maybe-doesnt-not-have-nickname-bob: when {
@@ -163,7 +163,7 @@ Feature: TypeQL Rule Validation
 
 
   Scenario: a rule may have multiple negations
-    Then typeql define
+    Then typeql schema query
       """
       define
 
@@ -184,7 +184,7 @@ Feature: TypeQL Rule Validation
 
 
   Scenario: a rule may have a conjunction in a negation
-    Then typeql define
+    Then typeql schema query
       """
       define
 
@@ -204,7 +204,7 @@ Feature: TypeQL Rule Validation
 
 
   Scenario: when a rule has two conclusions, an error is thrown
-    Then typeql define; throws exception
+    Then typeql schema query; throws exception
       """
       define
       rule robert-has-nicknames-bob-and-bobby: when {
@@ -217,7 +217,7 @@ Feature: TypeQL Rule Validation
 
 
   Scenario: a rule can use conjunction in its 'when' clause
-    Given typeql define
+    Given typeql schema query
       """
       define
       person plays both-named-robert:named-robert;
@@ -233,7 +233,7 @@ Feature: TypeQL Rule Validation
 
 
   Scenario: a rule can use disjunction in its 'when' clause
-    Then typeql define
+    Then typeql schema query
       """
       define
       rule sophie-and-fiona-have-nickname-fi: when {
@@ -247,7 +247,7 @@ Feature: TypeQL Rule Validation
 
 
   Scenario: a rule can use a negated disjunction in its 'when' clause
-    Then typeql define
+    Then typeql schema query
       """
       define
       rule those-who-arent-sophie-and-fiona-have-nickname-notfi: when {
@@ -261,7 +261,7 @@ Feature: TypeQL Rule Validation
 
 
   Scenario: when a rule contains an unbound variable in the 'then' clause, an error is thrown
-    Then typeql define; throws exception
+    Then typeql schema query; throws exception
       """
       define
       rule i-did-a-bad-typo: when {
@@ -273,7 +273,7 @@ Feature: TypeQL Rule Validation
 
 
   Scenario: the variables in the conclusion of a rule must be bound in the trunk of its 'when' clause
-    Then typeql define; throws exception
+    Then typeql schema query; throws exception
       """
       define
       person plays both-named-robert:named-robert;
@@ -288,7 +288,7 @@ Feature: TypeQL Rule Validation
 
 
   Scenario: Relation variable in 'then' must not be explicit
-    Then typeql define; throws exception
+    Then typeql schema query; throws exception
       """
       define
       person sub entity;
@@ -307,7 +307,7 @@ Feature: TypeQL Rule Validation
 
 
   Scenario: when a rule has an undefined attribute set in its 'then' clause, an error is thrown
-    Given typeql define; throws exception
+    Given typeql schema query; throws exception
       """
       define
       rule boudicca-is-1960-years-old: when {
@@ -319,7 +319,7 @@ Feature: TypeQL Rule Validation
 
 
   Scenario: when a rule attaches an attribute to a type that can't have that attribute, an error is thrown
-    Given typeql define; throws exception
+    Given typeql schema query; throws exception
       """
       define
       age sub attribute, value long;
@@ -332,7 +332,7 @@ Feature: TypeQL Rule Validation
 
 
   Scenario: when a rule creates an attribute value that doesn't match the attribute's type, an error is thrown
-    Then typeql define; throws exception
+    Then typeql schema query; throws exception
       """
       define
       rule may-has-nickname-5: when {
@@ -344,7 +344,7 @@ Feature: TypeQL Rule Validation
 
 
   Scenario: a rule can materialise a long attribute for a double attribute type
-    Then typeql define
+    Then typeql schema query
       """
       define
       person owns age;
@@ -359,7 +359,7 @@ Feature: TypeQL Rule Validation
 
 
   Scenario: when a rule creates double attribute for a long attribute type, an error is thrown
-    Then typeql define; throws exception
+    Then typeql schema query; throws exception
       """
       define
       person owns weight;
@@ -374,7 +374,7 @@ Feature: TypeQL Rule Validation
 
 
   Scenario: when a rule infers a relation whose type doesn't exist, an error is thrown
-    Then typeql define; throws exception
+    Then typeql schema query; throws exception
       """
       define
       rule bonnie-and-clyde-are-partners-in-crime: when {
@@ -387,7 +387,7 @@ Feature: TypeQL Rule Validation
 
 
   Scenario: when a rule infers a relation with an incorrect roleplayer, an error is thrown
-    Then typeql define; throws exception
+    Then typeql schema query; throws exception
       """
       define
       partners-in-crime sub relation, relates criminal, relates sidekick;
@@ -402,7 +402,7 @@ Feature: TypeQL Rule Validation
 
 
   Scenario: when a rule infers an abstract relation, an error is thrown
-    Then typeql define; throws exception
+    Then typeql schema query; throws exception
       """
       define
       partners-in-crime sub relation, abstract, relates criminal, relates sidekick;
@@ -417,7 +417,7 @@ Feature: TypeQL Rule Validation
 
 
   Scenario: when a rule infers an abstract attribute value, an error is thrown
-    Then typeql define; throws exception
+    Then typeql schema query; throws exception
       """
       define
       number-of-devices sub attribute, value long, abstract;
@@ -431,7 +431,7 @@ Feature: TypeQL Rule Validation
 
 
   Scenario: when defining a rule using an aliased role type, an error is thrown
-    Then typeql define; throws exception
+    Then typeql schema query; throws exception
       """
       define
       part-time-employment sub employment;
@@ -446,7 +446,7 @@ Feature: TypeQL Rule Validation
 
 
   Scenario: when defining a rule to generate new entities from existing ones, an error is thrown
-    Given typeql define
+    Given typeql schema query
       """
       define
 
@@ -454,7 +454,7 @@ Feature: TypeQL Rule Validation
       derivedEntity sub entity;
       """
 
-    Then typeql define; throws exception
+    Then typeql schema query; throws exception
       """
       define
       rule rule-1: when {
@@ -466,7 +466,7 @@ Feature: TypeQL Rule Validation
 
 
   Scenario: when defining a rule to generate new entities from existing relations, an error is thrown
-    Given typeql define
+    Given typeql schema query
       """
       define
 
@@ -483,7 +483,7 @@ Feature: TypeQL Rule Validation
           relates role2;
       """
 
-    Then typeql define; throws exception
+    Then typeql schema query; throws exception
       """
       define
       rule rule-1: when {
@@ -496,7 +496,7 @@ Feature: TypeQL Rule Validation
 
 
   Scenario: when defining a rule to generate new relations from existing ones, an error is thrown
-    Given typeql define
+    Given typeql schema query
       """
       define
 
@@ -509,7 +509,7 @@ Feature: TypeQL Rule Validation
           relates role2;
       """
 
-    Then typeql define; throws exception
+    Then typeql schema query; throws exception
       """
       define
       rule rule-1: when {
@@ -522,13 +522,13 @@ Feature: TypeQL Rule Validation
 
 
   Scenario: when defining a rule to infer an additional type that is missing a necessary attribute, an error is thrown
-    Given typeql define
+    Given typeql schema query
       """
       define
       dog sub entity;
       """
 
-    Then typeql define; throws exception
+    Then typeql schema query; throws exception
       """
       define
       rule romeo-is-a-dog: when {
@@ -541,7 +541,7 @@ Feature: TypeQL Rule Validation
 
   Scenario: when a rule negates its conclusion in the 'when', causing a (self-)loop, an error is thrown
   Ensure rule stratification is possible
-    Then typeql define
+    Then typeql schema query
       """
       define
       rule there-are-no-unemployed: when {
@@ -557,7 +557,7 @@ Feature: TypeQL Rule Validation
 
 
   Scenario: When multiple rules result in a loop with negation, an error is thrown
-    Then typeql define
+    Then typeql schema query
       """
       define
       rule scholar-is-employee: when {
@@ -585,7 +585,7 @@ Feature: TypeQL Rule Validation
 
 
   Scenario: When rules are mutually recursive via negated predicates (strictly negative loop), an error is thrown
-    Then typeql define
+    Then typeql schema query
       """
       define
       rule employed-nonscholar-is-apprentice: when {
@@ -605,7 +605,7 @@ Feature: TypeQL Rule Validation
     Then transaction commits; throws exception
 
   Scenario: When any branch in a disjunction creates a negative loop, an error is thrown
-    Then typeql define
+    Then typeql schema query
       """
       define
       rule employed-nonscholar-whois-apprentice: when {
@@ -623,7 +623,7 @@ Feature: TypeQL Rule Validation
 
 
   Scenario: When rule creates a loop with negation within a type hierarchy via specialisation, an error is thrown
-    Then typeql define
+    Then typeql schema query
       """
       define
       rule unemployed-are-selfemployed: when {
@@ -637,7 +637,7 @@ Feature: TypeQL Rule Validation
 
 
   Scenario: a rule can insert a generalisation of a negated type
-    Then typeql define
+    Then typeql schema query
       """
       define
       rule nonselfemployed-are-employed: when {
@@ -651,7 +651,7 @@ Feature: TypeQL Rule Validation
 
 
   Scenario: the rule body can contradict itself
-    Given typeql define
+    Given typeql schema query
       """
       define
       rule crazy-rule: when {
@@ -665,7 +665,7 @@ Feature: TypeQL Rule Validation
 
 
   Scenario: when a rule negates itself in the rule body, the rule commits even if that cycle involves a then clause in another rule
-    Given typeql define
+    Given typeql schema query
       """
       define
 
@@ -687,7 +687,7 @@ Feature: TypeQL Rule Validation
 
 
   Scenario: rules with cyclic inferences are allowed as long as there is no negation
-    When typeql define
+    When typeql schema query
       """
       define
 
@@ -710,7 +710,7 @@ Feature: TypeQL Rule Validation
 
 
   Scenario: when a rule has a conjunction as the conclusion, an error is thrown
-    When typeql define; throws exception
+    When typeql schema query; throws exception
     """
     define
 
@@ -726,7 +726,7 @@ Feature: TypeQL Rule Validation
 
 
   Scenario: when a rule has a down-cast in a rule conclusion, an error is thrown
-    When typeql define; throws exception
+    When typeql schema query; throws exception
       """
       define
 
@@ -743,7 +743,7 @@ Feature: TypeQL Rule Validation
 
 
   Scenario: when a rule has a side-cast in a rule, an error is thrown
-    When typeql define; throws exception
+    When typeql schema query; throws exception
       """
       define
 
@@ -767,7 +767,7 @@ Feature: TypeQL Rule Validation
 
   Scenario: when a rule adds a role to an existing relation, an error is thrown
   Checks adding new roles to existing relationships is not allowed
-    When typeql define; throws exception
+    When typeql schema query; throws exception
       """
       define
 
@@ -782,7 +782,7 @@ Feature: TypeQL Rule Validation
 
 
   Scenario: if a rule's body uses a type that doesn't exist, an error is thrown
-    When typeql define; throws exception
+    When typeql schema query; throws exception
       """
       define
 
@@ -796,7 +796,7 @@ Feature: TypeQL Rule Validation
 
 
   Scenario: if a rule uses a missing type within a negation, an error is thrown
-    When typeql define; throws exception
+    When typeql schema query; throws exception
       """
       define
 
@@ -811,7 +811,7 @@ Feature: TypeQL Rule Validation
 
 
   Scenario: a rule may infer a named variable for an attribute if the attribute type is left out
-    When typeql define
+    When typeql schema query
       """
       define
 
@@ -828,7 +828,7 @@ Feature: TypeQL Rule Validation
 
 
   Scenario: a rule may infer an attribute type when the value is concrete
-    When typeql define
+    When typeql schema query
     """
     define
 
@@ -844,7 +844,7 @@ Feature: TypeQL Rule Validation
 
 
   Scenario: if a rule infers both an attribute type and a named variable, an error is thrown
-    When typeql define; throws exception
+    When typeql schema query; throws exception
     """
     define
 

--- a/query/language/undefine.feature
+++ b/query/language/undefine.feature
@@ -8,13 +8,13 @@ Feature: TypeQL Undefine Query
   Background: Open connection and create a simple extensible schema
     Given typedb starts
     Given connection opens with default authentication
-    Given connection has been opened
-    Given connection does not have any database
+    Given connection is open: true
+    Given connection has 0 databases
     Given connection create database: typedb
     Given connection open schema session for database: typedb
     Given session opens transaction of type: write
 
-    Given typeql define
+    Given typeql schema query
       """
       define
       person sub entity, plays employment:employee, owns name, owns email @key;
@@ -42,7 +42,7 @@ Feature: TypeQL Undefine Query
       | label:abstract-type |
       | label:person        |
       | label:entity        |
-    When typeql undefine
+    When typeql schema query
       """
       undefine person sub entity;
       """
@@ -60,14 +60,14 @@ Feature: TypeQL Undefine Query
 
 
   Scenario: when undefining 'sub' on an entity type, specifying a type that isn't really its supertype throws
-    When typeql undefine; throws exception
+    When typeql schema query; throws exception
       """
       undefine person sub relation;
       """
 
 
   Scenario: a sub-entity type can be removed using 'sub' with its direct supertype, and its parent is preserved
-    Given typeql define
+    Given typeql schema query
       """
       define child sub person;
       """
@@ -82,7 +82,7 @@ Feature: TypeQL Undefine Query
       | x            |
       | label:person |
       | label:child  |
-    When typeql undefine
+    When typeql schema query
       """
       undefine child sub person;
       """
@@ -99,7 +99,7 @@ Feature: TypeQL Undefine Query
 
 
   Scenario: undefining a type 'sub' an indirect supertype should still remove that type
-    Given typeql define
+    Given typeql schema query
       """
       define child sub person;
       """
@@ -115,7 +115,7 @@ Feature: TypeQL Undefine Query
       | label:person |
       | label:child  |
     When session opens transaction of type: write
-    When typeql undefine
+    When typeql schema query
       """
       undefine child sub entity;
       """
@@ -132,28 +132,28 @@ Feature: TypeQL Undefine Query
 
 
   Scenario: undefining a supertype throws an error if subtypes exist
-    Given typeql define
+    Given typeql schema query
       """
       define child sub person;
       """
     Given transaction commits
 
     When session opens transaction of type: write
-    Then typeql undefine; throws exception
+    Then typeql schema query; throws exception
       """
       undefine person sub entity;
       """
 
 
   Scenario: removing a playable role from a super entity type also removes it from its subtypes
-    Given typeql define
+    Given typeql schema query
       """
       define child sub person;
       """
     Given transaction commits
 
     When session opens transaction of type: write
-    When typeql undefine
+    When typeql schema query
       """
       undefine person plays employment:employee;
       """
@@ -168,14 +168,14 @@ Feature: TypeQL Undefine Query
 
 
   Scenario: removing an attribute ownership from a super entity type also removes it from its subtypes
-    Given typeql define
+    Given typeql schema query
       """
       define child sub person;
       """
     Given transaction commits
 
     When session opens transaction of type: write
-    When typeql undefine
+    When typeql schema query
       """
       undefine person owns name;
       """
@@ -190,14 +190,14 @@ Feature: TypeQL Undefine Query
 
 
   Scenario: removing a key ownership from a super entity type also removes it from its subtypes
-    Given typeql define
+    Given typeql schema query
       """
       define child sub person;
       """
     Given transaction commits
 
     When session opens transaction of type: write
-    When typeql undefine
+    When typeql schema query
       """
       undefine person owns email;
       """
@@ -234,7 +234,7 @@ Feature: TypeQL Undefine Query
     Given connection close all sessions
     Given connection open schema session for database: typedb
     When session opens transaction of type: write
-    Then typeql undefine; throws exception
+    Then typeql schema query; throws exception
       """
       undefine person sub entity;
       """
@@ -254,7 +254,7 @@ Feature: TypeQL Undefine Query
     When connection close all sessions
     When connection open schema session for database: typedb
     When session opens transaction of type: write
-    When typeql undefine
+    When typeql schema query
       """
       undefine person sub entity;
       """
@@ -284,7 +284,7 @@ Feature: TypeQL Undefine Query
       | x                |
       | label:employment |
       | label:relation   |
-    When typeql undefine
+    When typeql schema query
       """
       undefine employment sub relation;
       """
@@ -301,7 +301,7 @@ Feature: TypeQL Undefine Query
 
 
   Scenario: removing playable roles from a super relation type also removes them from its subtypes
-    Given typeql define
+    Given typeql schema query
       """
       define
       employment-terms sub relation, relates employment;
@@ -318,7 +318,7 @@ Feature: TypeQL Undefine Query
     Given uniquely identify answer concepts
       | x                                 |
       | label:employment-terms:employment |
-    When typeql undefine
+    When typeql schema query
       """
       undefine employment plays employment-terms:employment;
       """
@@ -333,7 +333,7 @@ Feature: TypeQL Undefine Query
 
 
   Scenario: removing attribute ownerships from a super relation type also removes them from its subtypes
-    Given typeql define
+    Given typeql schema query
       """
       define
       start-date sub attribute, value datetime;
@@ -351,7 +351,7 @@ Feature: TypeQL Undefine Query
       | x                         |
       | label:employment          |
       | label:contract-employment |
-    When typeql undefine
+    When typeql schema query
       """
       undefine employment owns start-date;
       """
@@ -366,7 +366,7 @@ Feature: TypeQL Undefine Query
 
 
   Scenario: removing key ownerships from a super relation type also removes them from its subtypes
-    Given typeql define
+    Given typeql schema query
       """
       define
       employment-reference sub attribute, value string;
@@ -384,7 +384,7 @@ Feature: TypeQL Undefine Query
       | x                         |
       | label:employment          |
       | label:contract-employment |
-    When typeql undefine
+    When typeql schema query
       """
       undefine employment owns employment-reference;
       """
@@ -413,7 +413,7 @@ Feature: TypeQL Undefine Query
     Given connection close all sessions
     Given connection open schema session for database: typedb
     Given session opens transaction of type: write
-    Then typeql undefine; throws exception
+    Then typeql schema query; throws exception
       """
       undefine
       employment relates employee;
@@ -446,7 +446,7 @@ Feature: TypeQL Undefine Query
     Given connection close all sessions
     Given connection open schema session for database: typedb
     Given session opens transaction of type: write
-    Then typeql undefine; throws exception
+    Then typeql schema query; throws exception
       """
       undefine employment sub relation;
       """
@@ -466,7 +466,7 @@ Feature: TypeQL Undefine Query
     When connection close all sessions
     When connection open schema session for database: typedb
     When session opens transaction of type: write
-    When typeql undefine
+    When typeql schema query
       """
       undefine employment sub relation;
       """
@@ -493,7 +493,7 @@ Feature: TypeQL Undefine Query
     Given uniquely identify answer concepts
       | x            | y                         |
       | label:person | label:employment:employee |
-    When typeql undefine
+    When typeql schema query
       """
       undefine employment sub relation;
       """
@@ -523,7 +523,7 @@ Feature: TypeQL Undefine Query
       | x                         |
       | label:employment:employee |
       | label:employment:employer |
-    When typeql undefine
+    When typeql schema query
       """
       undefine employment relates employee;
       """
@@ -540,7 +540,7 @@ Feature: TypeQL Undefine Query
 
 
   Scenario: undefining all players of a role produces a valid schema
-    When typeql undefine
+    When typeql schema query
       """
       undefine person plays employment:employee;
       """
@@ -580,7 +580,7 @@ Feature: TypeQL Undefine Query
     Given connection close all sessions
     Given connection open schema session for database: typedb
     Given session opens transaction of type: write
-    When typeql undefine
+    When typeql schema query
       """
       undefine
       person plays employment:employee;
@@ -606,7 +606,7 @@ Feature: TypeQL Undefine Query
 
 
   Scenario: removing all roles from a relation type without undefining the relation type throws on commit
-    When typeql undefine
+    When typeql schema query
       """
       undefine
       employment relates employee;
@@ -626,7 +626,7 @@ Feature: TypeQL Undefine Query
     Given uniquely identify answer concepts
       | x            | y                         |
       | label:person | label:employment:employee |
-    When typeql undefine
+    When typeql schema query
       """
       undefine employment relates employee;
       """
@@ -644,7 +644,7 @@ Feature: TypeQL Undefine Query
 
 
   Scenario: removing a role throws an error if it is played by existing roleplayers in relations
-    Given typeql define
+    Given typeql schema query
       """
       define
       company sub entity, owns name, plays employment:employer;
@@ -666,7 +666,7 @@ Feature: TypeQL Undefine Query
     Given connection close all sessions
     Given connection open schema session for database: typedb
     Given session opens transaction of type: write
-    Then typeql undefine; throws exception
+    Then typeql schema query; throws exception
       """
       undefine employment relates employer;
       """
@@ -687,7 +687,7 @@ Feature: TypeQL Undefine Query
     Given connection close all sessions
     Given connection open schema session for database: typedb
     Given session opens transaction of type: write
-    When typeql undefine
+    When typeql schema query
       """
       undefine employment relates employer;
       """
@@ -704,14 +704,14 @@ Feature: TypeQL Undefine Query
 
 
   Scenario: removing a role from a super relation type also removes it from its subtypes
-    Given typeql define
+    Given typeql schema query
       """
       define part-time sub employment;
       """
     Given transaction commits
 
     When session opens transaction of type: write
-    When typeql undefine
+    When typeql schema query
       """
       undefine employment relates employer;
       """
@@ -762,7 +762,7 @@ Feature: TypeQL Undefine Query
     Given connection close all sessions
     Given connection open schema session for database: typedb
     Given session opens transaction of type: write
-    When typeql undefine
+    When typeql schema query
       """
       undefine person plays employment:employee;
       """
@@ -793,14 +793,14 @@ Feature: TypeQL Undefine Query
     Given uniquely identify answer concepts
       | x                         |
       | label:employment:employee |
-    When typeql undefine; throws exception
+    When typeql schema query; throws exception
       """
       undefine person plays employment:employer;
       """
 
 
   Scenario: undefining played inherited role types using alias role types throws
-    Given typeql define
+    Given typeql schema query
     """
     define
     part-time-employment sub employment;
@@ -808,7 +808,7 @@ Feature: TypeQL Undefine Query
     Given transaction commits
 
     Given session opens transaction of type: write
-    Given typeql undefine; throws exception
+    Given typeql schema query; throws exception
     """
     undefine
     person plays part-time-employment:employee;
@@ -830,7 +830,7 @@ Feature: TypeQL Undefine Query
     Given connection close all sessions
     Given connection open schema session for database: typedb
     Given session opens transaction of type: write
-    Then typeql undefine; throws exception
+    Then typeql schema query; throws exception
       """
       undefine person plays employment:employee;
       """
@@ -841,7 +841,7 @@ Feature: TypeQL Undefine Query
   ###################
 
   Scenario Outline: undefining 'sub attribute' on an attribute type with value type '<value_type>' removes it
-    Given typeql define
+    Given typeql schema query
       """
       define <attr> sub attribute, value <value_type>;
       """
@@ -853,7 +853,7 @@ Feature: TypeQL Undefine Query
       match $x type <attr>;
       """
     Given answer size is: 1
-    When typeql undefine
+    When typeql schema query
       """
       undefine <attr> sub attribute;
       """
@@ -875,7 +875,7 @@ Feature: TypeQL Undefine Query
 
 
   Scenario: undefining a regex on an attribute type removes the regex constraints on the attribute
-    When typeql undefine
+    When typeql schema query
       """
       undefine email regex ".+@\w+\..+";
       """
@@ -899,7 +899,7 @@ Feature: TypeQL Undefine Query
 
 
   Scenario: removing playable roles from a super attribute type also removes them from its subtypes
-    Given typeql define
+    Given typeql schema query
       """
       define
       employment relates manager-name;
@@ -916,7 +916,7 @@ Feature: TypeQL Undefine Query
     Given uniquely identify answer concepts
       | x                             |
       | label:employment:manager-name |
-    When typeql undefine
+    When typeql schema query
       """
       undefine abstract-name plays employment:manager-name;
       """
@@ -931,7 +931,7 @@ Feature: TypeQL Undefine Query
 
 
   Scenario: removing attribute ownerships from a super attribute type also removes them from its subtypes
-    Given typeql define
+    Given typeql schema query
       """
       define
       locale sub attribute, value string;
@@ -949,7 +949,7 @@ Feature: TypeQL Undefine Query
       | x                   |
       | label:abstract-name |
       | label:first-name    |
-    When typeql undefine
+    When typeql schema query
       """
       undefine abstract-name owns locale;
       """
@@ -964,7 +964,7 @@ Feature: TypeQL Undefine Query
 
 
   Scenario: removing a key ownership from a super attribute type also removes it from its subtypes
-    Given typeql define
+    Given typeql schema query
       """
       define
       name-id sub attribute, value long;
@@ -982,7 +982,7 @@ Feature: TypeQL Undefine Query
       | x                   |
       | label:abstract-name |
       | label:first-name    |
-    When typeql undefine
+    When typeql schema query
       """
       undefine abstract-name owns name-id;
       """
@@ -997,7 +997,7 @@ Feature: TypeQL Undefine Query
 
 
   Scenario: an attribute and its self-ownership can be removed simultaneously
-    Given typeql define
+    Given typeql schema query
       """
       define
       name owns name;
@@ -1005,7 +1005,7 @@ Feature: TypeQL Undefine Query
     Given transaction commits
 
     Given session opens transaction of type: write
-    When typeql undefine
+    When typeql schema query
       """
       undefine
       name owns name;
@@ -1021,7 +1021,7 @@ Feature: TypeQL Undefine Query
 
 
   Scenario: undefining the value type of an attribute throws an error
-    When typeql undefine; throws exception
+    When typeql schema query; throws exception
       """
       undefine name value string;
       """
@@ -1049,7 +1049,7 @@ Feature: TypeQL Undefine Query
     Given connection close all sessions
     Given connection open schema session for database: typedb
     Given session opens transaction of type: write
-    Then typeql undefine; throws exception
+    Then typeql schema query; throws exception
       """
       undefine name sub attribute;
       """
@@ -1069,7 +1069,7 @@ Feature: TypeQL Undefine Query
     When connection close all sessions
     When connection open schema session for database: typedb
     When session opens transaction of type: write
-    When typeql undefine
+    When typeql schema query
       """
       undefine name sub attribute;
       """
@@ -1101,7 +1101,7 @@ Feature: TypeQL Undefine Query
     Given uniquely identify answer concepts
       | x            |
       | label:person |
-    When typeql undefine
+    When typeql schema query
       """
       undefine person owns name;
       """
@@ -1119,28 +1119,28 @@ Feature: TypeQL Undefine Query
 
 
   Scenario: attempting to undefine an attribute ownership that was not actually owned to begin throws
-    When typeql undefine; throws exception
+    When typeql schema query; throws exception
       """
       undefine employment owns name;
       """
 
 
   Scenario: attempting to undefine an attribute ownership inherited from a parent throws
-    Given typeql define
+    Given typeql schema query
       """
       define child sub person;
       """
     Then transaction commits
 
     When session opens transaction of type: write
-    Then typeql undefine; throws exception
+    Then typeql schema query; throws exception
       """
       undefine child owns name;
       """
 
 
   Scenario: undefining a key ownership removes it
-    When typeql undefine
+    When typeql schema query
       """
       undefine person owns email;
       """
@@ -1155,14 +1155,14 @@ Feature: TypeQL Undefine Query
 
 
   Scenario: writing '@key' when undefining a key ownership is not allowed
-    Then typeql undefine; throws exception
+    Then typeql schema query; throws exception
       """
       undefine person owns email @key;
       """
 
 
   Scenario: writing '@key' when undefining an attribute ownership is not allowed
-    Then typeql undefine; throws exception
+    Then typeql schema query; throws exception
       """
       undefine person owns name @key;
       """
@@ -1190,7 +1190,7 @@ Feature: TypeQL Undefine Query
     Given connection close all sessions
     Given connection open schema session for database: typedb
     Given session opens transaction of type: write
-    When typeql undefine
+    When typeql schema query
       """
       undefine person owns name;
       """
@@ -1217,7 +1217,7 @@ Feature: TypeQL Undefine Query
     Given connection close all sessions
     Given connection open schema session for database: typedb
     Given session opens transaction of type: write
-    Then typeql undefine; throws exception
+    Then typeql schema query; throws exception
       """
       undefine person owns name;
       """
@@ -1236,7 +1236,7 @@ Feature: TypeQL Undefine Query
     Given connection close all sessions
     Given connection open schema session for database: typedb
     Given session opens transaction of type: write
-    Then typeql undefine; throws exception
+    Then typeql schema query; throws exception
       """
       undefine person owns email;
       """
@@ -1247,7 +1247,7 @@ Feature: TypeQL Undefine Query
   #########
 
   Scenario: undefining a rule removes it
-    Given typeql define
+    Given typeql schema query
       """
       define
       company sub entity, plays employment:employer;
@@ -1262,7 +1262,7 @@ Feature: TypeQL Undefine Query
 
     When session opens transaction of type: write
     Then rules contain: a-rule
-    When typeql undefine
+    When typeql schema query
       """
       undefine rule a-rule;
       """
@@ -1272,7 +1272,7 @@ Feature: TypeQL Undefine Query
     Then rules do not contain: a-rule
 
   Scenario: after undefining a rule, concepts previously inferred by that rule are no longer inferred
-    Given typeql define
+    Given typeql schema query
       """
       define
       rule samuel-email-rule:
@@ -1306,7 +1306,7 @@ Feature: TypeQL Undefine Query
     Given connection close all sessions
     Given connection open schema session for database: typedb
     Given session opens transaction of type: write
-    When typeql undefine
+    When typeql schema query
       """
       undefine rule samuel-email-rule;
       """
@@ -1325,7 +1325,7 @@ Feature: TypeQL Undefine Query
   # TODO enable when we can do reasoning in a schema write transaction
   @ignore
   Scenario: when undefining a rule, concepts inferred by that rule can still be retrieved until the next commit
-    Given typeql define
+    Given typeql schema query
       """
       define
       rule samuel-email-rule:
@@ -1358,7 +1358,7 @@ Feature: TypeQL Undefine Query
     Given uniquely identify answer concepts
       | n                 |
       | attr:name:Samuel  |
-    When typeql undefine
+    When typeql schema query
       """
       undefine rule samuel-email-rule;
       """
@@ -1374,7 +1374,7 @@ Feature: TypeQL Undefine Query
       | attr:name:Samuel  |
 
   Scenario: You cannot undefine a type if it is used in a rule
-    Given typeql define
+    Given typeql schema query
     """
     define
 
@@ -1391,14 +1391,14 @@ Feature: TypeQL Undefine Query
 
     Given session opens transaction of type: write
 
-    Given typeql undefine; throws exception
+    Given typeql schema query; throws exception
     """
     undefine
       type-to-undefine sub entity;
     """
 
   Scenario: You cannot undefine a type if it is used in a negation in a rule
-    Given typeql define
+    Given typeql schema query
     """
     define
     rel sub relation, relates rol;
@@ -1417,14 +1417,14 @@ Feature: TypeQL Undefine Query
 
     Given session opens transaction of type: write
 
-    Given typeql undefine; throws exception
+    Given typeql schema query; throws exception
     """
     undefine
       type-to-undefine sub entity;
     """
 
   Scenario: You cannot undefine a type if it is used in any disjunction in a rule
-    Given typeql define
+    Given typeql schema query
     """
     define
 
@@ -1442,14 +1442,14 @@ Feature: TypeQL Undefine Query
 
     Given session opens transaction of type: write
 
-    Given typeql undefine; throws exception
+    Given typeql schema query; throws exception
     """
     undefine
       type-to-undefine sub entity;
     """
 
   Scenario: You cannot undefine a type if it is used in the then of a rule
-    Given typeql define
+    Given typeql schema query
     """
     define
     name-to-undefine sub attribute, value string;
@@ -1466,7 +1466,7 @@ Feature: TypeQL Undefine Query
 
     Given session opens transaction of type: write
 
-    Given typeql undefine; throws exception
+    Given typeql schema query; throws exception
     """
     undefine
       name-to-undefine sub entity;
@@ -1496,7 +1496,7 @@ Feature: TypeQL Undefine Query
     Given connection close all sessions
     Given connection open schema session for database: typedb
     Given session opens transaction of type: write
-    Given typeql undefine
+    Given typeql schema query
       """
       undefine abstract-type abstract;
       """
@@ -1530,7 +1530,7 @@ Feature: TypeQL Undefine Query
 
 
   Scenario: undefining abstract on a type that is already non-abstract does nothing
-    When typeql undefine
+    When typeql schema query
       """
       undefine person abstract;
       """
@@ -1550,14 +1550,14 @@ Feature: TypeQL Undefine Query
 
 
   Scenario: an abstract type can be changed into a concrete type even if has an abstract child type
-    Given typeql define
+    Given typeql schema query
       """
       define sub-abstract-type sub abstract-type, abstract;
       """
     Given transaction commits
 
     Given session opens transaction of type: write
-    When typeql undefine
+    When typeql schema query
       """
       undefine abstract-type abstract;
       """
@@ -1577,7 +1577,7 @@ Feature: TypeQL Undefine Query
 
 
   Scenario: undefining abstract on an attribute type is allowed, even if that attribute type has an owner
-    Given typeql define
+    Given typeql schema query
       """
       define
       person abstract;
@@ -1587,7 +1587,7 @@ Feature: TypeQL Undefine Query
     Given transaction commits
 
     Given session opens transaction of type: write
-    When typeql undefine
+    When typeql schema query
       """
       undefine
       vehicle-registration abstract;
@@ -1628,7 +1628,7 @@ Feature: TypeQL Undefine Query
       | label:name      |
       | label:email     |
       | label:attribute |
-    When typeql undefine
+    When typeql schema query
       """
       undefine
       person sub entity, owns name;
@@ -1690,7 +1690,7 @@ Feature: TypeQL Undefine Query
       | label:employment:employee |
       | label:employment:employer |
       | label:relation:role       |
-    When typeql undefine
+    When typeql schema query
       """
       undefine
       person sub entity, owns name, owns email, plays employment:employee;

--- a/query/language/undefine.feature
+++ b/query/language/undefine.feature
@@ -164,7 +164,7 @@ Feature: TypeQL Undefine Query
       """
       match $x type child; $x plays employment:employee;
       """
-    Then answer size is: 0
+    Then answer size: 0
 
 
   Scenario: removing an attribute ownership from a super entity type also removes it from its subtypes
@@ -186,7 +186,7 @@ Feature: TypeQL Undefine Query
       """
       match $x type child; $x owns name;
       """
-    Then answer size is: 0
+    Then answer size: 0
 
 
   Scenario: removing a key ownership from a super entity type also removes it from its subtypes
@@ -208,7 +208,7 @@ Feature: TypeQL Undefine Query
       """
       match $x type child; $x owns email @key;
       """
-    Then answer size is: 0
+    Then answer size: 0
 
   Scenario: all existing instances of an entity type must be deleted in order to undefine it
     Given get answers of typeql read query
@@ -329,7 +329,7 @@ Feature: TypeQL Undefine Query
       """
       match contract-employment plays $x;
       """
-    Then answer size is: 0
+    Then answer size: 0
 
 
   Scenario: removing attribute ownerships from a super relation type also removes them from its subtypes
@@ -362,7 +362,7 @@ Feature: TypeQL Undefine Query
       """
       match $x owns start-date;
       """
-    Then answer size is: 0
+    Then answer size: 0
 
 
   Scenario: removing key ownerships from a super relation type also removes them from its subtypes
@@ -395,7 +395,7 @@ Feature: TypeQL Undefine Query
       """
       match $x owns employment-reference @key;
       """
-    Then answer size is: 0
+    Then answer size: 0
 
 
   Scenario: undefining a relation type throws on commit if it has existing instances
@@ -507,7 +507,7 @@ Feature: TypeQL Undefine Query
         $x plays $y;
 
       """
-    Then answer size is: 0
+    Then answer size: 0
 
 
   #############################
@@ -551,7 +551,7 @@ Feature: TypeQL Undefine Query
       """
       match $x plays employment:employee;
       """
-    Then answer size is: 0
+    Then answer size: 0
 
   #TODO: test is not working
   @ignore
@@ -595,7 +595,7 @@ Feature: TypeQL Undefine Query
       """
       match $x relates employee;
       """
-    Then answer size is: 0
+    Then answer size: 0
     Then typeql insert; throws exception
       """
       match
@@ -640,7 +640,7 @@ Feature: TypeQL Undefine Query
         $x plays $y;
 
       """
-    Then answer size is: 0
+    Then answer size: 0
 
 
   Scenario: removing a role throws an error if it is played by existing roleplayers in relations
@@ -775,7 +775,7 @@ Feature: TypeQL Undefine Query
       """
       match $x plays employment:employee;
       """
-    Then answer size is: 0
+    Then answer size: 0
     Then typeql insert; throws exception
       """
       match
@@ -852,7 +852,7 @@ Feature: TypeQL Undefine Query
       """
       match $x type <attr>;
       """
-    Given answer size is: 1
+    Given answer size: 1
     When typeql schema query
       """
       undefine <attr> sub attribute;
@@ -895,7 +895,7 @@ Feature: TypeQL Undefine Query
       """
       match $x isa email;
       """
-    Then answer size is: 1
+    Then answer size: 1
 
 
   Scenario: removing playable roles from a super attribute type also removes them from its subtypes
@@ -927,7 +927,7 @@ Feature: TypeQL Undefine Query
       """
       match first-name plays $x;
       """
-    Then answer size is: 0
+    Then answer size: 0
 
 
   Scenario: removing attribute ownerships from a super attribute type also removes them from its subtypes
@@ -960,7 +960,7 @@ Feature: TypeQL Undefine Query
       """
       match $x owns locale;
       """
-    Then answer size is: 0
+    Then answer size: 0
 
 
   Scenario: removing a key ownership from a super attribute type also removes it from its subtypes
@@ -993,7 +993,7 @@ Feature: TypeQL Undefine Query
       """
       match $x owns name-id @key;
       """
-    Then answer size is: 0
+    Then answer size: 0
 
 
   Scenario: an attribute and its self-ownership can be removed simultaneously
@@ -1115,7 +1115,7 @@ Feature: TypeQL Undefine Query
         $x type person;
 
       """
-    Then answer size is: 0
+    Then answer size: 0
 
 
   Scenario: attempting to undefine an attribute ownership that was not actually owned to begin throws
@@ -1151,7 +1151,7 @@ Feature: TypeQL Undefine Query
       """
       match $x owns email;
       """
-    Then answer size is: 0
+    Then answer size: 0
 
 
   Scenario: writing '@key' when undefining a key ownership is not allowed
@@ -1201,7 +1201,7 @@ Feature: TypeQL Undefine Query
       """
       match $x owns name;
       """
-    Then answer size is: 0
+    Then answer size: 0
 
 
   Scenario: removing an attribute ownership throws an error if it is owned by existing instances
@@ -1319,7 +1319,7 @@ Feature: TypeQL Undefine Query
         $x has name $n;
       get $n;
       """
-    Then answer size is: 0
+    Then answer size: 0
 
 
   # TODO enable when we can do reasoning in a schema write transaction
@@ -1484,7 +1484,7 @@ Feature: TypeQL Undefine Query
         not { $x abstract; };
 
       """
-    Given answer size is: 0
+    Given answer size: 0
     Given connection close all sessions
     Given connection open data session for database: typedb
     Given session opens transaction of type: write
@@ -1526,7 +1526,7 @@ Feature: TypeQL Undefine Query
       """
       match $x isa abstract-type;
       """
-    Then answer size is: 1
+    Then answer size: 1
 
 
   Scenario: undefining abstract on a type that is already non-abstract does nothing
@@ -1602,7 +1602,7 @@ Feature: TypeQL Undefine Query
         not { $x abstract; };
 
       """
-    Then answer size is: 1
+    Then answer size: 1
 
 
   ###################

--- a/query/language/update.feature
+++ b/query/language/update.feature
@@ -8,13 +8,13 @@ Feature: TypeQL Update Query
   Background: Open connection and create a simple extensible schema
     Given typedb starts
     Given connection opens with default authentication
-    Given connection has been opened
-    Given connection does not have any database
+    Given connection is open: true
+    Given connection has 0 databases
     Given connection create database: typedb
     Given connection open schema session for database: typedb
     Given session opens transaction of type: write
 
-    Given typeql define
+    Given typeql schema query
       """
       define
       person sub entity,
@@ -150,7 +150,7 @@ Feature: TypeQL Update Query
     Given connection close all sessions
     Given connection open schema session for database: typedb
     Given session opens transaction of type: write
-    Given typeql define
+    Given typeql schema query
       """
       define
       nameclass sub entity,

--- a/query/language/update.feature
+++ b/query/language/update.feature
@@ -203,7 +203,7 @@ Feature: TypeQL Update Query
       $p has name $n;
 
       """
-    Then answer size is: 0
+    Then answer size: 0
 
 
 

--- a/query/reasoner/attribute-attachment.feature
+++ b/query/reasoner/attribute-attachment.feature
@@ -62,14 +62,14 @@ Feature: Attribute Attachment Resolution
       """
       match $x isa person, has string-attribute $y;
       """
-    Then verify answer size is: 2
+    Then verify answer size: 2
     Then verify answers are sound
     Then verify answers are complete
     Given reasoning query
       """
       match $x isa string-attribute;
       """
-    Then verify answer size is: 1
+    Then verify answer size: 1
     Then verify answers are sound
     Then verify answers are complete
 
@@ -104,7 +104,7 @@ Feature: Attribute Attachment Resolution
       """
       match $x has string-attribute $y;
       """
-    Then verify answer size is: 3
+    Then verify answer size: 3
     Then verify answers are sound
     Then verify answers are complete
 
@@ -139,21 +139,21 @@ Feature: Attribute Attachment Resolution
       """
       match $x has retailer 'Ocado';
       """
-    Then verify answer size is: 2
+    Then verify answer size: 2
     Then verify answers are sound
     Then verify answers are complete
     Given reasoning query
       """
       match $x has retailer $r;
       """
-    Then verify answer size is: 4
+    Then verify answer size: 4
     Then verify answers are sound
     Then verify answers are complete
     Given reasoning query
       """
       match $x has retailer 'Tesco';
       """
-    Then verify answer size is: 2
+    Then verify answer size: 2
     Then verify answers are sound
     Then verify answers are complete
 
@@ -182,7 +182,7 @@ Feature: Attribute Attachment Resolution
       """
       match $x isa soft-drink, has retailer 'Ocado';
       """
-    Then verify answer size is: 2
+    Then verify answer size: 2
     Then verify answers are sound
     Then verify answers are complete
 
@@ -212,7 +212,7 @@ Feature: Attribute Attachment Resolution
       """
       match $x has retailer 'Tesco';
       """
-    Then verify answer size is: 3
+    Then verify answer size: 3
     Then verify answers are sound
     Then verify answers are complete
     Then verify answer set is equivalent for query
@@ -249,7 +249,7 @@ Feature: Attribute Attachment Resolution
       """
       match $x has retailer 'Tesco';
       """
-    Then verify answer size is: 1
+    Then verify answer size: 1
     Then verify answers are sound
     Then verify answers are complete
     Then verify answer set is equivalent for query
@@ -281,21 +281,21 @@ Feature: Attribute Attachment Resolution
       """
       match $x has age > 20;
       """
-    Then verify answer size is: 0
+    Then verify answer size: 0
     Then verify answers are sound
     Then verify answers are complete
     Given reasoning query
       """
       match $x has age > 5;
       """
-    Then verify answer size is: 1
+    Then verify answer size: 1
     Then verify answers are sound
     Then verify answers are complete
     Given reasoning query
       """
       match $x has age > 5; $x has age < 8;
       """
-    Then verify answer size is: 0
+    Then verify answer size: 0
     Then verify answers are sound
     Then verify answers are complete
 
@@ -326,7 +326,7 @@ Feature: Attribute Attachment Resolution
       """
       match $x has age-in-days $days;
       """
-    Then verify answer size is: 1
+    Then verify answer size: 1
     Then verify answers are sound
     Then verify answers are complete
 
@@ -338,7 +338,7 @@ Feature: Attribute Attachment Resolution
       get
         ?days;
       """
-    Then verify answer size is: 1
+    Then verify answer size: 1
     Then verify answer set is equivalent for query
       """
       match

--- a/query/reasoner/compound-queries.feature
+++ b/query/reasoner/compound-queries.feature
@@ -67,6 +67,6 @@ Feature: Compound Query Resolution
     # SOF | RET | PER | BSA |
     # SOF | NAM | SOF | RET |
     # SOF | RET | SOF | NAM |
-    Then verify answer size is: 9
+    Then verify answer size: 9
     Then verify answers are sound
     Then verify answers are complete

--- a/query/reasoner/concept-inequality.feature
+++ b/query/reasoner/concept-inequality.feature
@@ -93,7 +93,7 @@ Feature: Concept Inequality Resolution
       """
       match (state: $s) isa holds;
       """
-    Then verify answer size is: 1
+    Then verify answer size: 1
     Then verify answers are sound
     Then verify answers are complete
     Then verify answer set is equivalent for query
@@ -110,7 +110,7 @@ Feature: Concept Inequality Resolution
       """
     # materialised: [ab, ba, bc, cb]
     # inferred: [aa, ac, bb, ca, cc]
-    Then verify answer size is: 9
+    Then verify answer size: 9
     Then verify answers are sound
     Then verify answers are complete
     Given reasoning query
@@ -122,7 +122,7 @@ Feature: Concept Inequality Resolution
       """
     # materialised: [ab, ba, bc, cb]
     # inferred: [ac, ca]
-    Then verify answer size is: 6
+    Then verify answer size: 6
     Then verify answers are sound
     Then verify answers are complete
     # verify that the answer pairs to the previous query have distinct names within each pair
@@ -136,7 +136,7 @@ Feature: Concept Inequality Resolution
         not { $nx is $ny; };
       get $x, $y;
       """
-    Then verify answer size is: 6
+    Then verify answer size: 6
     Then verify answers are sound
     Then verify answers are complete
 
@@ -151,7 +151,7 @@ Feature: Concept Inequality Resolution
         $y has name 'c';
 
       """
-    Then verify answer size is: 2
+    Then verify answer size: 2
     Then verify answers are sound
     Then verify answers are complete
     # verify answers are [ac, bc]
@@ -164,7 +164,7 @@ Feature: Concept Inequality Resolution
         {$x has name 'a';} or {$x has name 'b';};
 
       """
-    Then verify answer size is: 2
+    Then verify answer size: 2
     Then verify answers are sound
     Then verify answers are complete
 
@@ -192,7 +192,7 @@ Feature: Concept Inequality Resolution
     # [aab, aac, aba, abc, aca, acb,
     #  bab, bac, bba, bbc, bca, bcb,
     #  cab, cac, cba, cbc, cca, ccb]
-    Then verify answer size is: 18
+    Then verify answer size: 18
     Then verify answers are sound
     Then verify answers are complete
     # verify that $y and $z always have distinct names
@@ -207,7 +207,7 @@ Feature: Concept Inequality Resolution
         not { $ny is $nz; };
       get $x, $y, $z;
       """
-    Then verify answer size is: 18
+    Then verify answer size: 18
     Then verify answers are sound
     Then verify answers are complete
 
@@ -232,7 +232,7 @@ Feature: Concept Inequality Resolution
         not { $x is $z; };
 
       """
-    Then verify answer size is: 18
+    Then verify answer size: 18
     Then verify answers are sound
     Then verify answers are complete
     # verify that $y and $z always have distinct names
@@ -247,7 +247,7 @@ Feature: Concept Inequality Resolution
         not { $nx is $nz; };
       get $x, $y, $z;
       """
-    Then verify answer size is: 18
+    Then verify answer size: 18
     Then verify answers are sound
     Then verify answers are complete
 
@@ -278,7 +278,7 @@ Feature: Concept Inequality Resolution
 
       """
     # For each of the [3] values of $x, there are 3^4 = 81 choices for {$y1, $z1, $y2, $z2}, for a total of 243
-    Then verify answer size is: 243
+    Then verify answer size: 243
     Then verify answers are sound
     Then verify answers are complete
     Given reasoning query
@@ -293,7 +293,7 @@ Feature: Concept Inequality Resolution
         not { $y2 is $z2; };
 
       """
-    Then verify answer size is: 108
+    Then verify answer size: 108
     # Each neq predicate reduces the answer size by 1/3, cutting it to 162, then 108
     Then verify answers are sound
     Then verify answers are complete
@@ -315,7 +315,7 @@ Feature: Concept Inequality Resolution
         not { $ny2 is $nz2; };
       get $x, $y1, $z1, $y2, $z2;
       """
-    Then verify answer size is: 108
+    Then verify answer size: 108
     Then verify answers are sound
     Then verify answers are complete
 
@@ -341,7 +341,7 @@ Feature: Concept Inequality Resolution
 
       """
     # There are 3^4 possible choices for the set {$x, $y, $z1, $z2}, for a total of 81
-    Then verify answer size is: 81
+    Then verify answer size: 81
     Then verify answers are sound
     Then verify answers are complete
     Given reasoning query
@@ -356,7 +356,7 @@ Feature: Concept Inequality Resolution
 
       """
     # Each neq predicate reduces the answer size by 1/3, cutting it to 54, then 36
-    Then verify answer size is: 36
+    Then verify answer size: 36
     Then verify answers are sound
     Then verify answers are complete
     # verify that $y1 and $z1 - as well as $y2 and $z2 - always have distinct names
@@ -376,7 +376,7 @@ Feature: Concept Inequality Resolution
         not { $ny is $nz2; };
       get $x, $y, $z1, $z2;
       """
-    Then verify answer size is: 36
+    Then verify answer size: 36
     Then verify answers are sound
     Then verify answers are complete
 
@@ -428,7 +428,7 @@ Feature: Concept Inequality Resolution
     # SOF | RET | PER | STA |
     # SOF | NAM | SOF | STA |
     # SOF | STA | SOF | NAM |
-    Then verify answer size is: 6
+    Then verify answer size: 6
     Then verify answers are sound
     Then verify answers are complete
 
@@ -488,6 +488,6 @@ Feature: Concept Inequality Resolution
       """
     # x      | value | type     |
     # Sprite | Tesco | retailer |
-    Then verify answer size is: 1
+    Then verify answer size: 1
     Then verify answers are sound
     Then verify answers are complete

--- a/query/reasoner/negation.feature
+++ b/query/reasoner/negation.feature
@@ -67,7 +67,7 @@ Feature: Negation Resolution
       """
       match $x isa person;
       """
-    Then verify answer size is: 5
+    Then verify answer size: 5
     Given reasoning query
       """
       match
@@ -77,7 +77,7 @@ Feature: Negation Resolution
         };
 
       """
-    Then verify answer size is: 3
+    Then verify answer size: 3
 
 
   Scenario: negation can check that an entity does not play any role in any relation
@@ -98,7 +98,7 @@ Feature: Negation Resolution
       """
       match $x isa person;
       """
-    Then verify answer size is: 5
+    Then verify answer size: 5
     Given reasoning query
       """
       match
@@ -108,7 +108,7 @@ Feature: Negation Resolution
         };
 
       """
-    Then verify answer size is: 3
+    Then verify answer size: 3
 
 
   Scenario: negation can check that an entity does not own any instance of a specific attribute type
@@ -126,7 +126,7 @@ Feature: Negation Resolution
       """
       match $x isa person;
       """
-    Then verify answer size is: 5
+    Then verify answer size: 5
     Given reasoning query
       """
       match
@@ -136,7 +136,7 @@ Feature: Negation Resolution
         };
 
       """
-    Then verify answer size is: 2
+    Then verify answer size: 2
 
 
   Scenario: negation can check that an entity does not own a particular attribute
@@ -154,7 +154,7 @@ Feature: Negation Resolution
       """
       match $x isa person;
       """
-    Then verify answer size is: 5
+    Then verify answer size: 5
     Given reasoning query
       """
       match
@@ -164,7 +164,7 @@ Feature: Negation Resolution
         };
 
       """
-    Then verify answer size is: 4
+    Then verify answer size: 4
 
 
   Scenario: negation can check that an entity owns an attribute which is not equal to a specific value
@@ -183,7 +183,7 @@ Feature: Negation Resolution
         not {$y 20;};
 
       """
-    Then verify answer size is: 1
+    Then verify answer size: 1
     Then verify answer set is equivalent for query
       """
       match
@@ -210,7 +210,7 @@ Feature: Negation Resolution
         not {$y isa name;};
 
       """
-    Then verify answer size is: 2
+    Then verify answer size: 2
     Then verify answer set is equivalent for query
       """
       match $x has age $y;
@@ -251,7 +251,7 @@ Feature: Negation Resolution
     # cbab, cbcb, cbcd, cdcb, cdcd, cdzd,
     # dcba, dcbc, dcdc, dcdz, dzdc, dzdz,
     # zdcb, zdcd, zdzd
-    Then verify answer size is: 24
+    Then verify answer size: 24
     Given reasoning query
       """
       match
@@ -262,7 +262,7 @@ Feature: Negation Resolution
 
       """
     # Eliminates (cdzd, zdzd)
-    Then verify answer size is: 22
+    Then verify answer size: 22
     Then verify answer set is equivalent for query
       """
       match
@@ -307,7 +307,7 @@ Feature: Negation Resolution
     # cba, cbc, cdc, cdz
     # dcb, dcd, dzd
     # zdc, zdz
-    Then verify answer size is: 14
+    Then verify answer size: 14
     Given reasoning query
       """
       match
@@ -318,7 +318,7 @@ Feature: Negation Resolution
 
       """
     # (d,z) is a friendship so we eliminate results where $b is 'd': these are (cdc, cdz, zdc, zdz)
-    Then verify answer size is: 10
+    Then verify answer size: 10
     Then verify answer set is equivalent for query
       """
       match
@@ -349,7 +349,7 @@ Feature: Negation Resolution
     # employee | PER |
     # role     | COM |
     # employer | COM |
-    Then verify answer size is: 4
+    Then verify answer size: 4
     Given reasoning query
       """
       match
@@ -357,7 +357,7 @@ Feature: Negation Resolution
         not {$r1 type relation:role;};
 
       """
-    Then verify answer size is: 2
+    Then verify answer size: 2
 
 
   Scenario: a negated statement with multiple properties can be re-written as a negation of multiple statements
@@ -376,7 +376,7 @@ Feature: Negation Resolution
       """
       match $x has attribute $r;
       """
-    Then verify answer size is: 8
+    Then verify answer size: 8
     Given reasoning query
       """
       match
@@ -386,7 +386,7 @@ Feature: Negation Resolution
         };
 
       """
-    Then verify answer size is: 6
+    Then verify answer size: 6
     Then verify answer set is equivalent for query
       """
       match
@@ -416,7 +416,7 @@ Feature: Negation Resolution
       """
       match $x has attribute $r;
       """
-    Then verify answer size is: 8
+    Then verify answer size: 8
     Given reasoning query
       """
       match
@@ -424,7 +424,7 @@ Feature: Negation Resolution
         not { $x isa company; };
 
       """
-    Then verify answer size is: 7
+    Then verify answer size: 7
     Given reasoning query
       """
       match
@@ -433,7 +433,7 @@ Feature: Negation Resolution
         not { $x has name "Tim"; };
 
       """
-    Then verify answer size is: 3
+    Then verify answer size: 3
     Given reasoning query
       """
       match
@@ -443,7 +443,7 @@ Feature: Negation Resolution
         not { $r 55; };
 
       """
-    Then verify answer size is: 2
+    Then verify answer size: 2
 
 
   Scenario: negation can exclude entities of specific types that play roles in a specific relation
@@ -471,7 +471,7 @@ Feature: Negation Resolution
       """
       match $x isa person;
       """
-    Then verify answer size is: 4
+    Then verify answer size: 4
     Given reasoning query
       """
       match
@@ -482,7 +482,7 @@ Feature: Negation Resolution
         };
 
       """
-    Then verify answer size is: 3
+    Then verify answer size: 3
 
 
   Scenario: when using negation to exclude entities of specific types, their subtypes are also excluded
@@ -516,7 +516,7 @@ Feature: Negation Resolution
         };
 
       """
-    Then verify answer size is: 2
+    Then verify answer size: 2
 
 
   Scenario: answers can be returned even if a statement in a conjunction in a negation is identical to a non-negated one
@@ -551,7 +551,7 @@ Feature: Negation Resolution
         };
 
       """
-    Then verify answer size is: 3
+    Then verify answer size: 3
 
 
   ##############################
@@ -594,7 +594,7 @@ Feature: Negation Resolution
         $area isa area;
 
       """
-    Then verify answer size is: 1
+    Then verify answer size: 1
     Given reasoning query
       """
       match
@@ -603,7 +603,7 @@ Feature: Negation Resolution
         not {(superior: $continent, subordinate: $area) isa location-hierarchy;};
 
       """
-    Then verify answer size is: 0
+    Then verify answer size: 0
     Then verify answers are sound
     Then verify answers are complete
 
@@ -675,7 +675,7 @@ Feature: Negation Resolution
         $x has index "aa";
 
       """
-    Then verify answer size is: 2
+    Then verify answer size: 2
     Then verify answer set is equivalent for query
       """
       match
@@ -715,14 +715,14 @@ Feature: Negation Resolution
       """
       match $x has name "Not Ten", has age 20;
       """
-    Then verify answer size is: 1
+    Then verify answer size: 1
     Then verify answers are sound
     Then verify answers are complete
     Given reasoning query
       """
       match $x has name "Not Ten", has age 10;
       """
-    Then verify answer size is: 0
+    Then verify answer size: 0
     Then verify answers are sound
     Then verify answers are complete
 
@@ -752,14 +752,14 @@ Feature: Negation Resolution
       """
       match $x isa person;
       """
-    Then verify answer size is: 3
+    Then verify answer size: 3
     Then verify answers are sound
     Then verify answers are complete
     Given reasoning query
       """
       match $x isa person, has name "No Age";
       """
-    Then verify answer size is: 1
+    Then verify answer size: 1
     Then verify answers are sound
     Then verify answers are complete
 
@@ -805,7 +805,7 @@ Feature: Negation Resolution
       """
       match $x isa company;
       """
-    Then verify answer size is: 4
+    Then verify answer size: 4
     Given reasoning query
       """
       match
@@ -814,7 +814,7 @@ Feature: Negation Resolution
 
       """
     # Should exclude both the company in France and the company with no country
-    Then verify answer size is: 2
+    Then verify answer size: 2
     Then verify answers are sound
     Then verify answers are complete
     Then verify answer set is equivalent for query
@@ -883,7 +883,7 @@ Feature: Negation Resolution
         };
 
       """
-    Then verify answer size is: 3
+    Then verify answer size: 3
     Then verify answer set is equivalent for query
       """
       match
@@ -990,7 +990,7 @@ Feature: Negation Resolution
       """
       match (diagnosed-fault: $flt, parent-session: $ts) isa diagnosis;
       """
-    Then verify answer size is: 0
+    Then verify answer size: 0
     Then verify answers are consistent across 5 executions
     Then verify answers are sound
     Then verify answers are complete
@@ -1065,7 +1065,7 @@ Feature: Negation Resolution
       """
       match (role-3: $x, role-4: $y) isa relation-4;
       """
-    Then verify answer size is: 11
+    Then verify answer size: 11
     Then verify answers are consistent across 5 executions
     Then verify answers are sound
     Then verify answers are complete
@@ -1147,7 +1147,7 @@ Feature: Negation Resolution
 
       """
     # aa is not linked to itself. ee, ff, gg are linked to each other, but not to aa. hh is not linked to anything
-    Then verify answer size is: 5
+    Then verify answer size: 5
     Then verify answers are sound
     Then verify answers are complete
     Then verify answer set is equivalent for query
@@ -1189,7 +1189,7 @@ Feature: Negation Resolution
         not { $r == "Ocado"; };
 
       """
-    Then verify answer size is: 0
+    Then verify answer size: 0
     Then verify answers are sound
     Then verify answers are complete
 
@@ -1220,7 +1220,7 @@ Feature: Negation Resolution
       """
       match $p isa person; not { ($p, $f) isa enemies; };
       """
-    Then verify answer size is: 0
+    Then verify answer size: 0
 #    TODO: Add a case with non-zero answers
 
 
@@ -1285,6 +1285,6 @@ Feature: Negation Resolution
       (from: $from, to: $to) isa reachable;
       get $from-name, $to-name;
       """
-    Then verify answer size is: 2
+    Then verify answer size: 2
     Then verify answers are sound
     Then verify answers are complete

--- a/query/reasoner/recursion.feature
+++ b/query/reasoner/recursion.feature
@@ -87,7 +87,7 @@ Feature: Recursion Resolution
       """
       match (subordinate: $x, superior: $y) isa big-location-hierarchy;
       """
-    Then verify answer size is: 1
+    Then verify answer size: 1
     Then verify answers are sound
     Then verify answers are complete
 
@@ -156,7 +156,7 @@ Feature: Recursion Resolution
       """
       match (role31: $x, role32: $y) isa relation3;
       """
-    Then verify answer size is: 1
+    Then verify answer size: 1
     Then verify answers are sound
     Then verify answers are complete
 
@@ -220,7 +220,7 @@ Feature: Recursion Resolution
       match (role31: $x, role32: $y) isa relation3;
       """
     # Each of the two material relation1 instances should infer a single relation3 via 1-to-2 and 2-to-3
-    Then verify answer size is: 2
+    Then verify answer size: 2
     Then verify answers are sound
     Then verify answers are complete
     Given reasoning query
@@ -228,7 +228,7 @@ Feature: Recursion Resolution
       match (role21: $x, role22: $y) isa relation2;
       """
     # Relation-3-to-2 should not make any additional inferences - it should merely assert that the relations exist
-    Then verify answer size is: 2
+    Then verify answer size: 2
     Then verify answers are sound
     Then verify answers are complete
 
@@ -264,7 +264,7 @@ Feature: Recursion Resolution
       """
       match $x isa dream; limit 10;
       """
-    Then verify answer size is: 10
+    Then verify answer size: 10
 
 
   # TODO: re-enable all steps when materialisation is possible (may be an infinite graph?) (#75)
@@ -354,14 +354,14 @@ Feature: Recursion Resolution
       """
       match $p isa pair, has name 'ff';
       """
-    Then verify answer size is: 16
+    Then verify answer size: 16
     Then verify answers are sound
     # Then verify answers are complete  # Not yet supported
     Given reasoning query
       """
       match $p isa pair;
       """
-    Then verify answer size is: 64
+    Then verify answer size: 64
     Then verify answers are sound
     # Then verify answers are complete  # Not yet supported
 
@@ -455,7 +455,7 @@ Feature: Recursion Resolution
         $x has index 'i';
       get $y;
       """
-    Then verify answer size is: 3
+    Then verify answer size: 3
     Then verify answers are sound
     Then verify answers are complete
     Then verify answer set is equivalent for query
@@ -530,7 +530,7 @@ Feature: Recursion Resolution
         $Y has name $name;
       get $Y, $name;
       """
-    Then verify answer size is: 3
+    Then verify answer size: 3
     Then verify answers are sound
     Then verify answers are complete
     Then verify answer set is equivalent for query
@@ -547,7 +547,7 @@ Feature: Recursion Resolution
         $X has name 'aa';
       get $Y;
       """
-    Then verify answer size is: 4
+    Then verify answer size: 4
     Then verify answers are sound
     Then verify answers are complete
     Then verify answer set is equivalent for query
@@ -561,7 +561,7 @@ Feature: Recursion Resolution
       """
       match (ancestor: $X, descendant: $Y) isa ancestorship;
       """
-    Then verify answer size is: 10
+    Then verify answer size: 10
     Then verify answers are sound
     Then verify answers are complete
     Then verify answer set is equivalent for query
@@ -580,7 +580,7 @@ Feature: Recursion Resolution
       """
       match ($X, $Y) isa ancestorship;
       """
-    Then verify answer size is: 20
+    Then verify answer size: 20
     Then verify answers are sound
     Then verify answers are complete
     Then verify answer set is equivalent for query
@@ -669,7 +669,7 @@ Feature: Recursion Resolution
         $Y has name $name;
       get $Y;
       """
-    Then verify answer size is: 2
+    Then verify answer size: 2
     Then verify answers are sound
     Then verify answers are complete
     Then verify answer set is equivalent for query
@@ -693,7 +693,7 @@ Feature: Recursion Resolution
         $Y has name 'd';
       get $X;
       """
-    Then verify answer size is: 3
+    Then verify answer size: 3
     Then verify answers are sound
     Then verify answers are complete
     Then verify answer set is equivalent for query
@@ -778,7 +778,7 @@ Feature: Recursion Resolution
         $x has name 'a';
       get $y;
       """
-    Then verify answer size is: 2
+    Then verify answer size: 2
     Then verify answers are sound
     Then verify answers are complete
     Then verify answer set is equivalent for query
@@ -855,7 +855,7 @@ Feature: Recursion Resolution
         $y has index 'a';
       get $x;
       """
-    Then verify answer size is: 1
+    Then verify answer size: 1
     Then verify answers are sound
     Then verify answers are complete
     Then verify answer set is equivalent for query
@@ -944,7 +944,7 @@ Feature: Recursion Resolution
       """
       match (from: $x, to: $y) isa reachable;
       """
-    Then verify answer size is: 7
+    Then verify answer size: 7
     Then verify answers are sound
     Then verify answers are complete
     Then verify answer set is equivalent for query
@@ -1020,7 +1020,7 @@ Feature: Recursion Resolution
         $x has index 'a';
       get $y;
       """
-    Then verify answer size is: 4
+    Then verify answer size: 4
     # Then verify answers are sound     # TODO: Runs out of memory on factory
     Then verify answers are complete
     Then verify answer set is equivalent for query
@@ -1097,7 +1097,7 @@ Feature: Recursion Resolution
         $x has name 'ann';
       get $y;
       """
-    Then verify answer size is: 3
+    Then verify answer size: 3
     Then verify answers are sound
     Then verify answers are complete
     Then verify answer set is equivalent for query
@@ -1205,7 +1205,7 @@ Feature: Recursion Resolution
         $x has name 'a';
       get $y;
       """
-    Then verify answer size is: 3
+    Then verify answer size: 3
     Then verify answers are sound
     Then verify answers are complete
     Then verify answer set is equivalent for query
@@ -1219,7 +1219,7 @@ Feature: Recursion Resolution
       """
       match (from: $x, to: $y) isa RevSG;
       """
-    Then verify answer size is: 11
+    Then verify answer size: 11
     Then verify answers are sound
     Then verify answers are complete
     Then verify answer set is equivalent for query
@@ -1397,7 +1397,7 @@ Feature: Recursion Resolution
         $x has index 'a0';
       get $y;
       """
-    Then verify answer size is: 5
+    Then verify answer size: 5
     Then verify answers are sound
     Then verify answers are complete
 
@@ -1602,7 +1602,7 @@ Feature: Recursion Resolution
         $x has index 'a0';
       get $y;
       """
-    Then verify answer size is: 60
+    Then verify answer size: 60
     Then verify answers are sound
     Then verify answers are complete
     Then verify answer set is equivalent for query
@@ -1752,7 +1752,7 @@ Feature: Recursion Resolution
         $x has index 'a';
       get $y;
       """
-    Then verify answer size is: 25
+    Then verify answer size: 25
     Then verify answers are sound
     Then verify answers are complete
 

--- a/query/reasoner/relation-inference.feature
+++ b/query/reasoner/relation-inference.feature
@@ -71,7 +71,7 @@ Feature: Relation Inference Resolution
         ($x) isa employment;
 
       """
-    Then verify answer size is: 2
+    Then verify answer size: 2
     Then verify answers are sound
     Then verify answers are complete
 
@@ -100,7 +100,7 @@ Feature: Relation Inference Resolution
         ($x) isa employment;
 
       """
-    Then verify answer size is: 1
+    Then verify answer size: 1
     Then verify answers are sound
     Then verify answers are complete
     Given reasoning query
@@ -110,7 +110,7 @@ Feature: Relation Inference Resolution
         ($x) isa employment;
 
       """
-    Then verify answer size is: 0
+    Then verify answer size: 0
     Then verify answers are sound
     Then verify answers are complete
 
@@ -145,7 +145,7 @@ Feature: Relation Inference Resolution
         $p 14.99 isa price;
 
       """
-    Then verify answer size is: 1
+    Then verify answer size: 1
     Then verify answers are sound
     Then verify answers are complete
 
@@ -180,7 +180,7 @@ Feature: Relation Inference Resolution
         ($x, employee: $p, employer: $y) isa employment;
 
       """
-    Then verify answer size is: 2
+    Then verify answer size: 2
     Then verify answers are sound
     Then verify answers are complete
 
@@ -219,7 +219,7 @@ Feature: Relation Inference Resolution
     # Adding a 2nd concept gives us 2 new relations - where each relation contains b, and one other concept (a or b).
     # Adding a 3rd concept gives us 3 new relations - where each relation contains c, and one other concept (a, b or c).
     # Generally, the total number of relations is the sum of all integers from 1 to n inclusive.
-    Then verify answer size is: 15
+    Then verify answer size: 15
     Then verify answers are sound
     Then verify answers are complete
 
@@ -250,7 +250,7 @@ Feature: Relation Inference Resolution
       match ($x, $y) isa friendship;
       """
     # Here there are n choices for x, and n choices for y, so the total answer size is n^2
-    Then verify answer size is: 25
+    Then verify answer size: 25
     Then verify answers are sound
     Then verify answers are complete
 
@@ -278,7 +278,7 @@ Feature: Relation Inference Resolution
       """
       match (employee: $x, employer: $x) isa employment;
       """
-    Then verify answer size is: 3
+    Then verify answer size: 3
     Then verify answers are sound
     Then verify answers are complete
 
@@ -304,7 +304,7 @@ Feature: Relation Inference Resolution
       """
       match (employee: $x, employer: $y) isa employment;
       """
-    Then verify answer size is: 1
+    Then verify answer size: 1
     Then verify answers are sound
     Then verify answers are complete
 
@@ -332,7 +332,7 @@ Feature: Relation Inference Resolution
       """
       match (employee: $x, employer: $x) isa employment;
       """
-    Then verify answer size is: 0
+    Then verify answer size: 0
     Then verify answers are sound
     Then verify answers are complete
 
@@ -397,7 +397,7 @@ Feature: Relation Inference Resolution
     # Coworker relations are symmetric, so (r2,p), (p,r1) and (r2,r1) are all coworker relations.
     # Applying the robot work rule a 2nd time, (r1,p) is a pet ownership and (p,r1) are coworkers,
     # therefore (r1,r1) is a reflexive coworker relation. So the answers are [p] and [r1].
-    Then verify answer size is: 2
+    Then verify answer size: 2
     Then verify answers are sound
     Then verify answers are complete
     Given reasoning query
@@ -413,7 +413,7 @@ Feature: Relation Inference Resolution
     # p  | r1 |
     # r2 | r1 |
     # r1 | r1 |
-    Then verify answer size is: 8
+    Then verify answer size: 8
     Then verify answers are sound
     Then verify answers are complete
 
@@ -447,7 +447,7 @@ Feature: Relation Inference Resolution
       """
       match $x isa location-hierarchy;
       """
-    Then verify answer size is: 3
+    Then verify answer size: 3
     Then verify answers are sound
     Then verify answers are complete
 
@@ -480,7 +480,7 @@ Feature: Relation Inference Resolution
       """
       match (subordinate: $x1, superior: $x2) isa location-hierarchy;
       """
-    Then verify answer size is: 6
+    Then verify answer size: 6
     Then verify answers are consistent across 5 executions
     Then verify answers are sound
     Then verify answers are complete
@@ -541,7 +541,7 @@ Feature: Relation Inference Resolution
       """
       match (subordinate: $x, superior: $y) isa location-hierarchy;
       """
-    Then verify answer size is: 1
+    Then verify answer size: 1
     Then verify answers are sound
     Then verify answers are complete
 
@@ -572,7 +572,7 @@ Feature: Relation Inference Resolution
       """
       match (employee: $x, employee: $y) isa employment;
       """
-    Then verify answer size is: 0
+    Then verify answer size: 0
     Then verify answers are sound
     Then verify answers are complete
 
@@ -599,7 +599,7 @@ Feature: Relation Inference Resolution
       """
       match (employee: $x) isa employment;
       """
-    Then verify answer size is: 1
+    Then verify answer size: 1
     Then verify answers are sound
     Then verify answers are complete
 
@@ -628,7 +628,7 @@ Feature: Relation Inference Resolution
       """
       match (friend: $a, friend: $b, friend: $c) isa friendship;
       """
-    Then verify answer size is: 6
+    Then verify answer size: 6
     Then verify answers are sound
     Then verify answers are complete
     Then verify answer set is equivalent for query
@@ -677,7 +677,7 @@ Feature: Relation Inference Resolution
 
       """
     # (a,a), (b,b), (c,c)
-    Then verify answer size is: 3
+    Then verify answer size: 3
     Then verify answers are sound
     Then verify answers are complete
     Given reasoning query
@@ -689,7 +689,7 @@ Feature: Relation Inference Resolution
         $n == 'a';
       get $x, $y;
       """
-    Then verify answer size is: 1
+    Then verify answer size: 1
     Then verify answers are sound
     Then verify answers are complete
     Then verify answer set is equivalent for query
@@ -738,7 +738,7 @@ Feature: Relation Inference Resolution
 
       """
     # $c in {'Turku Airport', 'Finland'}
-    Then verify answer size is: 2
+    Then verify answer size: 2
     Then verify answers are sound
     Then verify answers are complete
 
@@ -773,7 +773,7 @@ Feature: Relation Inference Resolution
         $b isa place, has name "Turku";
 
       """
-    Then verify answer size is: 1
+    Then verify answer size: 1
     Then verify answers are sound
     Then verify answers are complete
     Given reasoning query
@@ -786,7 +786,7 @@ Feature: Relation Inference Resolution
 
       """
     # (2 db relations + 1 inferred) x 2 for variable swap
-    Then verify answer size is: 6
+    Then verify answer size: 6
     Then verify answers are sound
     Then verify answers are complete
 
@@ -832,7 +832,7 @@ Feature: Relation Inference Resolution
     Then verify answers are complete
     # Despite there being more inferred relations, the answer size is still 6 (as in the previous scenario)
     # because the query is only interested in the related concepts, not in the relation instances themselves
-    Then verify answer size is: 6
+    Then verify answer size: 6
     Then verify answer set is equivalent for query
       """
       match ($a, $b);
@@ -880,7 +880,7 @@ Feature: Relation Inference Resolution
     # FIN | TUR | AIR |
     # FIN | AIR | FIN |
     # FIN | TUR | FIN |
-    Then verify answer size is: 12
+    Then verify answer size: 12
     Then verify answers are sound
     Then verify answers are complete
 
@@ -931,20 +931,20 @@ Feature: Relation Inference Resolution
       """
       match ($x) isa derivedRelation;
       """
-    Then verify answer size is: 2
+    Then verify answer size: 2
     Then verify answers are sound
     Then verify answers are complete
     Given reasoning query
       """
       match ($x) isa! derivedRelation;
       """
-    Then verify answer size is: 2
+    Then verify answer size: 2
     Then verify answers are sound
     Then verify answers are complete
     Given reasoning query
       """
       match ($x) isa directDerivedRelation;
       """
-    Then verify answer size is: 1
+    Then verify answer size: 1
     Then verify answers are sound
     Then verify answers are complete

--- a/query/reasoner/rule-interaction.feature
+++ b/query/reasoner/rule-interaction.feature
@@ -92,7 +92,7 @@ Feature: Rule Interaction Resolution
       """
       match $x isa person, has name $n, has tag "P";
       """
-    Then verify answer size is: 2
+    Then verify answer size: 2
     Then verify answers are sound
     Then verify answers are complete
 
@@ -145,7 +145,7 @@ Feature: Rule Interaction Resolution
       """
       match $x isa person, has name 'tracey';
       """
-    Then verify answer size is: 2
+    Then verify answer size: 2
     Then verify answers are sound
     Then verify answers are complete
 

--- a/query/reasoner/schema-queries.feature
+++ b/query/reasoner/schema-queries.feature
@@ -71,18 +71,18 @@ Feature: Schema Query Resolution (Variable Types)
       """
       match $x isa entity;
       """
-    Then verify answer size is: 3
+    Then verify answer size: 3
     Given reasoning query
       """
       match $x isa relation;
       """
     # (xx, yy, zz, xy, xz, yz)
-    Then verify answer size is: 6
+    Then verify answer size: 6
     Given reasoning query
       """
       match $x isa attribute;
       """
-    Then verify answer size is: 1
+    Then verify answer size: 1
     Given reasoning query
       """
       match $x isa $type;
@@ -91,7 +91,7 @@ Feature: Schema Query Resolution (Variable Types)
     # 6 friendships x 3 types of friendship {friendship, relation, thing}
     # 1 name x 3 types of name {name,attribute,thing}
     # = 9 + 18 + 3 = 30
-    Then verify answer size is: 30
+    Then verify answer size: 30
     Then verify answers are sound
     Then verify answers are complete
 
@@ -121,13 +121,13 @@ Feature: Schema Query Resolution (Variable Types)
       match ($u, $v) isa relation;
       """
     # (xx, yy, zz, xy, xz, yz, yx, zx, zy)
-    Then verify answer size is: 9
+    Then verify answer size: 9
     Given reasoning query
       """
       match ($u, $v) isa $type;
       """
     # 3 possible $u x 3 possible $v x 3 possible $type {friendship,relation,thing}
-    Then verify answer size is: 27
+    Then verify answer size: 27
     Then verify answers are sound
     Then verify answers are complete
 
@@ -178,7 +178,7 @@ Feature: Schema Query Resolution (Variable Types)
       """
       match $x isa relation;
       """
-    Then verify answer size is: 6
+    Then verify answer size: 6
     Then verify answers are sound
     Then verify answers are complete
     Given reasoning query
@@ -190,7 +190,7 @@ Feature: Schema Query Resolution (Variable Types)
       """
     # friendship can't have a contract... at least, not in this pristine test world
     # note: enforcing 'has contract' also eliminates 'relation' and 'thing' as possible types
-    Then verify answer size is: 4
+    Then verify answer size: 4
     Then verify answers are sound
     Then verify answers are complete
 
@@ -225,7 +225,7 @@ Feature: Schema Query Resolution (Variable Types)
       match $x isa relation;
       """
     # 3 friendships, 3 employments
-    Then verify answer size is: 6
+    Then verify answer size: 6
     Given reasoning query
       """
       match
@@ -234,7 +234,7 @@ Feature: Schema Query Resolution (Variable Types)
 
       """
     # 3 friendships, 3 employments, 6 relations
-    Then verify answer size is: 12
+    Then verify answer size: 12
     Then verify answers are sound
     Then verify answers are complete
 
@@ -285,7 +285,7 @@ Feature: Schema Query Resolution (Variable Types)
       """
       match $x isa relation;
       """
-    Then verify answer size is: 6
+    Then verify answer size: 6
     Then verify answers are sound
     Then verify answers are complete
     Given reasoning query
@@ -297,7 +297,7 @@ Feature: Schema Query Resolution (Variable Types)
       """
     # friendship can't be a documented-thing
     # note: enforcing 'plays legal-documentation:subject' also eliminates 'relation' and 'thing' as possible types
-    Then verify answer size is: 4
+    Then verify answer size: 4
     Then verify answers are sound
     Then verify answers are complete
 
@@ -334,7 +334,7 @@ Feature: Schema Query Resolution (Variable Types)
       """
       match (employee: $x, employer: $y) isa employment;
       """
-    Then verify answer size is: 3
+    Then verify answer size: 3
     Then verify answers are sound
     Then verify answers are complete
     Given reasoning query
@@ -345,7 +345,7 @@ Feature: Schema Query Resolution (Variable Types)
 
       """
     # 3 colonels * 5 supertypes of colonel (colonel, military-person, person, entity, thing)
-    Then verify answer size is: 15
+    Then verify answer size: 15
     Then verify answers are sound
     Then verify answers are complete
     Given reasoning query
@@ -357,7 +357,7 @@ Feature: Schema Query Resolution (Variable Types)
       """
     # (3 colonels * 5 supertypes of colonel * 1 company)
     # + (1 company * 3 supertypes of company * 3 colonels)
-    Then verify answer size is: 24
+    Then verify answer size: 24
     Then verify answers are sound
     Then verify answers are complete
 
@@ -404,7 +404,7 @@ Feature: Schema Query Resolution (Variable Types)
       """
     # All companies match when $type is company (or entity)
     # Query returns {ab,ac,ad,bc,bd,cd} and each of them with the variables flipped
-    Then verify answer size is: 12
+    Then verify answer size: 12
     Then verify answers are sound
     Then verify answers are complete
     Given reasoning query
@@ -425,7 +425,7 @@ Feature: Schema Query Resolution (Variable Types)
     # $type is forced to be either finance-company or retail-company, restricting the answer space
     # Query returns {ab,cd} and each of them with the variables flipped
     # Note: the two Captain Obvious rules should not affect the answer, as the concepts retain their original types
-    Then verify answer size is: 4
+    Then verify answer size: 4
     Then verify answers are sound
     Then verify answers are complete
 
@@ -452,7 +452,7 @@ Feature: Schema Query Resolution (Variable Types)
         $f type relation;
 
       """
-    Then verify answer size is: 1
+    Then verify answer size: 1
 
   Scenario: an inferred relation is correctly matched with a variable role type bound to the base role type
     Given reasoning schema
@@ -477,4 +477,4 @@ Feature: Schema Query Resolution (Variable Types)
         $role type relation:role;
 
       """
-    Then verify answer size is: 1
+    Then verify answer size: 1

--- a/query/reasoner/type-hierarchy.feature
+++ b/query/reasoner/type-hierarchy.feature
@@ -65,7 +65,7 @@ Feature: Type Hierarchy Resolution
 
       """
     # Answers are (actor:$x, writer:$z) and (actor:$x, writer:$v)
-    Then verify answer size is: 2
+    Then verify answer size: 2
     Then verify answers are sound
     Then verify answers are complete
     Given reasoning query
@@ -77,7 +77,7 @@ Feature: Type Hierarchy Resolution
         $y has name 'a';
 
       """
-    Then verify answer size is: 2
+    Then verify answer size: 2
     Then verify answers are sound
     Then verify answers are complete
     Given reasoning query
@@ -89,7 +89,7 @@ Feature: Type Hierarchy Resolution
 
       """
     # Answer is (actor:$x, writer:$v) ONLY
-    Then verify answer size is: 1
+    Then verify answer size: 1
     Then verify answers are sound
     Then verify answers are complete
     Given reasoning query
@@ -101,7 +101,7 @@ Feature: Type Hierarchy Resolution
         $y has name 'a';
 
       """
-    Then verify answer size is: 1
+    Then verify answer size: 1
     Then verify answers are sound
     Then verify answers are complete
     Given reasoning query
@@ -113,7 +113,7 @@ Feature: Type Hierarchy Resolution
 
       """
     # Answers are (actor:$x, writer:$z) and (actor:$x, writer:$v)
-    Then verify answer size is: 2
+    Then verify answer size: 2
     Then verify answers are sound
     Then verify answers are complete
     Given reasoning query
@@ -125,7 +125,7 @@ Feature: Type Hierarchy Resolution
         $y has name 'a';
 
       """
-    Then verify answer size is: 2
+    Then verify answer size: 2
     Then verify answers are sound
     Then verify answers are complete
 
@@ -168,13 +168,13 @@ Feature: Type Hierarchy Resolution
       """
       match (child: $x, father: $y) isa large-family;
       """
-    Then verify answer size is: 0
+    Then verify answer size: 0
     # Matching two siblings when only one is present
     Given reasoning query
       """
       match (mother: $x, father: $y) isa large-family;
       """
-    Then verify answer size is: 0
+    Then verify answer size: 0
     Then verify answers are sound
     Then verify answers are complete
 
@@ -223,7 +223,7 @@ Feature: Type Hierarchy Resolution
       """
       match (scifi-writer:$x, scifi-actor:$y) isa film-production;
       """
-    Then verify answer size is: 1
+    Then verify answer size: 1
     Then verify answers are sound
     Then verify answers are complete
 
@@ -272,7 +272,7 @@ Feature: Type Hierarchy Resolution
       """
       match (writer:$x, actor:$y) isa scifi-production;
       """
-    Then verify answer size is: 1
+    Then verify answer size: 1
     Then verify answers are sound
     Then verify answers are complete
 
@@ -321,7 +321,7 @@ Feature: Type Hierarchy Resolution
       """
       match (writer:$x, actor:$y) isa film-production;
       """
-    Then verify answer size is: 1
+    Then verify answer size: 1
     Then verify answers are sound
     Then verify answers are complete
 
@@ -390,7 +390,7 @@ Feature: Type Hierarchy Resolution
 
       """
     # Answers are (actor:$x, writer:$z) and (actor:$x, writer:$v)
-    Then verify answer size is: 2
+    Then verify answer size: 2
     Then verify answers are sound
     Then verify answers are complete
     Given reasoning query
@@ -402,7 +402,7 @@ Feature: Type Hierarchy Resolution
         $y has name 'a';
 
       """
-    Then verify answer size is: 2
+    Then verify answer size: 2
     Then verify answers are sound
     Then verify answers are complete
     Given reasoning query
@@ -414,7 +414,7 @@ Feature: Type Hierarchy Resolution
 
       """
     # Answer is (actor:$x, writer:$v) ONLY
-    Then verify answer size is: 1
+    Then verify answer size: 1
     Then verify answers are sound
     Then verify answers are complete
     Given reasoning query
@@ -426,7 +426,7 @@ Feature: Type Hierarchy Resolution
         $y has name 'a';
 
       """
-    Then verify answer size is: 1
+    Then verify answer size: 1
     Then verify answers are sound
     Then verify answers are complete
     Given reasoning query
@@ -438,7 +438,7 @@ Feature: Type Hierarchy Resolution
 
       """
     # Answers are (actor:$x, writer:$z) and (actor:$x, writer:$v)
-    Then verify answer size is: 2
+    Then verify answer size: 2
     Then verify answers are sound
     Then verify answers are complete
     Given reasoning query
@@ -450,7 +450,7 @@ Feature: Type Hierarchy Resolution
         $y has name 'a';
 
       """
-    Then verify answer size is: 2
+    Then verify answer size: 2
     Then verify answers are sound
     Then verify answers are complete
 
@@ -498,7 +498,7 @@ Feature: Type Hierarchy Resolution
       """
       match (home-owner: $x, resident: $y) isa residence;
       """
-    Then verify answer size is: 1
+    Then verify answer size: 1
     Then verify answers are sound
     Then verify answers are complete
     Given reasoning query
@@ -508,6 +508,6 @@ Feature: Type Hierarchy Resolution
         (parent-home-owner: $x, child-resident: $y) isa family-residence;
 
       """
-    Then verify answer size is: 1
+    Then verify answer size: 1
     Then verify answers are sound
     Then verify answers are complete

--- a/query/reasoner/value-predicate.feature
+++ b/query/reasoner/value-predicate.feature
@@ -60,7 +60,7 @@ Feature: Value Predicate Resolution
       """
       match $x has is-old $r;
       """
-    Then verify answer size is: 1
+    Then verify answer size: 1
     Then verify answers are sound
     Then verify answers are complete
 
@@ -90,7 +90,7 @@ Feature: Value Predicate Resolution
         $n <op> 1667;
 
       """
-    Then verify answer size is: <answer-size>
+    Then verify answer size: <answer-size>
     Then verify answers are sound
     Then verify answers are complete
 
@@ -129,7 +129,7 @@ Feature: Value Predicate Resolution
         $m <op> $n;
 
       """
-    Then verify answer size is: <answer-size>
+    Then verify answer size: <answer-size>
     Then verify answers are sound
     Then verify answers are complete
 
@@ -170,7 +170,7 @@ Feature: Value Predicate Resolution
         $n <op> 1667;
 
       """
-    Then verify answer size is: <answer-size>
+    Then verify answer size: <answer-size>
     Then verify answers are sound
     Then verify answers are complete
 
@@ -221,7 +221,7 @@ Feature: Value Predicate Resolution
     # x     | r     |
     # Fanta | Tesco |
     # Tango | Tesco |
-    Then verify answer size is: 2
+    Then verify answer size: 2
     Then verify answers are sound
     Then verify answers are complete
 
@@ -263,7 +263,7 @@ Feature: Value Predicate Resolution
     # x     | r     |
     # Fanta | Ocado |
     # Tango | Ocado |
-    Then verify answer size is: 2
+    Then verify answer size: 2
     Then verify answers are sound
     Then verify answers are complete
 
@@ -304,7 +304,7 @@ Feature: Value Predicate Resolution
         $rx contains "land";
 
       """
-    Then verify answer size is: 2
+    Then verify answer size: 2
     Then verify answers are sound
     Then verify answers are complete
 
@@ -357,7 +357,7 @@ Feature: Value Predicate Resolution
     # Fanta | Poundland | Fanta | Poundland |
     # Tango | Iceland   | Tango | Iceland   |
     # Tango | Poundland | Tango | Poundland |
-    Then verify answer size is: 8
+    Then verify answer size: 8
     Then verify answers are sound
     Then verify answers are complete
 
@@ -419,7 +419,7 @@ Feature: Value Predicate Resolution
     # Tango | Londis    | Tango | Poundland |
     # Fanta | Londis    | Fanta | Iceland   |
     # Tango | Londis    | Tango | Iceland   |
-    Then verify answer size is: 16
+    Then verify answer size: 16
     Then verify answers are sound
     Then verify answers are complete
 
@@ -460,7 +460,7 @@ Feature: Value Predicate Resolution
     # x     | r     |
     # Fanta | Tesco |
     # Tango | Tesco |
-    Then verify answer size is: 2
+    Then verify answer size: 2
     Then verify answers are sound
     Then verify answers are complete
     Given reasoning query
@@ -470,7 +470,7 @@ Feature: Value Predicate Resolution
         not { $r == "Ocado"; };
 
       """
-    Then verify answer size is: 2
+    Then verify answer size: 2
     Then verify answers are sound
     Then verify answers are complete
 
@@ -511,7 +511,7 @@ Feature: Value Predicate Resolution
     # x     | r     |
     # Fanta | Ocado |
     # Tango | Ocado |
-    Then verify answer size is: 2
+    Then verify answer size: 2
     Then verify answers are sound
     Then verify answers are complete
     Given reasoning query
@@ -521,7 +521,7 @@ Feature: Value Predicate Resolution
         not { $r != "Ocado"; };
 
       """
-    Then verify answer size is: 2
+    Then verify answer size: 2
     Then verify answers are sound
     Then verify answers are complete
 
@@ -565,7 +565,7 @@ Feature: Value Predicate Resolution
     # x     | r     |
     # Fanta | Tesco |
     # Tango | Tesco |
-    Then verify answer size is: 2
+    Then verify answer size: 2
     Then verify answers are sound
     Then verify answers are complete
 
@@ -612,7 +612,7 @@ Feature: Value Predicate Resolution
     # SOF | RET | PER | BSA |
     # SOF | NAM | SOF | RET |
     # SOF | RET | SOF | NAM |
-    Then verify answer size is: 6
+    Then verify answer size: 6
     Then verify answers are sound
     Then verify answers are complete
 
@@ -683,7 +683,7 @@ Feature: Value Predicate Resolution
         ($x, item: $y) isa price-classification;
 
       """
-    Then verify answer size is: 2
+    Then verify answer size: 2
     Then verify answers are sound
     Then verify answers are complete
     Given reasoning query
@@ -693,7 +693,7 @@ Feature: Value Predicate Resolution
         ($x, item: $y) isa price-classification;
 
       """
-    Then verify answer size is: 1
+    Then verify answer size: 1
     Then verify answers are sound
     Then verify answers are complete
     Given reasoning query
@@ -703,7 +703,7 @@ Feature: Value Predicate Resolution
         ($x, item: $y) isa price-classification;
 
       """
-    Then verify answer size is: 1
+    Then verify answer size: 1
     Then verify answers are sound
     Then verify answers are complete
     Given reasoning query
@@ -713,7 +713,7 @@ Feature: Value Predicate Resolution
         ($x, item: $y) isa price-classification;
 
       """
-    Then verify answer size is: 1
+    Then verify answer size: 1
     Then verify answers are sound
     Then verify answers are complete
     Given reasoning query
@@ -724,7 +724,7 @@ Feature: Value Predicate Resolution
 
       """
     # sum of all previous answers
-    Then verify answer size is: 5
+    Then verify answer size: 5
     Then verify answers are sound
     Then verify answers are complete
 
@@ -785,6 +785,6 @@ Feature: Value Predicate Resolution
       match (predecessor:$x1, successor:$x2) isa message-succession;
       """
     # the (n-1)th triangle number, where n is the number of replies to the first post
-    Then verify answer size is: 10
+    Then verify answer size: 10
     Then verify answers are sound
     Then verify answers are complete

--- a/query/reasoner/variable-roles.feature
+++ b/query/reasoner/variable-roles.feature
@@ -128,7 +128,7 @@ Feature: Variable Role Resolution
       """
       match (role1: $a, role2: $b) isa binary-base;
       """
-    Then verify answer size is: 9
+    Then verify answer size: 9
     Then verify answers are sound
     Then verify answers are complete
     Given reasoning query
@@ -136,7 +136,7 @@ Feature: Variable Role Resolution
       match (role1: $a, $r1: $b) isa binary-base;
       """
     # $r1 in {role, role2} (2 options => double answer size)
-    Then verify answer size is: 18
+    Then verify answer size: 18
     Then verify answers are sound
     Then verify answers are complete
 
@@ -147,7 +147,7 @@ Feature: Variable Role Resolution
       """
       match (role1: $a, $r1: $b) isa binary-base;
       """
-    Then verify answer size is: 18
+    Then verify answer size: 18
     Then verify answers are sound
     Then verify answers are complete
     # This query should be equivalent to the one above
@@ -158,7 +158,7 @@ Feature: Variable Role Resolution
         $r1 type binary-base:role1;
       get $a, $b, $r2;
       """
-    Then verify answer size is: 18
+    Then verify answer size: 18
     Then verify answers are sound
     Then verify answers are complete
 
@@ -169,7 +169,7 @@ Feature: Variable Role Resolution
       """
       match (role1: $a, role2: $b) isa binary-base;
       """
-    Then verify answer size is: 9
+    Then verify answer size: 9
     Then verify answers are sound
     Then verify answers are complete
     Given reasoning query
@@ -177,7 +177,7 @@ Feature: Variable Role Resolution
       match (role: $a, $r1: $b) isa binary-base;
       """
     # $r1 in {role, role1, role2} (3 options => triple answer size)
-    Then verify answer size is: 27
+    Then verify answer size: 27
     Then verify answers are sound
     Then verify answers are complete
 
@@ -188,7 +188,7 @@ Feature: Variable Role Resolution
       """
       match (role: $a, $r1: $b) isa binary-base;
       """
-    Then verify answer size is: 27
+    Then verify answer size: 27
     Then verify answers are sound
     Then verify answers are complete
     # This query should be equivalent to the one above
@@ -199,7 +199,7 @@ Feature: Variable Role Resolution
         $r1 type relation:role;
       get $a, $b, $r2;
       """
-    Then verify answer size is: 27
+    Then verify answer size: 27
     Then verify answers are sound
     Then verify answers are complete
 
@@ -210,7 +210,7 @@ Feature: Variable Role Resolution
       """
       match (role: $a, $r1: $b) isa binary-base;
       """
-    Then verify answer size is: 27
+    Then verify answer size: 27
     Then verify answers are sound
     Then verify answers are complete
     # This query should be equivalent to the one above
@@ -221,7 +221,7 @@ Feature: Variable Role Resolution
         $r1 sub relation:role;
       get $a, $b, $r2;
       """
-    Then verify answer size is: 27
+    Then verify answer size: 27
     Then verify answers are sound
     Then verify answers are complete
 
@@ -237,7 +237,7 @@ Feature: Variable Role Resolution
 
       """
     # $r1 must be 'role' and $r2 must be 'role2'
-    Then verify answer size is: 9
+    Then verify answer size: 9
     Then verify answers are sound
     Then verify answers are complete
     # This query is equivalent to the one above
@@ -248,7 +248,7 @@ Feature: Variable Role Resolution
         $r2 type binary-base:role2;
 
       """
-    Then verify answer size is: 9
+    Then verify answer size: 9
     Then verify answers are sound
     Then verify answers are complete
 
@@ -259,7 +259,7 @@ Feature: Variable Role Resolution
       """
       match (role1: $a, role2: $b) isa binary-base;
       """
-    Then verify answer size is: 9
+    Then verify answer size: 9
     Then verify answers are sound
     Then verify answers are complete
     Given reasoning query
@@ -274,7 +274,7 @@ Feature: Variable Role Resolution
     # role1 | role2 |
     # role2 | role  |
     # role2 | role1 |
-    Then verify answer size is: 63
+    Then verify answer size: 63
     Then verify answers are sound
     Then verify answers are complete
 
@@ -334,13 +334,13 @@ Feature: Variable Role Resolution
 
       """
     # This query is equivalent to matching ($r2: $a2, $r3: $a3) isa binary-base, as role1 and $a1 each have only 1 value
-    Then verify answer size is: 63
+    Then verify answer size: 63
     Given reasoning query
       """
       match (ternary-role1: $a1, $r2: $a2, $r3: $a3) isa ternary-base;
       """
     # Now the bound role 'role1' is in {a, b, c}, tripling the answer size
-    Then verify answer size is: 189
+    Then verify answer size: 189
     Given reasoning query
       """
       match ($r1: $a1, $r2: $a2, $r3: $a3) isa ternary-base;
@@ -359,7 +359,7 @@ Feature: Variable Role Resolution
     # For each pattern, we have one possible match per ternary-base relation
     # and there are 27 ternary-base relations in the knowledge graph (including both material and inferred)
     # giving an answer size of 34 * 27 = 918
-    Then verify answer size is: 918
+    Then verify answer size: 918
 
 
   Scenario: variable roles are correctly mapped to answers for a quaternary relation with 3 possible roleplayers
@@ -371,13 +371,13 @@ Feature: Variable Role Resolution
 
       """
     # This query is equivalent to matching ($r2: $a2, $r3: $a3, $r4: $a4) isa ternary-base
-    Then verify answer size is: 918
+    Then verify answer size: 918
     Given reasoning query
       """
       match (quat-role1: $a1, $r2: $a2, $r3: $a3, $r4: $a4) isa quaternary-base;
       """
     # Now the bound role 'role1' is in {a, b, c}, tripling the answer size
-    Then verify answer size is: 2754
+    Then verify answer size: 2754
     Given reasoning query
       """
       match ($r1: $a1, $r2: $a2, $r3: $a3, $r4: $a4) isa quaternary-base;
@@ -393,7 +393,7 @@ Feature: Variable Role Resolution
     # For each pattern, we have one possible match per quaternary-base relation
     # and there are 81 quaternary-base relations in the knowledge graph (including both material and inferred)
     # giving an answer size of 209 * 81 = 16929
-    Then verify answer size is: 16929
+    Then verify answer size: 16929
 
 
   # Note: This test uses the sub-relation 'quaternary' while the others use the super-relations '{n}-ary-base'.
@@ -407,13 +407,13 @@ Feature: Variable Role Resolution
 
       """
     # This query is equivalent to matching ($r2: $a2, $r3: $a3, $r4: $a4) isa ternary
-    Then verify answer size is: 272
+    Then verify answer size: 272
     Given reasoning query
       """
       match (quat-role1: $a1, $r2: $a2, $r3: $a3, $r4: $a4) isa quaternary;
       """
     # Now the bound role 'role1' is in {a, b}, doubling the answer size
-    Then verify answer size is: 544
+    Then verify answer size: 544
     Given reasoning query
       """
       match ($r1: $a1, $r2: $a2, $r3: $a3, $r4: $a4) isa quaternary;
@@ -422,4 +422,4 @@ Feature: Variable Role Resolution
     # For each pattern, we have one possible match per quaternary relation
     # and there are 16 quaternary relations in the knowledge graph (including both material and inferred)
     # giving an answer size of 209 * 16 = 3344
-    Then verify answer size is: 3344
+    Then verify answer size: 3344


### PR DESCRIPTION
## Usage and product changes
We reimagine driver BDDs in 3.0 to concentrate on the drivers' API testing instead of recovering the server's validations for each client.

The goals are:
* reduce the amount of time spent on driver testing without significant benefits (-> reduce CI costs and mitigate CI configuration);
* make sure that all the drivers implement the required features in a similar fashion;
* make the process of developing and maintaining driver BDDs (both declarations and implementations) faster and lighter.

## Implementation
The updated driver BDDs use the updated step declarations from TypeDB 3.0 server but also introduce special steps relevant only to clients to avoid the need to reimplement complex parsing algorithms in different languages.

It's expected that all the drivers maintained by TypeDB cover the following BDD packages:
* connection (mostly for "exotic" cases of a small amount);
* driver (aims to cover **all** possible API calls that should be implemented for each driver).