### PR TITLE
3.0 Driver fetch tests

### DIFF
--- a/connection/database.feature
+++ b/connection/database.feature
@@ -21,7 +21,6 @@ Feature: Connection Database
       | cAn-be_Like-that_WITH-a_pretty-looooooooooooong_name-and·even‿a·smile |
       | 資料庫                                                                   |
 
-
   Scenario: create many databases
     When connection create databases:
       | alice   |
@@ -62,6 +61,10 @@ Feature: Connection Database
     Then connection create database: !; fails
     Then connection create database: ...; fails
     Then connection create database: ·‿·; fails
+
+    # TODO: Merge it with the regular "cannot create database with an incorrect name" after fixing https://github.com/typedb/typedb-driver/issues/699
+  @ignore-typedb-driver-java
+  Scenario: cannot create database with an emoji
     Then connection create database: 😎; fails
     Then connection create database: my😎database; fails
 
@@ -149,4 +152,3 @@ Feature: Connection Database
     Then transaction commits
     Then connection delete database: typedb
     Then connection does not have database: typedb
-

--- a/driver/driver.feature
+++ b/driver/driver.feature
@@ -30,7 +30,7 @@ Feature: TypeDB Driver
 
   Scenario: Driver can connect after an unsuccessful connection attempt
     When connection closes
-    When connection opens with a wrong port; fails with a message containing: "connect error"
+    When connection opens with a wrong port; fails with a message containing: "address"
     Then connection is open: false
     When connection opens with a wrong host; fails with a message containing: "failed to lookup address information"
     Then connection is open: false
@@ -358,7 +358,7 @@ Feature: TypeDB Driver
       """
     Then answer type is: ok
     Then answer type is not: concept rows
-    Then answer type is not: concept trees
+    Then answer type is not: concept documents
     Then answer unwraps as ok
     Then transaction commits
 
@@ -376,7 +376,7 @@ Feature: TypeDB Driver
       """
     Then answer type is: concept rows
     Then answer type is not: ok
-    Then answer type is not: concept trees
+    Then answer type is not: concept documents
     Then answer unwraps as concept rows
     Then answer query type is: read
     Then answer query type is not: schema
@@ -393,7 +393,7 @@ Feature: TypeDB Driver
       """
     Then answer type is: concept rows
     Then answer type is not: ok
-    Then answer type is not: concept trees
+    Then answer type is not: concept documents
     Then answer query type is: read
     Then answer query type is not: schema
     Then answer query type is not: write
@@ -416,7 +416,7 @@ Feature: TypeDB Driver
       """
     Then answer type is: concept rows
     Then answer type is not: ok
-    Then answer type is not: concept trees
+    Then answer type is not: concept documents
     Then answer query type is: read
     Then answer query type is not: schema
     Then answer query type is not: write
@@ -441,7 +441,7 @@ Feature: TypeDB Driver
       """
     Then answer type is: concept rows
     Then answer type is not: ok
-    Then answer type is not: concept trees
+    Then answer type is not: concept documents
     Then answer query type is: read
     Then answer query type is not: schema
     Then answer query type is not: write
@@ -464,7 +464,7 @@ Feature: TypeDB Driver
       """
     Then answer type is: concept rows
     Then answer type is not: ok
-    Then answer type is not: concept trees
+    Then answer type is not: concept documents
     Then answer size is: 0
 
     When transaction closes
@@ -475,7 +475,7 @@ Feature: TypeDB Driver
       """
     Then answer type is: concept rows
     Then answer type is not: ok
-    Then answer type is not: concept trees
+    Then answer type is not: concept documents
     Then answer query type is: write
     Then answer query type is not: schema
     Then answer query type is not: read
@@ -491,7 +491,7 @@ Feature: TypeDB Driver
       """
     Then answer type is: concept rows
     Then answer type is not: ok
-    Then answer type is not: concept trees
+    Then answer type is not: concept documents
     Then answer query type is: read
     Then answer query type is not: schema
     Then answer query type is not: write
@@ -512,8 +512,8 @@ Feature: TypeDB Driver
   #Scenario: Driver processes concept row query answers with value groups correctly
 
 
-  # TODO: Implement concept trees checks
-  #Scenario: Driver processes concept tree query answers correctly
+  # TODO: Implement concept documents checks
+  #Scenario: Driver processes concept document query answers correctly
 
 
   Scenario: Driver processes query errors correctly
@@ -670,6 +670,7 @@ Feature: TypeDB Driver
     Then answer get row(0) get variable(p) is attribute: false
 
     Then answer get row(0) get variable(p) as entity type
+    Then answer get row(0) get variable(p) get label: person
     Then answer get row(0) get type(p) get label: person
     Then answer get row(0) get entity type(p) get label: person
 
@@ -700,6 +701,7 @@ Feature: TypeDB Driver
     Then answer get row(0) get variable(p) is attribute: false
 
     Then answer get row(0) get variable(p) as relation type
+    Then answer get row(0) get variable(p) get label: parentship
     Then answer get row(0) get type(p) get label: parentship
     Then answer get row(0) get relation type(p) get label: parentship
 
@@ -730,6 +732,7 @@ Feature: TypeDB Driver
     Then answer get row(0) get variable(p) is attribute: false
 
     Then answer get row(0) get variable(p) as role type
+    Then answer get row(0) get variable(p) get label: parentship:parent
     Then answer get row(0) get type(p) get label: parentship:parent
     Then answer get row(0) get role type(p) get label: parentship:parent
 
@@ -760,6 +763,7 @@ Feature: TypeDB Driver
     Then answer get row(0) get variable(a) is attribute: false
 
     Then answer get row(0) get variable(a) as attribute type
+    Then answer get row(0) get variable(a) get label: untyped
     Then answer get row(0) get type(a) get label: untyped
     Then answer get row(0) get attribute type(a) get label: untyped
 
@@ -803,6 +807,7 @@ Feature: TypeDB Driver
     Then answer get row(0) get variable(a) is attribute: false
 
     Then answer get row(0) get variable(a) as attribute type
+    Then answer get row(0) get variable(a) get label: typed
     Then answer get row(0) get type(a) get label: typed
     Then answer get row(0) get attribute type(a) get label: typed
 
@@ -872,6 +877,7 @@ Feature: TypeDB Driver
     Then answer get row(0) get variable(a) is attribute: false
 
     Then answer get row(0) get variable(a) as attribute type
+    Then answer get row(0) get variable(a) get label: film
     Then answer get row(0) get type(a) get label: film
     Then answer get row(0) get attribute type(a) get label: film
 
@@ -921,8 +927,11 @@ Feature: TypeDB Driver
     Then answer get row(0) get variable(p) is attribute: false
 
     Then answer get row(0) get variable(p) as entity
+    Then answer get row(0) get variable(p) get label: person
+    Then answer get row(0) get instance(p) get label: person
     Then answer get row(0) get instance(p) get type get label: person
     Then answer get row(0) get entity(p) get iid exists
+    Then answer get row(0) get entity(p) get label: person
     Then answer get row(0) get entity(p) get label: person
     Then answer get row(0) get entity(p) get type get label: person
     Then answer get row(0) get entity(p) get type is entity: false
@@ -964,6 +973,8 @@ Feature: TypeDB Driver
     Then answer get row(0) get variable(p) is attribute: false
 
     Then answer get row(0) get variable(p) as relation
+    Then answer get row(0) get variable(p) get label: parentship
+    Then answer get row(0) get instance(p) get label: parentship
     Then answer get row(0) get instance(p) get type get label: parentship
     Then answer get row(0) get relation(p) get iid exists
     Then answer get row(0) get relation(p) get label: parentship
@@ -1007,6 +1018,8 @@ Feature: TypeDB Driver
     Then answer get row(0) get variable(a) is attribute: true
 
     Then answer get row(0) get variable(a) as attribute
+    Then answer get row(0) get variable(a) get label: typed
+    Then answer get row(0) get instance(a) get label: typed
     Then answer get row(0) get instance(a) get type get label: typed
     Then answer get row(0) get attribute(a) get label: typed
     Then answer get row(0) get attribute(a) get type get label: typed
@@ -1117,6 +1130,8 @@ Feature: TypeDB Driver
 #    Then answer get row(0) get variable(f) is attribute: true
 #
 #    Then answer get row(0) get variable(f) as attribute
+#    Then answer get row(0) get variable(f) get label: typed
+#    Then answer get row(0) get instance(f) get label: typed
 #    Then answer get row(0) get instance(f) get type get label: typed
 #    Then answer get row(0) get attribute(f) get label: typed
 #    Then answer get row(0) get attribute(f) get type get label: typed
@@ -1165,7 +1180,6 @@ Feature: TypeDB Driver
 #    Then answer query type is: read
 #    Then answer size is: 1
 #
-#    Then answer get row(0) get variable(value) get label: value-type
 #    Then answer get row(0) get variable(value) is type: false
 #    Then answer get row(0) get variable(value) is instance: false
 #    Then answer get row(0) get variable(value) is value: true
@@ -1178,6 +1192,8 @@ Feature: TypeDB Driver
 #    Then answer get row(0) get variable(value) is attribute: false
 #
 #    Then answer get row(0) get variable(value) as value
+#    Then answer get row(0) get variable(value) get label: <value-type>
+#    Then answer get row(0) get value(value) get label: <value-type>
 #    Then answer get row(0) get value(value) get value type: <value-type>
 #    Then answer get row(0) get value(value) is boolean: <is-boolean>
 #    Then answer get row(0) get value(value) is long: <is-long>
@@ -1314,7 +1330,7 @@ Feature: TypeDB Driver
       match $a isa age;
       """
     Then answer unwraps as ok; fails
-    Then answer unwraps as concept trees; fails
+    Then answer unwraps as concept documents; fails
     Then answer get row(0) get variable(unknown); fails with a message containing: "The variable 'unknown' does not exist"
     Then answer get row(0) get variable(); fails
     Then answer get row(0) get variable(a) as entity; fails with a message containing: "Invalid concept conversion"
@@ -1335,7 +1351,7 @@ Feature: TypeDB Driver
       match $n isa name;
       """
     Then answer unwraps as ok; fails
-    Then answer unwraps as concept trees; fails
+    Then answer unwraps as concept documents; fails
     Then answer get row(0) get variable(n) as relation; fails with a message containing: "Invalid concept conversion"
     Then answer get row(0) get attribute(n) as long; fails with a message containing: "Invalid value casting to 'long'"
 
@@ -1391,7 +1407,6 @@ Feature: TypeDB Driver
       insert $dt 2023-05-01T00:00:00 Asia/Calcutta isa dt;
       """
     Then answer get row(0) get attribute(dt) get value is: 2023-05-01T00:00:00 Asia/Calcutta
-    Then answer get row(0) get attribute(dt) get value is: 2023-04-30T13:30:00 America/Chicago
     Then answer get row(0) get attribute(dt) get value is not: 2023-04-30T13:30:00 Asia/Calcutta
     Then answer get row(0) get attribute(dt) get value is not: 2023-05-01T00:00:00 America/Chicago
 
@@ -1400,7 +1415,6 @@ Feature: TypeDB Driver
       match $x isa dt;
       """
     Then answer get row(0) get attribute(x) get value is: 2023-05-01T00:00:00 Asia/Calcutta
-    Then answer get row(0) get attribute(x) get value is: 2023-04-30T13:30:00 America/Chicago
     Then answer get row(0) get attribute(x) get value is not: 2023-04-30T13:30:00 Asia/Calcutta
     Then answer get row(0) get attribute(x) get value is not: 2023-05-01T00:00:00 America/Chicago
     When transaction commits
@@ -1415,7 +1429,6 @@ Feature: TypeDB Driver
       match $x isa dt;
       """
     Then answer get row(0) get attribute(x) get value is: 2023-05-01T00:00:00 Asia/Calcutta
-    Then answer get row(0) get attribute(x) get value is: 2023-04-30T13:30:00 America/Chicago
     Then answer get row(0) get attribute(x) get value is not: 2023-04-30T13:30:00 Asia/Calcutta
     Then answer get row(0) get attribute(x) get value is not: 2023-05-01T00:00:00 America/Chicago
 
@@ -1429,6 +1442,5 @@ Feature: TypeDB Driver
       match $x isa dt;
       """
     Then answer get row(0) get attribute(x) get value is: 2023-05-01T00:00:00 Asia/Calcutta
-    Then answer get row(0) get attribute(x) get value is: 2023-04-30T13:30:00 America/Chicago
     Then answer get row(0) get attribute(x) get value is not: 2023-04-30T13:30:00 Asia/Calcutta
     Then answer get row(0) get attribute(x) get value is not: 2023-05-01T00:00:00 America/Chicago

--- a/driver/driver.feature
+++ b/driver/driver.feature
@@ -384,6 +384,9 @@ Feature: TypeDB Driver
     Then answer size is: 1
     Then answer column names are:
       | p |
+    Then answer get row(0) query type is: read
+    Then answer get row(0) query type is not: schema
+    Then answer get row(0) query type is not: write
     Then answer get row(0) get concepts size is: 1
     Then answer get row(0) get entity type(p) get label: person
     Then answer get row(0) get entity type by index of variable(p) get label: person
@@ -426,11 +429,17 @@ Feature: TypeDB Driver
     Then answer column names are:
       | p |
       | n |
+    Then answer get row(0) query type is: read
+    Then answer get row(0) query type is not: schema
+    Then answer get row(0) query type is not: write
     Then answer get row(0) get concepts size is: 2
     Then answer get row(0) get entity type(p) get label: person
     Then answer get row(0) get attribute type(n) get label: name
     Then answer get row(0) get entity type by index of variable(p) get label: person
     Then answer get row(0) get attribute type by index of variable(n) get label: name
+    Then answer get row(1) query type is: read
+    Then answer get row(1) query type is not: schema
+    Then answer get row(1) query type is not: write
     Then answer get row(1) get concepts size is: 2
     Then answer get row(1) get entity type(p) get label: person
     Then answer get row(1) get attribute type(n) get label: age
@@ -488,6 +497,9 @@ Feature: TypeDB Driver
     Then answer size is: 1
     Then answer column names are:
       | p |
+    Then answer get row(0) query type is: write
+    Then answer get row(0) query type is not: schema
+    Then answer get row(0) query type is not: read
     Then answer get row(0) get concepts size is: 1
     Then answer get row(0) get entity(p) get type get label: person
     Then answer get row(0) get entity by index of variable(p) get type get label: person


### PR DESCRIPTION
## Usage and product changes
We add new behaviour tests steps to test fetch responses (concept documents) received by the TypeDB drivers.

Additionally, we refactor some of the already existing steps to align with the Java driver's implementation, and cover additional API's missed before.


