### PR TITLE
Introduce 3.0 undefine behaviour steps. Add more steps for define, redefine, match value, match as

### DIFF
--- a/concept/thing/attribute.feature
+++ b/concept/thing/attribute.feature
@@ -59,16 +59,17 @@ Feature: Concept Attribute
     Then attribute $x has value type: <type>
     Then attribute $x has value: <value>
     Examples:
-      | attr              | type        | value                              |
-      | is-alive          | boolean     | true                               |
-      | age               | long        | 21                                 |
-      | score             | double      | 123.456                            |
-      | name              | string      | alice                              |
-      | birth-date        | date        | 1990-01-01                         |
-      | event-datetime    | datetime    | 1990-01-01T11:22:33.123456789      |
-      | global-date       | datetime-tz | 1990-01-01T11:22:33 Asia/Kathmandu |
-      | global-date       | datetime-tz | 1990-01-01T11:22:33-0100           |
-      | schedule-interval | duration    | P1Y2M3DT4H5M6.789S                 |
+      | attr              | type        | value                                                                              |
+      | is-alive          | boolean     | true                                                                               |
+      | age               | long        | 21                                                                                 |
+      | score             | double      | 123.456                                                                            |
+      | name              | string      | alice                                                                              |
+      | name              | string      | very-long-string-with_@strangESymßo¬s¡2)*(()˚¬ª#08uj!@%@£^%*&%(*@!_++±§≥≤<>?:😎資料庫 |
+      | birth-date        | date        | 1990-01-01                                                                         |
+      | event-datetime    | datetime    | 1990-01-01T11:22:33.123456789                                                      |
+      | global-date       | datetime-tz | 1990-01-01T11:22:33 Asia/Kathmandu                                                 |
+      | global-date       | datetime-tz | 1990-01-01T11:22:33-0100                                                           |
+      | schedule-interval | duration    | P1Y2M3DT4H5M6.789S                                                                 |
 
   Scenario Outline: Attribute with value type <type> can be retrieved by its value
     When $x = attribute(<attr>) put instance with value: <value>
@@ -78,16 +79,17 @@ Feature: Concept Attribute
     When $x = attribute(<attr>) get instance with value: <value>
     Then attribute(<attr>) get instances contain: $x
     Examples:
-      | attr              | type        | value                              |
-      | is-alive          | boolean     | true                               |
-      | age               | long        | 21                                 |
-      | score             | double      | 123.456                            |
-      | name              | string      | alice                              |
-      | birth-date        | date        | 1990-01-01                         |
-      | event-datetime    | datetime    | 1990-01-01T11:22:33.123456789      |
-      | global-date       | datetime-tz | 1990-01-01 11:22:33 Asia/Kathmandu |
-      | global-date       | datetime-tz | 1990-01-01T11:22:33-0100           |
-      | schedule-interval | duration    | P1Y2M3DT4H5M6.789S                 |
+      | attr              | type        | value                                                                              |
+      | is-alive          | boolean     | true                                                                               |
+      | age               | long        | 21                                                                                 |
+      | score             | double      | 123.456                                                                            |
+      | name              | string      | alice                                                                              |
+      | name              | string      | very-long-string-with_@strangESymßo¬s¡2)*(()˚¬ª#08uj!@%@£^%*&%(*@!_++±§≥≤<>?:😎資料庫 |
+      | birth-date        | date        | 1990-01-01                                                                         |
+      | event-datetime    | datetime    | 1990-01-01T11:22:33.123456789                                                      |
+      | global-date       | datetime-tz | 1990-01-01 11:22:33 Asia/Kathmandu                                                 |
+      | global-date       | datetime-tz | 1990-01-01T11:22:33-0100                                                           |
+      | schedule-interval | duration    | P1Y2M3DT4H5M6.789S                                                                 |
 
   Scenario Outline: Attribute with value type <type> can be deleted
     When $x = attribute(<attr>) put instance with value: <value>

--- a/connection/transaction.feature
+++ b/connection/transaction.feature
@@ -94,8 +94,8 @@ Feature: Connection Transaction
       | <type> |
       | <type> |
     Examples:
-      | type   |
-      | read   |
+      | type |
+      | read |
 # TODO: Fix multiple write and schema transactions (or create a test that expects an explicit error instead of hanging!)
 #      | write  |
 #      | schema |
@@ -173,8 +173,8 @@ Feature: Connection Transaction
       | <type> |
       | <type> |
     Examples:
-      | type   |
-      | read   |
+      | type |
+      | read |
 # TODO: Fix multiple write and schema transactions (or create a test that expects an explicit error instead of hanging!)
 #      | write  |
 #      | schema |
@@ -193,7 +193,7 @@ Feature: Connection Transaction
 #      | read   |
 #      | write  |
 #      | schema |
-#      | read   |ƒ
+#      | read   |
 #      | write  |
 #      | schema |
 #      | read   |
@@ -239,8 +239,8 @@ Feature: Connection Transaction
       insert $person isa person;
       """
     Examples:
-      | type   |
-      | read   |
+      | type |
+      | read |
 
   Scenario: commit in a read transaction fails
     When connection create database: typedb

--- a/connection/transaction.feature
+++ b/connection/transaction.feature
@@ -193,7 +193,7 @@ Feature: Connection Transaction
 #      | read   |
 #      | write  |
 #      | schema |
-#      | read   |
+#      | read   |ƒ
 #      | write  |
 #      | schema |
 #      | read   |
@@ -247,7 +247,7 @@ Feature: Connection Transaction
     Given connection open read transaction for database: typedb
     Then transaction commits; fails
 
-  Scenario Outline: <command> in a schema transaction fails
+  Scenario Outline: <command> in a schema transaction closes the transaction
     Given connection create database: typedb
     Given connection open schema transaction for database: typedb
     Given typeql schema query
@@ -261,7 +261,7 @@ Feature: Connection Transaction
       | close   |
       | commit  |
 
-  Scenario Outline: <command> in a write transaction fails
+  Scenario Outline: <command> in a write transaction closes the transaction
     Given connection create database: typedb
     Given connection open schema transaction for database: typedb
     Given typeql schema query

--- a/query/language/define.feature
+++ b/query/language/define.feature
@@ -50,6 +50,39 @@ Feature: TypeQL Define Query
       | label:dog |
 
 
+  Scenario: new entity type declaration should contain kind
+    Then typeql schema query; fails
+      """
+      define dog;
+      """
+
+
+  Scenario: new entity types can be defined in multiple steps within one query
+    When typeql schema query
+      """
+      define
+      dog owns name;
+      dog plays income:earner;
+      dog @abstract;
+      dog;
+      entity dog;
+      """
+    Then transaction commits
+
+    When connection open schema transaction for database: typedb
+    When get answers of typeql read query
+      """
+      match
+      $x owns name;
+      $x plays income:earner;
+      entity $x;
+      """
+    Then uniquely identify answer concepts
+      | x            |
+      | label:person |
+      | label:dog    |
+
+
   Scenario: a new entity type can be defined as a subtype, creating a new child of its parent type
     When typeql schema query
       """
@@ -332,7 +365,7 @@ Feature: TypeQL Define Query
 #      | label:house |
 
 
-  Scenario: defining a type without a kind throws
+  Scenario: defining a type without a kind errors
     Then typeql schema query; fails
       """
       define flying-spaghetti-monster;
@@ -394,6 +427,38 @@ Feature: TypeQL Define Query
       | label:pet-ownership |
 
 
+  Scenario: new relation type declaration should contain kind
+    Then typeql schema query; fails
+      """
+      define pet-ownership;
+      """
+
+
+  Scenario: new relation types can be defined in multiple steps within one query
+    When typeql schema query
+      """
+      define
+      pet-ownership relates pet-owner;
+      pet-ownership relates owned-pet;
+      pet-ownership @abstract;
+      pet-ownership;
+      relation pet-ownership;
+      """
+    Then transaction commits
+
+    When connection open schema transaction for database: typedb
+    When get answers of typeql read query
+      """
+      match
+      $x relates pet-owner;
+      $x relates owned-pet;
+      relation $x;
+      """
+    Then uniquely identify answer concepts
+      | x                   |
+      | label:pet-ownership |
+
+
   Scenario: a new relation type can be defined as a subtype, creating a new child of its parent type
     When typeql schema query
       """
@@ -429,7 +494,7 @@ Feature: TypeQL Define Query
       """
 
 
-  Scenario: defining a relation type throws on commit if it has no roleplayers and is not abstract
+  Scenario: defining a relation type errors on commit if it has no roleplayers and is not abstract
     Then typeql schema query
       """
       define relation useless-relation;
@@ -877,7 +942,6 @@ Feature: TypeQL Define Query
 
       """
     Then answer size is: 1
-
     Examples:
       | value-type  | label              |
       | long        | number-of-cows     |
@@ -891,7 +955,42 @@ Feature: TypeQL Define Query
       | duration    | procedure-duration |
 
 
-  Scenario: defining an attribute type throws if you don't specify a value type
+  Scenario: new attribute type declaration should contain kind
+    Then typeql schema query; fails
+      """
+      define number-of-cows;
+      """
+
+
+  Scenario: new attribute types can be defined in multiple steps within one query
+    When typeql schema query
+      """
+      define
+      number-of value long;
+      number-of @abstract;
+      number-of-cows @abstract;
+      number-of-cows sub number-of;
+      number-of;
+      attribute number-of-cows;
+      attribute number-of;
+      """
+    Then transaction commits
+
+    When connection open schema transaction for database: typedb
+    When get answers of typeql read query
+      """
+      match
+      $x label number-of;
+      $x-cows sub! $x;
+      attribute $x;
+      attribute $x-cows;
+      """
+    Then uniquely identify answer concepts
+      | x               | x-cows               |
+      | label:number-of | label:number-of-cows |
+
+
+  Scenario: defining an attribute type errors if you don't specify a value type
     When typeql schema query
       """
       define attribute colour;
@@ -907,7 +1006,7 @@ Feature: TypeQL Define Query
     Then transaction commits
 
 
-  Scenario: defining an attribute type throws if the specified value type is not a recognised value type
+  Scenario: defining an attribute type errors if the specified value type is not a recognised value type
     Then typeql schema query; fails
       """
       define attribute colour value rgba;
@@ -971,7 +1070,7 @@ Feature: TypeQL Define Query
 #      | label:door-code |
 
 
-  Scenario: defining an attribute subtype throws if it is given a different value type to what its parent has
+  Scenario: defining an attribute subtype errors if it is given a different value type to what its parent has
     When typeql schema query
       """
       define attribute name @abstract; entity person @abstract;

--- a/query/language/define.feature
+++ b/query/language/define.feature
@@ -1038,11 +1038,15 @@ Feature: TypeQL Define Query
       define name value long;
       """
 
+  ###########
+  # STRUCTS #
+  ###########
+
+    # TODO 3.x: Add tests for structs
+
   ###############
   # ANNOTATIONS #
   ###############
-
-  # TODO: Add annotation tests for structs and their fields
 
   # TODO: For all "can set annotation ... to" tests, add match queries to check the definition when "match @..." is implemented
 
@@ -2670,12 +2674,11 @@ Feature: TypeQL Define Query
       """
     Then transaction commits
 
-    # TODO: Adding this check makes reset take 60 seconds after the failed query...
-#    Given connection open write transaction for database: typedb
-#    Given typeql write query; fails
-#      """
-#      insert $x isa person, has name "Bob", has email "bob2@gmail.com";
-#      """
+    Given connection open write transaction for database: typedb
+    Given typeql write query; fails
+      """
+      insert $x isa person, has name "Bob", has email "bob2@gmail.com";
+      """
 
 
   Scenario: defining a uniqueness on existing ownership fail if data does not conform to uniqueness requirements
@@ -2750,11 +2753,10 @@ Feature: TypeQL Define Query
 #      """
 #    Then answer size is: 0
 
-    # TODO: Adding this check makes reset take 60 seconds after the failed query...
-#    Given typeql write query; fails
-#      """
-#      insert $x isa person, has email "jane@gmail.com";
-#      """
+    Given typeql write query; fails
+      """
+      insert $x isa person, has email "jane@gmail.com";
+      """
 
 
   Scenario: converting unique to key is possible if the data conforms to key requirements
@@ -2778,12 +2780,12 @@ Feature: TypeQL Define Query
       """
     Then transaction commits
 
-    # TODO: Adding this check makes reset take 60 seconds after the failed query...
-#    Given connection open write transaction for database: typedb
-#    Then typeql write query; fails
-#      """
-#      insert $x isa person, has phone-nr "9999", has phone-nr "8888", has email "pqr@gmail.com";
-#      """
+    When connection open write transaction for database: typedb
+    When typeql write query
+      """
+      insert $x isa person, has phone-nr "9999", has phone-nr "8888", has email "pqr@gmail.com";
+      """
+    Then transaction commits; fails with a message containing: "key constraint violation"
 
 
   Scenario: converting unique to key fails if the data does not conform to key requirements
@@ -3290,8 +3292,5 @@ Feature: TypeQL Define Query
       relation huge-pineapple sub big-pineapple, relates tree as source, relates grows-from;
       """
     Then transaction commits
-
-    # TODO 3.x: Add tests for structs
-
 
     # TODO 3.0: Add tests for functions

--- a/query/language/define.feature
+++ b/query/language/define.feature
@@ -449,7 +449,7 @@ Feature: TypeQL Define Query
       match
         $x relates parent;
         $x relates child;
-     
+
       """
     Then uniquely identify answer concepts
       | x                |
@@ -459,7 +459,7 @@ Feature: TypeQL Define Query
       match
         $x relates father;
         $x relates son;
-     
+
       """
     Then uniquely identify answer concepts
       | x                    |
@@ -771,7 +771,7 @@ Feature: TypeQL Define Query
       match
         $x label <label>;
         attribute $x;
-     
+
       """
     Then answer size is: 1
 
@@ -1913,7 +1913,7 @@ Feature: TypeQL Define Query
       match
       $name type super-name @abstract;
       $location type location-name, sub super-name;
-     
+
       """
     Then uniquely identify answer concepts
       | name             | location            |

--- a/query/language/define.feature
+++ b/query/language/define.feature
@@ -29,7 +29,6 @@ Feature: TypeQL Define Query
 
     Given connection open schema transaction for database: typedb
 
-
   ################
   # ENTITY TYPES #
   ################
@@ -200,15 +199,16 @@ Feature: TypeQL Define Query
       """
     Given transaction commits
 
-    Given connection open read transaction for database: typedb
-    When get answers of typeql read query
-      """
-      match $x owns email @key;
-      """
-    Then uniquely identify answer concepts
-      | x            |
-      | label:person |
-      | label:child  |
+    # TODO: Uncomment when "match @..." is implemented
+#    Given connection open read transaction for database: typedb
+#    When get answers of typeql read query
+#      """
+#      match $x owns email @key;
+#      """
+#    Then uniquely identify answer concepts
+#      | x            |
+#      | label:person |
+#      | label:child  |
 
 
   Scenario: a newly defined entity subtype inherits keys from all of its supertypes
@@ -221,17 +221,18 @@ Feature: TypeQL Define Query
       """
     Given transaction commits
 
-    Given connection open read transaction for database: typedb
-    When get answers of typeql read query
-      """
-      match $x owns email @key;
-      """
-    Then uniquely identify answer concepts
-      | x              |
-      | label:person   |
-      | label:athlete  |
-      | label:runner   |
-      | label:sprinter |
+    # TODO: Uncomment when "match @..." is implemented
+#    Given connection open read transaction for database: typedb
+#    When get answers of typeql read query
+#      """
+#      match $x owns email @key;
+#      """
+#    Then uniquely identify answer concepts
+#      | x              |
+#      | label:person   |
+#      | label:athlete  |
+#      | label:runner   |
+#      | label:sprinter |
 
 
   Scenario: defining a playable role is idempotent
@@ -282,14 +283,15 @@ Feature: TypeQL Define Query
       """
     Given transaction commits
 
-    Given connection open read transaction for database: typedb
-    When get answers of typeql read query
-      """
-      match $x owns address @key;
-      """
-    Then uniquely identify answer concepts
-      | x           |
-      | label:house |
+    # TODO: Uncomment when "match @..." is implemented
+#    Given connection open read transaction for database: typedb
+#    When get answers of typeql read query
+#      """
+#      match $x owns address @key;
+#      """
+#    Then uniquely identify answer concepts
+#      | x           |
+#      | label:house |
 
 
   Scenario: defining a type without a kind throws
@@ -332,7 +334,6 @@ Feature: TypeQL Define Query
       """
       define entity $x;
       """
-
 
   ##################
   # RELATION TYPES #
@@ -449,17 +450,16 @@ Feature: TypeQL Define Query
       match
         $x relates parent;
         $x relates child;
-
       """
     Then uniquely identify answer concepts
-      | x                |
-      | label:parenthood |
+      | x                    |
+      | label:parenthood     |
+      | label:father-sonhood |
     When get answers of typeql read query
       """
       match
         $x relates father;
         $x relates son;
-
       """
     Then uniquely identify answer concepts
       | x                    |
@@ -489,7 +489,7 @@ Feature: TypeQL Define Query
       | label:father-sonhood:father | label:father-sonhood:son |
 
 
-  Scenario: a specialised role is no longer associated with the relation type that specialises it
+  Scenario: a specialised role is still associated with the relation type that specialises it, but with @abstract
     Given typeql schema query
       """
       define relation part-time-employment sub employment, relates part-timer as employee;
@@ -502,8 +502,18 @@ Feature: TypeQL Define Query
       match $x relates employee;
       """
     Then uniquely identify answer concepts
-      | x                |
-      | label:employment |
+      | x                          |
+      | label:employment           |
+      | label:part-time-employment |
+
+    # TODO: Uncomment when "match @..." is implemented
+#    When get answers of typeql read query
+#      """
+#      match $x relates employee @abstract;
+#      """
+#    Then uniquely identify answer concepts
+#      | x                          |
+#      | label:part-time-employment |
 
 
   Scenario: when specialising a role that doesn't exist on the parent relation, an error is thrown
@@ -648,15 +658,16 @@ Feature: TypeQL Define Query
       """
     Given transaction commits
 
-    Given connection open read transaction for database: typedb
-    When get answers of typeql read query
-      """
-      match $x owns employment-reference-code @key;
-      """
-    Then uniquely identify answer concepts
-      | x                         |
-      | label:employment          |
-      | label:contract-employment |
+    # TODO: Uncomment when "match @..." is implemented
+#    Given connection open read transaction for database: typedb
+#    When get answers of typeql read query
+#      """
+#      match $x owns employment-reference-code @key;
+#      """
+#    Then uniquely identify answer concepts
+#      | x                         |
+#      | label:employment          |
+#      | label:contract-employment |
 
 
   Scenario: a newly defined relation subtype inherits keys from all of its supertypes
@@ -669,17 +680,18 @@ Feature: TypeQL Define Query
       """
     Given transaction commits
 
-    Given connection open read transaction for database: typedb
-    When get answers of typeql read query
-      """
-      match $x owns employment-reference-code @key;
-      """
-    Then uniquely identify answer concepts
-      | x                                 |
-      | label:employment                  |
-      | label:transport-employment        |
-      | label:aviation-employment         |
-      | label:flight-attendant-employment |
+    # TODO: Uncomment when "match @..." is implemented
+#    Given connection open read transaction for database: typedb
+#    When get answers of typeql read query
+#      """
+#      match $x owns employment-reference-code @key;
+#      """
+#    Then uniquely identify answer concepts
+#      | x                                 |
+#      | label:employment                  |
+#      | label:transport-employment        |
+#      | label:aviation-employment         |
+#      | label:flight-attendant-employment |
 
 
   Scenario: a relation type cannot be defined with no roleplayers even if it is marked as @abstract
@@ -752,7 +764,6 @@ Feature: TypeQL Define Query
       | x               |
       | label:loan      |
       | label:ownership |
-
 
   ###################
   # ATTRIBUTE TYPES #
@@ -840,14 +851,15 @@ Feature: TypeQL Define Query
       """
     Then transaction commits
 
-    Given connection open read transaction for database: typedb
-    When get answers of typeql read query
-      """
-      match $x label door-code, value string;
-      """
-    Then uniquely identify answer concepts
-      | x               |
-      | label:door-code |
+    # TODO: ConstraintBase::ValueType is not implemented
+#    Given connection open read transaction for database: typedb
+#    When get answers of typeql read query
+#      """
+#      match $x label door-code, value string;
+#      """
+#    Then uniquely identify answer concepts
+#      | x               |
+#      | label:door-code |
 
 
   Scenario: defining an attribute subtype throws if it is given a different value type to what its parent has
@@ -884,32 +896,6 @@ Feature: TypeQL Define Query
       define attribute code-name-2 sub name;
       """
 
-  # TODO: re-enable when fixed (currently gives wrong answer)
-  @ignore
-  Scenario: a regex constraint can be defined on a 'string' attribute type
-    Given typeql schema query
-      """
-      define attribute response @regex("^(yes|no|maybe)$"), value string;
-      """
-    Given transaction commits
-
-    Given connection open read transaction for database: typedb
-    When get answers of typeql read query
-      """
-      match $x @regex("^(yes|no|maybe)$");
-      """
-    Then uniquely identify answer concepts
-      | x              |
-      | label:resource |
-
-
-  Scenario: a regex constraint cannot be defined on an attribute type whose value type is anything other than 'string'
-    Then typeql schema query; fails
-      """
-      define attribute name-in-binary @regex("^(0|1)+$"), value long;
-      """
-
-
   Scenario Outline: a type can own a '<value_type>' attribute type
     When typeql schema query
       """
@@ -937,23 +923,27 @@ Feature: TypeQL Define Query
       | datetime   | graduation-date   |
 
 
-  # TODO
-#  Scenario Outline: a type can own a '<value_type>' attribute type as a key
-#
-#  Scenario Outline: a '<value_type>' attribute type is not allowed to be a key
-
-
   ###############
   # ANNOTATIONS #
   ###############
 
-  # TODO: Add tests for structs and their fields
+  # TODO: Add annotation tests for structs and their fields
+
+  # TODO: For all "can set annotation ... to" tests, add match queries to check the definition when "match @..." is implemented
 
   Scenario Outline: can set annotation @<annotation> to entity types
     Then typeql schema query
       """
       define
       entity player @<annotation>;
+      """
+    Then transaction commits
+
+    When connection open schema transaction for database: typedb
+    Then typeql schema query
+      """
+      define
+      player @<annotation> @<annotation> @<annotation>;
       """
     Then transaction commits
     Examples:
@@ -980,11 +970,30 @@ Feature: TypeQL Define Query
       | values("1", "2") |
 
 
+    # Uncomment and fill when annotations with arguments appear for entity types
+#  Scenario Outline: cannot define different annotations of the same category on entity types
+#    Then typeql schema query; fails with a message containing: "Try redefine instead"
+#      """
+#      define
+#      entity player @<annotation-1> @<annotation-2>;
+#      """
+#    Examples:
+#      | annotation-1 | annotation-2 |
+
+
   Scenario Outline: can set annotation @<annotation> to relation types
     Then typeql schema query
       """
       define
       relation parentship @<annotation>, relates parent;
+      """
+    Then transaction commits
+
+    When connection open schema transaction for database: typedb
+    Then typeql schema query
+      """
+      define
+      parentship @<annotation> @<annotation> @<annotation>;
       """
     Then transaction commits
     Examples:
@@ -1011,11 +1020,31 @@ Feature: TypeQL Define Query
       | values("1", "2") |
 
 
+    # Uncomment and fill when annotations with arguments appear for relation types
+#  Scenario Outline: cannot define different annotations of the same category on relation types
+#    Then typeql schema query; fails with a message containing: "Try redefine instead"
+#      """
+#      define
+#      relation parentship @<annotation-1> @<annotation-2>, relates parent;
+#      """
+#    Then transaction commits
+#    Examples:
+#      | annotation-1 | annotation-2 |
+
+
   Scenario Outline: can set annotation @<annotation> to attribute types
     Then typeql schema query
       """
       define
       attribute description @<annotation>, value string;
+      """
+    Then transaction commits
+
+    When connection open schema transaction for database: typedb
+    Then typeql schema query
+      """
+      define
+      description @<annotation> @<annotation> @<annotation>;
       """
     Then transaction commits
     Examples:
@@ -1042,11 +1071,31 @@ Feature: TypeQL Define Query
       | values("1", "2") |
 
 
+    # Uncomment and fill when annotations with arguments appear for attribute types
+#  Scenario Outline: cannot define different annotations of the same category on attribute types
+#    Then typeql schema query; fails with a message containing: "Try redefine instead"
+#      """
+#      define
+#      attribute description @<annotation-1> @<annotation-2>, value string;
+#      """
+#    Then transaction commits
+#    Examples:
+#      | annotation-1 | annotation-2 |
+
+
   Scenario Outline: can set annotation @<annotation> to relates/role types
     Then typeql schema query
       """
       define
       relation parentship @abstract, relates parent @<annotation>;
+      """
+    Then transaction commits
+
+    When connection open schema transaction for database: typedb
+    Then typeql schema query
+      """
+      define
+      parentship relates parent @<annotation> @<annotation> @<annotation>;
       """
     Then transaction commits
     Examples:
@@ -1073,11 +1122,30 @@ Feature: TypeQL Define Query
       | values("1", "2") |
 
 
+  Scenario Outline: cannot define different annotations of the same category on role types
+    Then typeql schema query; fails with a message containing: "Try redefine instead"
+      """
+      define
+      relation parentship relates parent @<annotation-1> @<annotation-2>;
+      """
+    Examples:
+      | annotation-1 | annotation-2 |
+      | card(1..1)   | card(0..5)   |
+
+
   Scenario Outline: can set annotation @<annotation> to relates/role types lists
     Then typeql schema query
       """
       define
       relation parentship @abstract, relates parent[] @<annotation>;
+      """
+    Then transaction commits
+
+    When connection open schema transaction for database: typedb
+    Then typeql schema query
+      """
+      define
+      parentship relates parent[] @<annotation> @<annotation> @<annotation>;
       """
     Then transaction commits
     Examples:
@@ -1111,6 +1179,14 @@ Feature: TypeQL Define Query
       entity player owns name @<annotation>;
       """
     Then transaction commits
+
+    When connection open schema transaction for database: typedb
+    Then typeql schema query
+      """
+      define
+      player owns name @<annotation> @<annotation> @<annotation>;
+      """
+    Then transaction commits
     Examples:
       | annotation       |
       | card(1..1)       |
@@ -1133,6 +1209,20 @@ Feature: TypeQL Define Query
       | distinct    |
       | independent |
 #      | cascade          | # TODO: Cascade is temporarily turned off
+
+
+  Scenario Outline: cannot define different annotations of the same category on owns
+    Then typeql schema query; fails with a message containing: "Try redefine instead"
+      """
+      define
+      entity player owns name @<annotation-1> @<annotation-2>;
+      """
+    Examples:
+      | annotation-1        | annotation-2               |
+      | card(1..1)          | card(0..5)                 |
+      | regex("one")        | regex("another")           |
+      | range("one".."two") | range("another".."second") |
+      | values("1", "2")    | values("3", "4")           |
 
 
   Scenario Outline: cannot set annotation @<annotation> to owns of attribute type of wrong <value-type>
@@ -1195,9 +1285,9 @@ Feature: TypeQL Define Query
       | values(2024-06-04T00:00:00+0010)                      | , value date        |
       | values(2024-06-04T16:35:02)                           | , value date        |
       | values("福")                                           | , value date        |
+      | values(2024-06-04T00:00:00 Europe/Belfast)            | , value datetime    |
       | values(2024-06-04T00:00:00+0010)                      | , value datetime    |
       | values(2024-06-04)                                    | , value datetime-tz |
-      | values(2024-06-04T00:00:00 Europe/Belfast)            | , value datetime-tz |
       | values(123)                                           | , value duration    |
       | values("string")                                      | , value duration    |
       | values(2024-06-04)                                    | , value duration    |
@@ -1250,6 +1340,14 @@ Feature: TypeQL Define Query
       entity player owns name[] @<annotation>;
       """
     Then transaction commits
+
+    When connection open schema transaction for database: typedb
+    Then typeql schema query
+      """
+      define
+      player owns name[] @<annotation> @<annotation> @<annotation>;
+      """
+    Then transaction commits
     Examples:
       | annotation       |
       | distinct         |
@@ -1281,6 +1379,14 @@ Feature: TypeQL Define Query
       entity player plays employment:employee @<annotation>;
       """
     Then transaction commits
+
+    When connection open schema transaction for database: typedb
+    Then typeql schema query
+      """
+      define
+      player plays employment:employee @<annotation> @<annotation> @<annotation>;
+      """
+    Then transaction commits
     Examples:
       | annotation |
       | card(1..1) |
@@ -1305,11 +1411,30 @@ Feature: TypeQL Define Query
       | values("1", "2") |
 
 
+  Scenario Outline: cannot define different annotations of the same category on owns
+    Then typeql schema query; fails with a message containing: "Try redefine instead"
+      """
+      define
+      entity player plays employment:employee @<annotation-1> @<annotation-2>;
+      """
+    Examples:
+      | annotation-1        | annotation-2               |
+      | card(1..1)          | card(0..5)                 |
+
+
   Scenario Outline: can set annotation @<annotation> to value types
     Then typeql schema query
       """
       define
       attribute description value string @<annotation>;
+      """
+    Then transaction commits
+
+    When connection open schema transaction for database: typedb
+    Then typeql schema query
+      """
+      define
+      description value string @<annotation> @<annotation> @<annotation>;
       """
     Then transaction commits
     Examples:
@@ -1371,14 +1496,27 @@ Feature: TypeQL Define Query
       | values(2024-06-04T00:00:00+0010)                      | date        |
       | values(2024-06-04T16:35:02)                           | date        |
       | values("福")                                           | date        |
+      | values(2024-06-04T00:00:00 Europe/Belfast)            | datetime    |
       | values(2024-06-04T00:00:00+0010)                      | datetime    |
       | values(2024-06-04)                                    | datetime-tz |
-      | values(2024-06-04T00:00:00 Europe/Belfast)            | datetime-tz |
       | values(123)                                           | duration    |
       | values("string")                                      | duration    |
       | values(2024-06-04)                                    | duration    |
       | values(2024-06-04T00:00:00+0100)                      | duration    |
       | values("year")                                        | duration    |
+
+
+  Scenario Outline: cannot define different annotations of the same category on owns
+    Then typeql schema query; fails with a message containing: "Try redefine instead"
+      """
+      define
+      attribute description value string @<annotation-1> @<annotation-2>;
+      """
+    Examples:
+      | annotation-1        | annotation-2               |
+      | regex("one")        | regex("another")           |
+      | range("one".."two") | range("another".."second") |
+      | values("1", "2")    | values("3", "4")           |
 
 
   Scenario Outline: cannot set annotation @values(<arg0>, <arg1>, <arg0>) with duplicated arguments to value type
@@ -1702,6 +1840,79 @@ Feature: TypeQL Define Query
     # TODO: Add a test for @cascade when it appears again
 
 
+  Scenario: annotations can be added on subtypes
+    Given typeql schema query
+      """
+      define
+      entity child sub person, owns school-id @unique;
+      attribute school-id value string;
+      """
+    Then transaction commits
+
+
+  Scenario: annotations are inherited
+    Given typeql schema query
+      """
+      define entity child sub person;
+      """
+    Given transaction commits
+
+    # TODO: Uncomment when "match @..." is implemented
+#    Then connection open read transaction for database: typedb
+#    When get answers of typeql read query
+#      """
+#      match $t owns $a @key;
+#      """
+#    Then uniquely identify answer concepts
+#      | t                | a                               |
+#      | label:person     | label:email                     |
+#      | label:child      | label:email                     |
+#      | label:employment | label:employment-reference-code |
+#    When get answers of typeql read query
+#      """
+#      match $t owns $a @unique;
+#      """
+#    Then uniquely identify answer concepts
+#      | t            | a              |
+#      | label:person | label:phone-nr |
+#      | label:child  | label:phone-nr |
+
+
+  Scenario: redefining inherited annotations errors for types and capabilities
+    Then typeql schema query
+      """
+      define entity child sub person; # owns email @key from background
+      """
+    Then transaction commits
+    When connection open schema transaction for database: typedb
+    Then typeql schema query
+      """
+      define child owns email @key;
+      """
+    Then transaction commits; fails with a message containing: "without specialisation"
+    When connection open schema transaction for database: typedb
+    Then typeql schema query
+      """
+      define child owns phone-nr @unique;
+      """
+    Then transaction commits; fails with a message containing: "without specialisation"
+    When connection open schema transaction for database: typedb
+    Then typeql schema query
+      """
+      define email @abstract; attribute working-email sub email, value string @regex("^.*@.*$");
+      """
+    Then transaction commits; fails with a message containing: "without specialisation"
+
+
+  Scenario: type cannot specialise owns
+    Then typeql schema query; parsing fails
+      """
+      define
+      entity person @abstract;
+      attribute phone-nr @abstract;
+      entity child sub person, owns mobile as phone-nr;
+      """
+
   ##################
   # ABSTRACT TYPES #
   ##################
@@ -1713,14 +1924,17 @@ Feature: TypeQL Define Query
       """
     Then transaction commits
 
-    Given connection open read transaction for database: typedb
-    When get answers of typeql read query
-      """
-      match $x label animal; $x @abstract;
-      """
-    Then uniquely identify answer concepts
-      | x            |
-      | label:animal |
+    # TODO: Uncomment when "match @..." is implemented
+#    Given connection open read transaction for database: typedb
+#    When get answers of typeql read query
+#      """
+#      match
+#      $x label animal;
+#      $x @abstract;
+#      """
+#    Then uniquely identify answer concepts
+#      | x            |
+#      | label:animal |
 
 
   Scenario: a concrete entity type can be defined as a subtype of an abstract entity type
@@ -1752,15 +1966,16 @@ Feature: TypeQL Define Query
       """
     Then transaction commits
 
-    Given connection open read transaction for database: typedb
-    When get answers of typeql read query
-      """
-      match $x sub animal; $x @abstract;
-      """
-    Then uniquely identify answer concepts
-      | x            |
-      | label:animal |
-      | label:fish   |
+    # TODO: Uncomment when "match @..." is implemented
+#    Given connection open read transaction for database: typedb
+#    When get answers of typeql read query
+#      """
+#      match $x sub animal; $x @abstract;
+#      """
+#    Then uniquely identify answer concepts
+#      | x            |
+#      | label:animal |
+#      | label:fish   |
 
 
   Scenario: an abstract entity type cannot be defined as a subtype of a concrete entity type
@@ -1779,14 +1994,15 @@ Feature: TypeQL Define Query
       """
     Then transaction commits
 
-    Given connection open read transaction for database: typedb
-    When get answers of typeql read query
-      """
-      match $x label membership; $x @abstract;
-      """
-    Then uniquely identify answer concepts
-      | x                |
-      | label:membership |
+    # TODO: Uncomment when "match @..." is implemented
+#    Given connection open read transaction for database: typedb
+#    When get answers of typeql read query
+#      """
+#      match $x label membership; $x @abstract;
+#      """
+#    Then uniquely identify answer concepts
+#      | x                |
+#      | label:membership |
 
 
   Scenario: a concrete relation type can be defined as a subtype of an abstract relation type
@@ -1818,15 +2034,16 @@ Feature: TypeQL Define Query
       """
     Then transaction commits
 
-    When connection open read transaction for database: typedb
-    When get answers of typeql read query
-      """
-      match $x sub requirement; $x @abstract;
-      """
-    Then uniquely identify answer concepts
-      | x                      |
-      | label:requirement      |
-      | label:tool-requirement |
+    # TODO: Uncomment when "match @..." is implemented
+#    When connection open read transaction for database: typedb
+#    When get answers of typeql read query
+#      """
+#      match $x sub requirement; $x @abstract;
+#      """
+#    Then uniquely identify answer concepts
+#      | x                      |
+#      | label:requirement      |
+#      | label:tool-requirement |
 
 
   Scenario: an abstract relation type cannot be defined as a subtype of a concrete relation type
@@ -1845,14 +2062,15 @@ Feature: TypeQL Define Query
       """
     Then transaction commits
 
-    Given connection open read transaction for database: typedb
-    When get answers of typeql read query
-      """
-      match $x label number-of-limbs; $x @abstract;
-      """
-    Then uniquely identify answer concepts
-      | x                     |
-      | label:number-of-limbs |
+    # TODO: Uncomment when "match @..." is implemented
+#    Given connection open read transaction for database: typedb
+#    When get answers of typeql read query
+#      """
+#      match $x label number-of-limbs; $x @abstract;
+#      """
+#    Then uniquely identify answer concepts
+#      | x                     |
+#      | label:number-of-limbs |
 
 
   Scenario: a concrete attribute type can be defined as a subtype of an abstract attribute type
@@ -1884,15 +2102,16 @@ Feature: TypeQL Define Query
       """
     Then transaction commits
 
-    Given connection open read transaction for database: typedb
-    When get answers of typeql read query
-      """
-      match $x sub number-of-limbs; $x @abstract;
-      """
-    Then uniquely identify answer concepts
-      | x                                |
-      | label:number-of-limbs            |
-      | label:number-of-artificial-limbs |
+    # TODO: Uncomment when "match @..." is implemented
+#    Given connection open read transaction for database: typedb
+#    When get answers of typeql read query
+#      """
+#      match $x @abstract, sub number-of-limbs;
+#      """
+#    Then uniquely identify answer concepts
+#      | x                                |
+#      | label:number-of-limbs            |
+#      | label:number-of-artificial-limbs |
 
 
   Scenario: defining attribute type hierarchies is idempotent
@@ -1911,133 +2130,12 @@ Feature: TypeQL Define Query
     When get answers of typeql read query
       """
       match
-      $name type super-name @abstract;
-      $location type location-name, sub super-name;
-
+      $name label super-name;
+      $location label location-name, sub super-name;
       """
     Then uniquely identify answer concepts
       | name             | location            |
       | label:super-name | label:location-name |
-
-  # TODO: Reenable this scenario after closing https://github.com/vaticle/typeql/issues/281
-  @ignore
-  @ignore-typedb-driver-rust
-  Scenario: repeating the term 'abstract' when defining a type causes an error to be thrown
-    Given typeql schema query; fails
-      """
-      define entity animal @abstract @abstract @abstract;
-      """
-
-  ##############
-  # Annotation #
-  ##############
-
-  Scenario: annotations can be added on subtypes
-    Given typeql schema query
-      """
-      define
-      entity child sub person, owns school-id @unique;
-      attribute school-id value string;
-      """
-    Then transaction commits
-
-
-  Scenario: annotations are inherited
-    Given typeql schema query
-      """
-      define entity child sub person;
-      """
-    Given transaction commits
-    Then connection open read transaction for database: typedb
-    When get answers of typeql read query
-      """
-      match $t owns $a @key;
-      """
-    Then uniquely identify answer concepts
-      | t                | a                               |
-      | label:person     | label:email                     |
-      | label:child      | label:email                     |
-      | label:employment | label:employment-reference-code |
-    When get answers of typeql read query
-      """
-      match $t owns $a @unique;
-      """
-    Then uniquely identify answer concepts
-      | t            | a              |
-      | label:person | label:phone-nr |
-      | label:child  | label:phone-nr |
-
-
-  Scenario: redefining inherited annotations throws for types, does not for capabilities
-    Then typeql schema query
-      """
-      define entity child sub person, owns email @key;
-      """
-    Then transaction commits
-    When connection open schema transaction for database: typedb
-    Then typeql schema query
-      """
-      define entity child sub person, owns phone-nr @unique;
-      """
-    Then transaction commits
-    When connection open schema transaction for database: typedb
-    Then typeql schema query
-      """
-      define email @abstract; attribute working-email sub email, value string @regex("^.*@.*$");
-      """
-    Then transaction commits; fails
-
-
-  Scenario: type cannot specialise owns
-    Then typeql schema query; parsing fails
-      """
-      define
-      entity person @abstract;
-      attribute phone-nr @abstract;
-      entity child sub person, owns mobile as phone-nr;
-      """
-
-
-    # TODO: Should be checked without specialise
-#  Scenario: annotations are inherited through specialises
-#    Given typeql schema query
-#      """
-#      define
-#      entity person @abstract;
-#      attribute phone-nr @abstract;
-#      entity child sub person, owns mobile as phone-nr;
-#      attribute mobile sub phone-nr;
-#      """
-#    Given transaction commits
-#    Then connection open schema transaction for database: typedb
-#    When get answers of typeql read query
-#      """
-#      match $t owns $a @unique;
-#      """
-#    Then uniquely identify answer concepts
-#      | t            | a              |
-#      | label:person | label:phone-nr |
-#      | label:child  | label:mobile   |
-#    Given typeql schema query
-#      """
-#      define
-#      entity child @abstract;
-#      attribute mobile @abstract;
-#      entity infant sub child, owns baby-phone-nr as mobile;
-#      attribute baby-phone-nr sub mobile;
-#      """
-#    Given transaction commits
-#    Then connection open read transaction for database: typedb
-#    When get answers of typeql read query
-#      """
-#      match $t owns $a @unique;
-#      """
-#    Then uniquely identify answer concepts
-#      | t            | a                   |
-#      | label:person | label:phone-nr      |
-#      | label:child  | label:mobile        |
-#      | label:infant | label:baby-phone-nr |
-
 
   ###################
   # SCHEMA MUTATION #
@@ -2130,7 +2228,7 @@ Feature: TypeQL Define Query
     Given transaction commits
 
     Given connection open write transaction for database: typedb
-    Given typeql insert
+    Given typeql write query
       """
       insert
       $x isa product, has name "Cheese", has barcode "10001";
@@ -2148,17 +2246,18 @@ Feature: TypeQL Define Query
       """
     Then transaction commits
 
-    Given connection open read transaction for database: typedb
-    When get answers of typeql read query
-      """
-      match $x owns barcode @key;
-      """
-    Then uniquely identify answer concepts
-      | x             |
-      | label:product |
+    # TODO: Uncomment when "match @..." is implemented
+#    Given connection open read transaction for database: typedb
+#    When get answers of typeql read query
+#      """
+#      match $x owns barcode @key;
+#      """
+#    Then uniquely identify answer concepts
+#      | x             |
+#      | label:product |
 
 
-  Scenario: defining a key on a type throws if existing instances don't have that key
+  Scenario: defining a key on a type errors if existing instances don't have that key
     Given typeql schema query
       """
       define
@@ -2168,7 +2267,7 @@ Feature: TypeQL Define Query
     Given transaction commits
 
     Given connection open write transaction for database: typedb
-    Given typeql insert
+    Given typeql write query
       """
       insert
       $x isa product, has name "Cheese";
@@ -2184,7 +2283,7 @@ Feature: TypeQL Define Query
       """
 
 
-  Scenario: defining a key on a type throws if there is a key collision between two existing instances
+  Scenario: defining a key on a type errors if there is a key collision between two existing instances
     Given typeql schema query
       """
       define
@@ -2194,7 +2293,7 @@ Feature: TypeQL Define Query
     Given transaction commits
 
     Given connection open write transaction for database: typedb
-    Given typeql insert
+    Given typeql write query
       """
       insert
       $x isa product, has name "Cheese", has barcode "10000";
@@ -2246,7 +2345,7 @@ Feature: TypeQL Define Query
   Scenario: a regex constraint can be added to an existing attribute type if all its instances satisfy it
     Given transaction closes
     Given connection open write transaction for database: typedb
-    Given typeql insert
+    Given typeql write query
       """
       insert
       $x isa person, has name "Alice", has email "alice@vaticle.com";
@@ -2260,20 +2359,21 @@ Feature: TypeQL Define Query
       """
     Then transaction commits
 
-    Given connection open read transaction for database: typedb
-    Then get answers of typeql read query
-      """
-      match $x @regex("^A.*$");
-      """
-    Then uniquely identify answer concepts
-      | x          |
-      | label:name |
+    # TODO: Uncomment when "match @..." is implemented
+#    Given connection open read transaction for database: typedb
+#    Then get answers of typeql read query
+#      """
+#      match $x @regex("^A.*$");
+#      """
+#    Then uniquely identify answer concepts
+#      | x          |
+#      | label:name |
 
 
   Scenario: a regex cannot be added to an existing attribute type if there is an instance that doesn't satisfy it
     Given transaction closes
     Given connection open write transaction for database: typedb
-    Given typeql insert
+    Given typeql write query
       """
       insert
       $x isa person, has name "Maria", has email "maria@vaticle.com";
@@ -2334,14 +2434,15 @@ Feature: TypeQL Define Query
       """
     Then transaction commits
 
-    Given connection open read transaction for database: typedb
-    When get answers of typeql read query
-      """
-      match $x owns name @key;
-      """
-    Then uniquely identify answer concepts
-      | x            |
-      | label:person |
+    # TODO: Uncomment when "match @..." is implemented
+#    Given connection open read transaction for database: typedb
+#    When get answers of typeql read query
+#      """
+#      match $x owns name @key;
+#      """
+#    Then uniquely identify answer concepts
+#      | x            |
+#      | label:person |
 
 
   Scenario: an attribute key ownership can be converted to a regular ownership
@@ -2359,11 +2460,13 @@ Feature: TypeQL Define Query
     Then uniquely identify answer concepts
       | x            |
       | label:person |
-    When get answers of typeql read query
-      """
-      match $x owns email @key;
-      """
-    Then answer size is: 0
+
+    # TODO: Uncomment when "match @..." is implemented
+#    When get answers of typeql read query; fails ......
+#      """
+#      match $x owns email @key;
+#      """
+#    Then answer size is: 0
 
 
   Scenario: defining a uniqueness on existing ownership is possible if data conforms to uniqueness requirements
@@ -2373,11 +2476,11 @@ Feature: TypeQL Define Query
       """
     Given transaction commits
     Given connection open write transaction for database: typedb
-    When typeql insert
+    When typeql write query
       """
       insert $x isa person, has name "Bob", has email "bob@gmail.com";
       """
-    Then typeql insert
+    Then typeql write query
       """
       insert $x isa person, has name "Jane", has name "Doe", has email "janedoe@gmail.com";
       """
@@ -2388,21 +2491,23 @@ Feature: TypeQL Define Query
       define person owns name @unique;
       """
     Then transaction commits
-    Given connection open write transaction for database: typedb
-    Given typeql insert; fails
-      """
-      insert $x isa person, has name "Bob", has email "bob2@gmail.com";
-      """
+
+    # TODO: Adding this check makes reset take 60 seconds after the failed query...
+#    Given connection open write transaction for database: typedb
+#    Given typeql write query; fails
+#      """
+#      insert $x isa person, has name "Bob", has email "bob2@gmail.com";
+#      """
 
 
   Scenario: defining a uniqueness on existing ownership fail if data does not conform to uniqueness requirements
     Given transaction closes
     Given connection open write transaction for database: typedb
-    When typeql insert
+    When typeql write query
       """
       insert $x isa person, has name "Bob", has email "bob@gmail.com";
       """
-    Then typeql insert
+    Then typeql write query
       """
       insert $x isa person, has name "Bob", has email "bob2@gmail.com";
       """
@@ -2421,7 +2526,7 @@ Feature: TypeQL Define Query
       """
     Given transaction commits
     Given connection open write transaction for database: typedb
-    Given typeql insert
+    Given typeql write query
       """
       insert
       $x isa person, has phone-nr "123", has email "abc@gmail.com";
@@ -2433,7 +2538,7 @@ Feature: TypeQL Define Query
   Scenario: a key ownership can be converted to a unique ownership
     Given transaction closes
     Given connection open write transaction for database: typedb
-    Given typeql insert
+    Given typeql write query
       """
       insert
       $x isa person, has email "jane@gmail.com";
@@ -2441,36 +2546,43 @@ Feature: TypeQL Define Query
       """
     Given transaction commits
     Given connection open schema transaction for database: typedb
-    # TODO: Wait for undefine queries to undefine unique!
+    Given typeql schema query
+      """
+      undefine @key from person owns email;
+      """
     Given typeql schema query
       """
       define person owns email @unique;
       """
     Then transaction commits
+
     Given connection open write transaction for database: typedb
-    When get answers of typeql read query
-      """
-      match $x owns $y @unique;
-      """
-    Then uniquely identify answer concepts
-      | x            | y              |
-      | label:person | label:email    |
-      | label:person | label:phone-nr |
-    When get answers of typeql read query
-      """
-      match person owns $y @key;
-      """
-    Then answer size is: 0
-    Given typeql insert; fails
-      """
-      insert $x isa person, has email "jane@gmail.com";
-      """
+    # TODO: Uncomment when "match @..." is implemented
+#    When get answers of typeql read query
+#      """
+#      match $x owns $y @unique;
+#      """
+#    Then uniquely identify answer concepts
+#      | x            | y              |
+#      | label:person | label:email    |
+#      | label:person | label:phone-nr |
+#    When get answers of typeql read query
+#      """
+#      match person owns $y @key;
+#      """
+#    Then answer size is: 0
+
+    # TODO: Adding this check makes reset take 60 seconds after the failed query...
+#    Given typeql write query; fails
+#      """
+#      insert $x isa person, has email "jane@gmail.com";
+#      """
 
 
   Scenario: converting unique to key is possible if the data conforms to key requirements
     Given transaction closes
     Given connection open write transaction for database: typedb
-    Given typeql insert
+    Given typeql write query
       """
       insert
       $x isa person, has phone-nr "123", has email "abc@gmail.com";
@@ -2478,25 +2590,29 @@ Feature: TypeQL Define Query
       """
     Given transaction commits
     Given connection open schema transaction for database: typedb
-    # TODO: Wait for undefine queries to undefine unique!
     Given typeql schema query
       """
-      define
-      person owns phone-nr @key;
+      undefine @unique from person owns phone-nr;
+      """
+    Given typeql schema query
+      """
+      define person owns phone-nr @key;
       """
     Then transaction commits
-    Given connection open write transaction for database: typedb
-    Then typeql insert; fails
-      """
-      insert $x isa person, has phone-nr "9999", has phone-nr "8888", has email "pqr@gmail.com";
-      """
+
+    # TODO: Adding this check makes reset take 60 seconds after the failed query...
+#    Given connection open write transaction for database: typedb
+#    Then typeql write query; fails
+#      """
+#      insert $x isa person, has phone-nr "9999", has phone-nr "8888", has email "pqr@gmail.com";
+#      """
 
 
   Scenario: converting unique to key fails if the data does not conform to key requirements
     Given transaction closes
     Given connection open write transaction for database: typedb
     # no instances of phone-nr -> 0 vs key's card 1..1
-    Given typeql insert
+    Given typeql write query
       """
       insert $x isa person, has email "abc@gmail.com";
       """
@@ -2508,7 +2624,6 @@ Feature: TypeQL Define Query
       person owns phone-nr @key;
       """
 
-
   #############################
   # SCHEMA MUTATION: ABSTRACT #
   #############################
@@ -2516,18 +2631,19 @@ Feature: TypeQL Define Query
   Scenario: a concrete entity type can be converted to an abstract entity type
     When typeql schema query
       """
-      define person @abstract;
+      define entity person @abstract;
       """
     Then transaction commits
 
-    When connection open read transaction for database: typedb
-    When get answers of typeql read query
-      """
-      match $x sub person; $x @abstract;
-      """
-    Then uniquely identify answer concepts
-      | x            |
-      | label:person |
+    # TODO: Uncomment when "match @..." is implemented
+#    When connection open read transaction for database: typedb
+#    When get answers of typeql read query
+#      """
+#      match $x @abstract, sub person;
+#      """
+#    Then uniquely identify answer concepts
+#      | x            |
+#      | label:person |
 
 
   Scenario: a concrete relation type can be converted to an abstract relation type
@@ -2543,14 +2659,15 @@ Feature: TypeQL Define Query
       """
     Then transaction commits
 
-    Given connection open read transaction for database: typedb
-    When get answers of typeql read query
-      """
-      match $x sub friendship @abstract;
-      """
-    Then uniquely identify answer concepts
-      | x                |
-      | label:friendship |
+    # TODO: Uncomment when "match @..." is implemented
+#    Given connection open read transaction for database: typedb
+#    When get answers of typeql read query
+#      """
+#      match $x @abstract, sub friendship;
+#      """
+#    Then uniquely identify answer concepts
+#      | x                |
+#      | label:friendship |
 
 
   Scenario: a concrete attribute type can be converted to an abstract attribute type
@@ -2565,20 +2682,22 @@ Feature: TypeQL Define Query
       define age @abstract;
       """
     Then transaction commits
-    Given connection open read transaction for database: typedb
-    When get answers of typeql read query
-      """
-      match $x sub age @abstract;
-      """
-    Then uniquely identify answer concepts
-      | x         |
-      | label:age |
+
+    # TODO: Uncomment when "match @..." is implemented
+#    Given connection open read transaction for database: typedb
+#    When get answers of typeql read query
+#      """
+#      match $x @abstract, sub age;
+#      """
+#    Then uniquely identify answer concepts
+#      | x         |
+#      | label:age |
 
 
   Scenario: an existing entity type cannot be converted to abstract if it has existing instances
     Given transaction closes
     Given connection open write transaction for database: typedb
-    Given typeql insert
+    Given typeql write query
       """
       insert
       $x isa person, has name "Jeremy", has email "jeremy@vaticle.com";
@@ -2595,7 +2714,7 @@ Feature: TypeQL Define Query
   Scenario: an existing relation type cannot be converted to abstract if it has existing instances
     Given transaction closes
     Given connection open write transaction for database: typedb
-    Given typeql insert
+    Given typeql write query
       """
       insert
       $x isa person, has name "Jeremy", has email "jeremy@vaticle.com";
@@ -2613,7 +2732,7 @@ Feature: TypeQL Define Query
   Scenario: an existing attribute type cannot be converted to abstract if it has existing instances
     Given transaction closes
     Given connection open write transaction for database: typedb
-    Given typeql insert
+    Given typeql write query
       """
       insert
       $x isa person, has name "Jeremy", has email "jeremy@vaticle.com";
@@ -2626,21 +2745,9 @@ Feature: TypeQL Define Query
       define name @abstract;
       """
 
-
-  Scenario: changing a concrete type to abstract throws on commit if it has a concrete supertype
-
-  @ignore
-  # TODO: re-enable when rules are indexed
-  Scenario: changing a concrete relation type to abstract throws on commit if it appears in the conclusion of any rule
-
-#  @ignore
-#  # TODO: re-enable when rules are indexed
-#  Scenario: changing a concrete attribute type to abstract throws on commit if it appears in the conclusion of any rule
-
   ######################
   # HIERARCHY MUTATION #
   ######################
-
 
   Scenario: an existing entity type cannot be switched to a new supertype through define
     Given typeql schema query
@@ -2674,44 +2781,6 @@ Feature: TypeQL Define Query
       define
       relation sabbatical sub vacation;
       """
-
-
-  Scenario: an existing attribute type can be switched to a new supertype with a matching value type
-    Given typeql schema query
-      """
-      define
-      attribute measure @abstract, value double;
-      attribute shoe-size sub measure;
-      entity shoe owns shoe-size;
-      """
-    Given transaction commits
-
-    Given connection open write transaction for database: typedb
-    # TODO: 9 is considered long, while it should be transformed into double before thing_manager
-    Given typeql insert
-      """
-      insert $s isa shoe, has shoe-size 9;
-      """
-    Given transaction commits
-
-    Given connection open schema transaction for database: typedb
-    When typeql schema query
-      """
-      define
-      attribute size value double @abstract;
-      attribute shoe-size sub size;
-      """
-    # TODO: This will probably fail because of the value type redundancy. Move this test to redefine/undefine?
-    Then transaction commits
-
-    When connection open read transaction for database: typedb
-    When get answers of typeql read query
-      """
-      match $x sub shoe-size;
-      """
-    Then uniquely identify answer concepts
-      | x               |
-      | label:shoe-size |
 
 
   Scenario: assigning a supertype without previous supertype succeeds even if they have different attributes + roles, if there are no instances
@@ -2756,7 +2825,7 @@ Feature: TypeQL Define Query
     Given transaction commits
 
     Given connection open write transaction for database: typedb
-    Given typeql insert
+    Given typeql write query
       """
       insert $p isa pigeon;
       """
@@ -2780,7 +2849,7 @@ Feature: TypeQL Define Query
     Given transaction commits
 
     Given connection open write transaction for database: typedb
-    Given typeql insert
+    Given typeql write query
       """
       insert $p isa pigeon2;
       """
@@ -2804,7 +2873,7 @@ Feature: TypeQL Define Query
     Given transaction commits
 
     Given connection open write transaction for database: typedb
-    Given typeql insert
+    Given typeql write query
       """
       insert $p isa pigeon3;
       """
@@ -2838,32 +2907,9 @@ Feature: TypeQL Define Query
       entity person sub species;
       """
 
-
-  # TODO: write this once 'assign new supertype .. with existing data' succeeds if the supertypes have the same attributes
-  Scenario: assigning a new supertype throws if existing data has attributes not present on the new supertype
-
-  # TODO: write this once 'assign new supertype .. with existing data' succeeds if the supertypes play the same roles
-  Scenario: assigning a new supertype throws if existing data plays a role that it can't with the new supertype
-
-  # TODO: write this once 'assign new supertype throws if .. data has attributes not present on the new supertype' is written
-  Scenario: assigning a new supertype throws if that supertype has a has not @key present in the existing data (?)
-
-  # TODO: write this once 'define new 'sub' on relation type changes its supertype' is written
-  Scenario: assigning a new super-relation throws if existing data has roleplayers not present on the new supertype (?)
-
-  # TODO: write this once 'define new 'sub' on attribute type changes its supertype' passes
-  Scenario: assigning a new super-attribute throws if it has a different value type (?)
-
-  # TODO: write this if 'assign new super-attribute throws if it has a different value type ..' turns out to not throw
-  Scenario: assigning a new super-attribute throws if it has existing data and a different value type (?)
-
-  # TODO: write this once 'define new 'sub' on attribute type changes its supertype' passes
-  Scenario: assigning a new super-attribute throws if the new supertype has a regex and existing data doesn't match it (?)
-
   ###############################
   # SCHEMA MUTATION INHERITANCE #
   ###############################
-
 
   Scenario: when adding a playable role to an existing type, the change is propagated to its subtypes
     Given typeql schema query
@@ -2920,15 +2966,16 @@ Feature: TypeQL Define Query
       """
     Given transaction commits
 
-    Given connection open read transaction for database: typedb
-    When get answers of typeql read query
-      """
-      match $x label child, owns $y @key;
-      """
-    Then uniquely identify answer concepts
-      | x           | y                  |
-      | label:child | label:email        |
-      | label:child | label:phone-number |
+    # TODO: Uncomment when "match @..." is implemented
+#    Given connection open read transaction for database: typedb
+#    When get answers of typeql read query
+#      """
+#      match $x label child, owns $y @key;
+#      """
+#    Then uniquely identify answer concepts
+#      | x           | y                  |
+#      | label:child | label:email        |
+#      | label:child | label:phone-number |
 
 
   Scenario: when adding a related role to an existing relation type, the change is propagated to all its subtypes
@@ -2950,7 +2997,6 @@ Feature: TypeQL Define Query
       | label:part-time-employment | label:employment:employee |
       | label:part-time-employment | label:employment:employer |
 
-
   ####################
   # TRANSACTIONALITY #
   ####################
@@ -2960,16 +3006,12 @@ Feature: TypeQL Define Query
       """
       define entity dog;
       """
-    # TODO: The current framework doesn't support another transaction from the same client without closing the
-    # already existing one. It might contradict the test!
     Given transaction closes
     Given connection open read transaction for database: typedb
-    # TODO: What did this "fails" mean?
-    Then typeql get; fails
+    Then typeql read query; fails with a message containing: "not found"
       """
       match $x label dog;
       """
-
 
   ########################
   # CYCLIC SCHEMA GRAPHS #
@@ -3071,5 +3113,7 @@ Feature: TypeQL Define Query
       """
     Then transaction commits
 
-    # TODO 3.0: Add tests for structs
+    # TODO 3.x: Add tests for structs
+
+
     # TODO 3.0: Add tests for functions

--- a/query/language/match.feature
+++ b/query/language/match.feature
@@ -245,6 +245,29 @@ Feature: TypeQL Match Clause
       | label:person |
 
 
+  Scenario: 'owns' matches types that own the specified attribute type with their inheriting subtypes
+    Given typeql schema query
+      """
+      define
+      entity child sub person;
+      entity man sub person;
+      entity boy sub man;
+      """
+    Given transaction commits
+
+    Given connection open read transaction for database: typedb
+    When get answers of typeql read query
+      """
+      match $x owns age;
+      """
+    Then uniquely identify answer concepts
+      | x            |
+      | label:person |
+      | label:child  |
+      | label:man    |
+      | label:boy    |
+
+
   Scenario: 'owns' does not match types that own only a subtype of the specified attribute type
     Given typeql schema query
       """
@@ -338,6 +361,7 @@ Feature: TypeQL Match Clause
   #     | label:person | label:email |
 
 
+  # TODO: handle different annotations for different types/capabilities
   # TODO: handle type statement annotations
   # Scenario: inherited 'owns' annotations are queryable
   #   Given typeql schema query
@@ -429,6 +453,29 @@ Feature: TypeQL Match Clause
     Then uniquely identify answer concepts
       | x            |
       | label:person |
+
+
+  Scenario: 'plays' matches types that own the specified attribute type with their inheriting subtypes
+    Given typeql schema query
+      """
+      define
+      entity child sub person;
+      entity man sub person;
+      entity boy sub man;
+      """
+    Given transaction commits
+
+    Given connection open read transaction for database: typedb
+    When get answers of typeql read query
+      """
+      match $x plays friendship:friend;
+      """
+    Then uniquely identify answer concepts
+      | x            |
+      | label:person |
+      | label:child  |
+      | label:man    |
+      | label:boy    |
 
 
   Scenario: 'plays' does not match types that only play a subrole of the specified role
@@ -590,6 +637,30 @@ Feature: TypeQL Match Clause
       | x                |
       | label:employment |
 
+
+  Scenario: 'plays' matches types that own the specified attribute type with their inheriting subtypes
+    Given typeql schema query
+      """
+      define
+      relation part-time-employment sub employment;
+      relation full-time-employment sub employment;
+      relation internship sub full-time-employment;
+      """
+    Given transaction commits
+
+    Given connection open read transaction for database: typedb
+    When get answers of typeql read query
+      """
+      match $x relates employee;
+      """
+    Then uniquely identify answer concepts
+      | x                          |
+      | label:employment           |
+      | label:part-time-employment |
+      | label:full-time-employment |
+      | label:internship           |
+
+
   # TODO cannot currently query for schema with 'as'
   @ignore
   Scenario: 'relates' with 'as' matches relation types that specialise the specified roleplayer
@@ -676,11 +747,11 @@ Feature: TypeQL Match Clause
       match $x isa $y;
       """
     Then uniquely identify answer concepts
-      | x          | y               |
-      | key:ref:0  | label:person    |
-      | key:ref:1  | label:person    |
-      | attr:ref:0 | label:ref       |
-      | attr:ref:1 | label:ref       |
+      | x          | y            |
+      | key:ref:0  | label:person |
+      | key:ref:1  | label:person |
+      | attr:ref:0 | label:ref    |
+      | attr:ref:1 | label:ref    |
 
   Scenario: 'isa' matches things of the specified type and all its subtypes
     Given typeql schema query
@@ -1456,14 +1527,14 @@ Feature: TypeQL Match Clause
     Then answer size is: 0
 
     Examples:
-      | attr        | type        | value                              |
-      | colour      | string      | "Green"                            |
-      | calories    | long        | 1761                               |
-      | grams       | double      | 9.6                                |
-      | gluten-free | boolean     | false                              |
-      | use-by-date | datetime    | 2020-06-16                         |
-      | global-date | datetime-tz | 1990-01-01T11:22:33-0100           |
-      | interval    | duration    | P1Y2M3DT4H5M6.789S                 |
+      | attr        | type        | value                    |
+      | colour      | string      | "Green"                  |
+      | calories    | long        | 1761                     |
+      | grams       | double      | 9.6                      |
+      | gluten-free | boolean     | false                    |
+      | use-by-date | datetime    | 2020-06-16               |
+      | global-date | datetime-tz | 1990-01-01T11:22:33-0100 |
+      | interval    | duration    | P1Y2M3DT4H5M6.789S       |
 
 
   # TODO `like` / `contains`
@@ -2362,9 +2433,9 @@ Feature: TypeQL Match Clause
       match $phrase isa favorite-phrase;
       """
     Then uniquely identify answer concepts
-      | phrase                             |
+      | phrase                        |
       | attr:favorite-phrase:你明白了吗    |
-      | attr:favorite-phrase:בוקר טוב      |
+      | attr:favorite-phrase:בוקר טוב |
 
     Given get answers of typeql read query
       """
@@ -2412,7 +2483,7 @@ Feature: TypeQL Match Clause
       """
     Then uniquely identify answer concepts
       | t         |
-      | label:人  |
+      | label:人   |
       | label:אדם |
 
     Given get answers of typeql read query
@@ -2450,7 +2521,7 @@ Feature: TypeQL Match Clause
       match $人 isa person; $人 has name "Liu";
       """
     Then uniquely identify answer concepts
-      | 人        |
+      | 人         |
       | key:ref:0 |
 
     Given get answers of typeql read query

--- a/query/language/match.feature
+++ b/query/language/match.feature
@@ -455,7 +455,7 @@ Feature: TypeQL Match Clause
       | label:person |
 
 
-  Scenario: 'plays' matches types that own the specified attribute type with their inheriting subtypes
+  Scenario: 'plays' matches types that play the specified role type with their inheriting subtypes
     Given typeql schema query
       """
       define
@@ -638,13 +638,34 @@ Feature: TypeQL Match Clause
       | label:employment |
 
 
-  Scenario: 'plays' matches types that own the specified attribute type with their inheriting subtypes
+  Scenario: 'relates' matches types that relate the specified role type with their inheriting subtypes, even as specialised
     Given typeql schema query
       """
       define
       relation part-time-employment sub employment;
       relation full-time-employment sub employment;
       relation internship sub full-time-employment;
+      """
+    Given transaction commits
+
+    Given connection open read transaction for database: typedb
+    When get answers of typeql read query
+      """
+      match $x relates employee;
+      """
+    Then uniquely identify answer concepts
+      | x                          |
+      | label:employment           |
+      | label:part-time-employment |
+      | label:full-time-employment |
+      | label:internship           |
+    When transaction closes
+
+    Given connection open schema transaction for database: typedb
+    When typeql schema query
+      """
+      define
+      relation full-time-employment relates full-time-employee as employee;
       """
     Given transaction commits
 

--- a/query/language/match.feature
+++ b/query/language/match.feature
@@ -1490,47 +1490,302 @@ Feature: TypeQL Match Clause
     """
     Then answer size is: 1
 
+
+# TODO: Uncomment "as!" steps when it is implemented
+  Scenario: match 'as' pattern works similarly to `sub`
+    Given typeql schema query
+      """
+      define
+      relation parentship relates parent, relates child;
+      relation fathership sub parentship, relates father as parent, relates father-child as child;
+      relation adoption relates adopter, relates adoptee;
+      relation child-adoption sub adoption, relates child as adoptee;
+      relation boy-adoption sub child-adoption, relates boy as child;
+      """
+    Given transaction commits
+
+    When connection open read transaction for database: typedb
+    When get answers of typeql read query
+      """
+      match
+      $x relates $_ as parentship:child;
+      """
+    Then uniquely identify answer concepts
+      | x                |
+      | label:fathership |
+      | label:parentship |
+
+#    When get answers of typeql read query
+#      """
+#      match
+#      $x relates $_ as! parentship:child;
+#      """
+#    Then uniquely identify answer concepts
+#      | x                |
+#      | label:fathership |
+
+    When get answers of typeql read query
+      """
+      match
+      $x relates $_ as child;
+      """
+    Then uniquely identify answer concepts
+      | x                    |
+      | label:parentship     |
+      | label:fathership     |
+      | label:boy-adoption   |
+      | label:child-adoption |
+
+#    When get answers of typeql read query
+#      """
+#      match
+#      $x relates $_ as! child;
+#      """
+#    Then uniquely identify answer concepts
+#      | x                  |
+#      | label:fathership   |
+#      | label:boy-adoption |
+
+    When get answers of typeql read query
+      """
+      match
+      $x relates $_ as parentship:parent;
+      """
+    Then uniquely identify answer concepts
+      | x                |
+      | label:parentship |
+      | label:fathership |
+
+#    When get answers of typeql read query
+#      """
+#      match
+#      $x relates $_ as! parentship:parent;
+#      """
+#    Then uniquely identify answer concepts
+#      | x                |
+#      | label:fathership |
+
+    When get answers of typeql read query
+      """
+      match
+      $x relates $_ as parent;
+      """
+    Then uniquely identify answer concepts
+      | x                |
+      | label:parentship |
+      | label:fathership |
+
+#    When get answers of typeql read query
+#      """
+#      match
+#      $x relates $_ as! parent;
+#      """
+#    Then uniquely identify answer concepts
+#      | x                |
+#      | label:fathership |
+
+    When get answers of typeql read query
+      """
+      match
+      $_ relates $x as parentship:child;
+      """
+    Then uniquely identify answer concepts
+      | x                             |
+      | label:parentship:child        |
+      | label:fathership:father-child |
+
+#    When get answers of typeql read query
+#      """
+#      match
+#      $_ relates $x as! parentship:child;
+#      """
+#    Then uniquely identify answer concepts
+#      | x                  |
+#      | label:father-child |
+
+    When get answers of typeql read query
+      """
+      match
+      $_ relates $x as child;
+      """
+    Then uniquely identify answer concepts
+      | x                             |
+      | label:parentship:child        |
+      | label:fathership:father-child |
+      | label:child-adoption:child    |
+      | label:boy-adoption:boy        |
+
+#    When get answers of typeql read query
+#      """
+#      match
+#      $_ relates $x as! child;
+#      """
+#    Then uniquely identify answer concepts
+#      | x                             |
+#      | label:fathership:father-child |
+#      | label:boy-adoption:boy        |
+
+    When get answers of typeql read query
+      """
+      match
+      $_ relates $x as parentship:parent;
+      """
+    Then uniquely identify answer concepts
+      | x                       |
+      | label:parentship:parent |
+      | label:fathership:father |
+
+#    When get answers of typeql read query
+#      """
+#      match
+#      $_ relates $x as! parentship:parent;
+#      """
+#    Then uniquely identify answer concepts
+#      | x                       |
+#      | label:fathership:father |
+
+    When get answers of typeql read query
+      """
+      match
+      $_ relates $x as parent;
+      """
+    Then uniquely identify answer concepts
+      | x                       |
+      | label:parentship:parent |
+      | label:fathership:father |
+
+#    When get answers of typeql read query
+#      """
+#      match
+#      $_ relates $x as! parent;
+#      """
+#    Then uniquely identify answer concepts
+#      | x                       |
+#      | label:fathership:father |
+
   ##############
   # ATTRIBUTES #
   ##############
 
-  # TODO: `value` type constraint
-  # Scenario Outline: '<type>' attributes can be matched by value
-  #   Given typeql schema query
-  #     """
-  #     define attribute <attr> @independent, value <type>;
-  #     """
-  #   Given transaction commits
-  #
-  #   Given connection open write transaction for database: typedb
-  #   Given typeql write query
-  #     """
-  #     insert $n <value> isa <attr>;
-  #     """
-  #   Given transaction commits
-  #
-  #   Given connection open read transaction for database: typedb
-  #   When get answers of typeql read query
-  #     """
-  #     match $a <value> isa <attr>;
-  #     """
-  #   Then uniquely identify answer concepts
-  #     | a                   |
-  #     | attr:<attr>:<value> |
-  #
-  #   Examples:
-  #     | attr              | type        | value                              |
-  #     | is-alive          | boolean     | true                               |
-  #     | age               | long        | 21                                 |
-  #     | score             | double      | 123.456                            |
-  #     | balance           | decimal     | 123.456                            |
-  #     | name              | string      | "alice"                            |
-  #     | birth-date        | date        | 1990-01-01                         |
-  #     | event-datetime    | datetime    | 1990-01-01T11:22:33.123456789      |
-  #     | global-date       | datetime-tz | 1990-01-01T11:22:33 Asia/Kathmandu |
-  #     | global-date       | datetime-tz | 1990-01-01T11:22:33-0100           |
-  #     | schedule-interval | duration    | P1Y2M3DT4H5M6.789S                 |
-  #     | schedule-interval | duration    | P1Y2M3DT4H5M6S                     |
+  Scenario: match value pattern works for all built-in value types
+    Given typeql schema query
+      """
+      define
+      attribute root @abstract;
+      attribute age, value long;
+      attribute name, value string;
+      attribute is-new, value boolean;
+      attribute success, value double;
+      attribute balance, value decimal;
+      attribute birth-date, value date;
+      attribute birth-time, value datetime;
+      attribute current-time, value datetime-tz;
+      attribute expiration, value duration;
+      """
+    Given transaction commits
+
+    Given connection open schema transaction for database: typedb
+    When get answers of typeql read query
+      """
+      match
+      $lo value long;
+      $st value string;
+      $bo value boolean;
+      $do value double;
+      $de value decimal;
+      $date value date;
+      $datet value datetime;
+      $datet-t value datetime-tz;
+      $du value duration;
+
+      not { $st label email; };
+      not { $lo label ref; };
+      """
+    Then uniquely identify answer concepts
+      | lo        | st         | bo           | do            | de            | date             | datet            | datet-t            | du               |
+      | label:age | label:name | label:is-new | label:success | label:balance | label:birth-date | label:birth-time | label:current-time | label:expiration |
+
+    When typeql schema query
+      """
+      define
+      balance @abstract;
+      attribute shared-balance @abstract, sub balance;
+      attribute family-surname sub shared-balance;
+      attribute loading-time sub root, value duration;
+      """
+    When transaction commits
+
+    When connection open read transaction for database: typedb
+    When get answers of typeql read query
+      """
+      match
+      $de value decimal;
+      """
+    Then uniquely identify answer concepts
+      | de                   |
+      | label:balance        |
+      | label:shared-balance |
+      | label:family-surname |
+
+    When get answers of typeql read query
+      """
+      match
+      $du value duration;
+      """
+    Then uniquely identify answer concepts
+      | du                 |
+      | label:expiration   |
+      | label:loading-time |
+
+    When get answers of typeql read query
+      """
+      match
+      $datet value datetime;
+      """
+    Then uniquely identify answer concepts
+      | datet            |
+      | label:birth-time |
+
+
+  Scenario Outline: '<type>' attributes can be matched by value
+    Given typeql schema query
+       """
+       define attribute <attr> @independent, value <type>;
+       """
+    Given transaction commits
+
+    Given connection open write transaction for database: typedb
+    Given typeql write query
+       """
+       insert $n <value> isa <attr>;
+       """
+    Given transaction commits
+
+    Given connection open read transaction for database: typedb
+    When get answers of typeql read query
+       """
+       match $a <value> isa <attr>;
+       """
+    Then uniquely identify answer concepts
+      | a                   |
+      | attr:<attr>:<value> |
+
+    Examples:
+      | attr              | type        | value                              |
+      | is-alive          | boolean     | true                               |
+      | age               | long        | 21                                 |
+      | score             | double      | 123.456                            |
+      | balance           | decimal     | 123.456                            |
+      | name              | string      | "alice"                            |
+      | birth-date        | date        | 1990-01-01                         |
+      | event-datetime    | datetime    | 1990-01-01T11:22:33.123456789      |
+      | global-date       | datetime-tz | 1990-01-01T11:22:33 Asia/Kathmandu |
+      | global-date       | datetime-tz | 1990-01-01T11:22:33-0100           |
+      | schedule-interval | duration    | P1Y2M3DT4H5M6.789S                 |
+      | schedule-interval | duration    | P1Y2M3DT4H5M6S                     |
+
+
+    # TODO: Add tests for structs
 
 
   Scenario Outline: when matching a '<type>' attribute by a value that doesn't exist, an empty answer is returned
@@ -2102,14 +2357,14 @@ Feature: TypeQL Match Clause
 
   Scenario: when one entity exists, and we match two variables with concept inequality, an empty answer is returned
     Given transaction commits
-  
+
     Given connection open write transaction for database: typedb
     Given typeql write query
       """
       insert $x isa person, has ref 0;
       """
     Given transaction commits
-  
+
     Given connection open read transaction for database: typedb
     When get answers of typeql read query
       """
@@ -2455,7 +2710,7 @@ Feature: TypeQL Match Clause
       """
     Then uniquely identify answer concepts
       | phrase                        |
-      | attr:favorite-phrase:你明白了吗 |
+      | attr:favorite-phrase:你明白了吗    |
       | attr:favorite-phrase:בוקר טוב |
 
     Given get answers of typeql read query

--- a/query/language/match.feature
+++ b/query/language/match.feature
@@ -1614,15 +1614,15 @@ Feature: TypeQL Match Clause
 #      | x                  |
 #      | label:fathership:father-child |
 
-#    When get answers of typeql read query
-#      """
-#      match
-#      $y relates $x;
-#      $x sub! parentship:child;
-#      """
-#    Then uniquely identify answer concepts
-#      | x                             | y                |
-#      | label:fathership:father-child | label:fathership |
+    When get answers of typeql read query
+      """
+      match
+      $y relates $x;
+      $x sub! parentship:child;
+      """
+    Then uniquely identify answer concepts
+      | x                             | y                |
+      | label:fathership:father-child | label:fathership |
 
     When get answers of typeql read query
       """

--- a/query/language/match.feature
+++ b/query/language/match.feature
@@ -1594,6 +1594,17 @@ Feature: TypeQL Match Clause
       | label:parentship:child        |
       | label:fathership:father-child |
 
+    When get answers of typeql read query
+      """
+      match
+      $y relates $x;
+      $x sub parentship:child;
+      """
+    Then uniquely identify answer concepts
+      | x                             | y                |
+      | label:parentship:child        | label:parentship |
+      | label:fathership:father-child | label:fathership |
+
 #    When get answers of typeql read query
 #      """
 #      match
@@ -1601,7 +1612,17 @@ Feature: TypeQL Match Clause
 #      """
 #    Then uniquely identify answer concepts
 #      | x                  |
-#      | label:father-child |
+#      | label:fathership:father-child |
+
+#    When get answers of typeql read query
+#      """
+#      match
+#      $y relates $x;
+#      $x sub! parentship:child;
+#      """
+#    Then uniquely identify answer concepts
+#      | x                             | y                |
+#      | label:fathership:father-child | label:fathership |
 
     When get answers of typeql read query
       """

--- a/query/language/match.feature
+++ b/query/language/match.feature
@@ -2455,7 +2455,7 @@ Feature: TypeQL Match Clause
       """
     Then uniquely identify answer concepts
       | phrase                        |
-      | attr:favorite-phrase:你明白了吗    |
+      | attr:favorite-phrase:你明白了吗 |
       | attr:favorite-phrase:בוקר טוב |
 
     Given get answers of typeql read query

--- a/query/language/match.feature
+++ b/query/language/match.feature
@@ -1492,7 +1492,7 @@ Feature: TypeQL Match Clause
 
 
 # TODO: Uncomment "as!" steps when it is implemented
-  Scenario: match 'as' pattern works similarly to `sub`
+  Scenario: match 'as' pattern works similarly to `sub`, but with a constraint to declared `as`
     Given typeql schema query
       """
       define
@@ -1603,6 +1603,7 @@ Feature: TypeQL Match Clause
     Then uniquely identify answer concepts
       | x                             | y                |
       | label:parentship:child        | label:parentship |
+      | label:parentship:child        | label:fathership |
       | label:fathership:father-child | label:fathership |
 
 #    When get answers of typeql read query

--- a/query/language/redefine.feature
+++ b/query/language/redefine.feature
@@ -525,21 +525,16 @@ Feature: TypeQL Redefine Query
       """
     Then transaction commits
 
-    When connection open read transaction for database: typedb
-    When get answers of typeql read query
-      """
-      match $_ relates $x as empty-abstract-role;
-      """
-    # TODO: This is incorrect! Fix the executor and add tests to match.feature. Skip for now...
-    Then uniquely identify answer concepts
-      | x                                         |
-      | label:employment:employee                 |
-      | label:income:earner                       |
-      | label:income:source                       |
-      | label:empty-relation:empty-role           |
-      | label:empty-relation:empty-abstract-role  |
-      | label:part-time-employment:part-time-role |
-    When transaction closes
+    # TODO: Uncomment when querying for specialise works. Now it returns every `$_ relates $x`.
+#    When connection open read transaction for database: typedb
+#    When get answers of typeql read query
+#      """
+#      match $_ relates $x as empty-abstract-role;
+#      """
+#    Then uniquely identify answer concepts
+#      | x                                         |
+#      | label:part-time-employment:part-time-role |
+#    When transaction closes
 
     When connection open schema transaction for database: typedb
     Then typeql schema query; fails with a message containing: "already defined"
@@ -869,6 +864,12 @@ Feature: TypeQL Redefine Query
       redefine attribute phone-nr value string;
       """
     Then transaction commits
+
+  ###########
+  # STRUCTS #
+  ###########
+
+    # TODO 3.x: Add tests for structs
 
   ###############
   # ANNOTATIONS #
@@ -1585,9 +1586,6 @@ Feature: TypeQL Redefine Query
     Then uniquely identify answer concepts
       | x            |
       | label:pigeon |
-
-
-    # TODO 3.0: Add tests for structs
 
 
     # TODO 3.0: Add tests for functions?

--- a/query/language/redefine.feature
+++ b/query/language/redefine.feature
@@ -39,7 +39,6 @@ Feature: TypeQL Redefine Query
 
     Given connection open schema transaction for database: typedb
 
-
   ################
   # ENTITY TYPES #
   ################
@@ -188,15 +187,16 @@ Feature: TypeQL Redefine Query
       """
     Then transaction commits
 
-    When connection open read transaction for database: typedb
-    When get answers of typeql read query
-      """
-      match $x owns name[];
-      """
-    Then uniquely identify answer concepts
-      | x            |
-      | label:person |
-    When transaction closes
+    # TODO: Uncomment when match with lists is implemented
+#    When connection open read transaction for database: typedb
+#    When get answers of typeql read query
+#      """
+#      match $x owns name[];
+#      """
+#    Then uniquely identify answer concepts
+#      | x            |
+#      | label:person |
+#    When transaction closes
 
     When connection open schema transaction for database: typedb
     When typeql schema query
@@ -272,7 +272,6 @@ Feature: TypeQL Redefine Query
       """
       redefine entity $x;
       """
-
 
   ##################
   # RELATION TYPES #
@@ -351,9 +350,9 @@ Feature: TypeQL Redefine Query
       match $x sub employment;
       """
     Then uniquely identify answer concepts
-      | x                    |
-      | label:employment     |
-      | label:fun-employment |
+      | x                          |
+      | label:employment           |
+      | label:part-time-employment |
 
 
   Scenario: a redefined relation subtype inherits roles from its supertype
@@ -414,15 +413,16 @@ Feature: TypeQL Redefine Query
       """
     Then transaction commits
 
-    When connection open read transaction for database: typedb
-    When get answers of typeql read query
-      """
-      match $x relates employee[];
-      """
-    Then uniquely identify answer concepts
-      | x                |
-      | label:employment |
-    When transaction closes
+    # TODO: Uncomment when match with lists is implemented
+#    When connection open read transaction for database: typedb
+#    When get answers of typeql read query
+#      """
+#      match $x relates employee[];
+#      """
+#    Then uniquely identify answer concepts
+#      | x                |
+#      | label:employment |
+#    When transaction closes
 
     When connection open schema transaction for database: typedb
     When typeql schema query
@@ -462,15 +462,16 @@ Feature: TypeQL Redefine Query
       """
     Then transaction commits
 
-    When connection open read transaction for database: typedb
-    When get answers of typeql read query
-      """
-      match $x owns start-date[];
-      """
-    Then uniquely identify answer concepts
-      | x                |
-      | label:employment |
-    When transaction closes
+    # TODO: Uncomment when match with lists is implemented
+#    When connection open read transaction for database: typedb
+#    When get answers of typeql read query
+#      """
+#      match $x owns start-date[];
+#      """
+#    Then uniquely identify answer concepts
+#      | x                |
+#      | label:employment |
+#    When transaction closes
 
     When connection open schema transaction for database: typedb
     When typeql schema query
@@ -526,7 +527,6 @@ Feature: TypeQL Redefine Query
       redefine relation $x;
       """
 
-
   ###################
   # ATTRIBUTE TYPES #
   ###################
@@ -573,6 +573,45 @@ Feature: TypeQL Redefine Query
       redefine
       attribute email value string @regex("^.*@.*$") @range("A".."zzzzzzzzzzzzzzzzzzzzzzzzzz");
       """
+
+  Scenario: an existing attribute type can be switched to a new supertype with a matching value type
+    Given typeql schema query
+      """
+      define
+      attribute measure @abstract, value double;
+      attribute shoe-size sub measure;
+      entity shoe owns shoe-size;
+      """
+    Given transaction commits
+
+    Given connection open write transaction for database: typedb
+    Given typeql write query
+      """
+      insert $s isa shoe, has shoe-size 9;
+      """
+    Given transaction commits
+
+    Given connection open schema transaction for database: typedb
+    When typeql schema query
+      """
+      define
+      attribute size @abstract, value double;
+      """
+    When typeql schema query
+      """
+      redefine
+      attribute shoe-size sub size;
+      """
+    Then transaction commits
+
+    When connection open read transaction for database: typedb
+    When get answers of typeql read query
+      """
+      match $x sub shoe-size;
+      """
+    Then uniquely identify answer concepts
+      | x               |
+      | label:shoe-size |
 
 
   Scenario Outline: attribute types' value type can be redefined from '<value-type-1>' to '<value-type-2>'
@@ -641,14 +680,15 @@ Feature: TypeQL Redefine Query
       """
     Then transaction commits
 
-    Given connection open read transaction for database: typedb
-    When get answers of typeql read query
-      """
-      match $x label empty-sub-data, value decimal;
-      """
-    Then uniquely identify answer concepts
-      | x                    |
-      | label:empty-sub-data |
+    # TODO: ConstraintBase::ValueType is not implemented
+#    Given connection open read transaction for database: typedb
+#    When get answers of typeql read query
+#      """
+#      match $x label empty-sub-data, value decimal;
+#      """
+#    Then uniquely identify answer concepts
+#      | x                    |
+#      | label:empty-sub-data |
 
 
   Scenario: redefining an attribute subtype throws if it is given a different value type to what its parent has
@@ -701,7 +741,6 @@ Feature: TypeQL Redefine Query
       redefine attribute phone-nr value string;
       """
     Then transaction commits
-
 
   ###############
   # ANNOTATIONS #
@@ -1205,7 +1244,6 @@ Feature: TypeQL Redefine Query
       """
     Then transaction commits
 
-
   ######################
   # HIERARCHY MUTATION #
   ######################
@@ -1275,7 +1313,7 @@ Feature: TypeQL Redefine Query
       relation species-membership relates species, relates member;
       attribute lifespan value double;
       entity organism owns lifespan, plays species-membership:member;
-      entity human sub person;
+      entity human sub creature;
       """
     Given transaction commits
 
@@ -1283,7 +1321,7 @@ Feature: TypeQL Redefine Query
     When typeql schema query
       """
       redefine
-      entity creature sub organism;
+      creature sub organism;
       """
     Then transaction commits
 
@@ -1309,7 +1347,7 @@ Feature: TypeQL Redefine Query
     Given transaction commits
 
     Given connection open write transaction for database: typedb
-    Given typeql insert
+    Given typeql write query
       """
       insert $p isa pigeon;
       """
@@ -1349,7 +1387,7 @@ Feature: TypeQL Redefine Query
     Given transaction commits
 
     Given connection open write transaction for database: typedb
-    Given typeql insert
+    Given typeql write query
       """
       insert $p isa pigeon;
       """
@@ -1389,7 +1427,7 @@ Feature: TypeQL Redefine Query
     Given transaction commits
 
     Given connection open write transaction for database: typedb
-    Given typeql insert
+    Given typeql write query
       """
       insert $p isa pigeon;
       """

--- a/query/language/undefine.feature
+++ b/query/language/undefine.feature
@@ -70,7 +70,7 @@ Feature: TypeQL Undefine Query
       """
     Given transaction commits
 
-    When connection open write transaction for database: typedb
+    When connection open schema transaction for database: typedb
     Given get answers of typeql read query
       """
       match $x sub person;
@@ -111,7 +111,7 @@ Feature: TypeQL Undefine Query
       | x            |
       | label:person |
       | label:child  |
-    When connection open write transaction for database: typedb
+    When connection open schema transaction for database: typedb
     When typeql schema query
       """
       undefine child;
@@ -135,7 +135,7 @@ Feature: TypeQL Undefine Query
       """
     Given transaction commits
 
-    When connection open write transaction for database: typedb
+    When connection open schema transaction for database: typedb
     Then typeql schema query; fails
       """
       undefine person;
@@ -149,19 +149,18 @@ Feature: TypeQL Undefine Query
       """
     Given transaction commits
 
-    When connection open write transaction for database: typedb
+    When connection open schema transaction for database: typedb
     When typeql schema query
       """
-      undefine person plays employment:employee;
+      undefine plays employment:employee from person;
       """
     Then transaction commits
 
     When connection open read transaction for database: typedb
-    When get answers of typeql read query
+    Then typeql read query; fails with a message containing: "empty-set for some variable"
       """
       match $x label child; $x plays employment:employee;
       """
-    Then answer size is: 0
 
 
   Scenario: removing an attribute ownership from a super entity type also removes it from its subtypes
@@ -171,19 +170,18 @@ Feature: TypeQL Undefine Query
       """
     Given transaction commits
 
-    When connection open write transaction for database: typedb
+    When connection open schema transaction for database: typedb
     When typeql schema query
       """
-      undefine person owns name;
+      undefine owns name from person;
       """
     Then transaction commits
 
     When connection open read transaction for database: typedb
-    When get answers of typeql read query
+    Then typeql read query; fails with a message containing: "empty-set for some variable"
       """
       match $x label child; $x owns name;
       """
-    Then answer size is: 0
 
 
   Scenario: removing a key ownership from a super entity type also removes it from its subtypes
@@ -193,19 +191,19 @@ Feature: TypeQL Undefine Query
       """
     Given transaction commits
 
-    When connection open write transaction for database: typedb
+    When connection open schema transaction for database: typedb
     When typeql schema query
       """
-      undefine person owns email;
+      undefine owns email from person;
       """
     Then transaction commits
 
     When connection open read transaction for database: typedb
-    When get answers of typeql read query
+    Then typeql read query; fails with a message containing: "empty-set for some variable"
       """
-      match $x label child; $x owns email @key;
+      match $x label child; $x owns email;
       """
-    Then answer size is: 0
+
 
   Scenario: all existing instances of an entity type must be deleted in order to undefine it
     Given get answers of typeql read query
@@ -227,14 +225,14 @@ Feature: TypeQL Undefine Query
     Given transaction commits
 
     Given transaction closes
-    When connection open write transaction for database: typedb
+    When connection open schema transaction for database: typedb
     Then typeql schema query; fails
       """
       undefine person;
       """
 
     When transaction closes
-    When connection open write transaction for database: typedb
+    When connection open schema transaction for database: typedb
     When typeql write query
       """
       match
@@ -245,7 +243,7 @@ Feature: TypeQL Undefine Query
     Then transaction commits
 
     When transaction closes
-    When connection open write transaction for database: typedb
+    When connection open schema transaction for database: typedb
     When typeql schema query
       """
       undefine person;
@@ -298,7 +296,7 @@ Feature: TypeQL Undefine Query
       """
     Given transaction commits
 
-    Given connection open write transaction for database: typedb
+    Given connection open schema transaction for database: typedb
     Given get answers of typeql read query
       """
       match contract-employment plays $x;
@@ -330,7 +328,7 @@ Feature: TypeQL Undefine Query
       """
     Given transaction commits
 
-    Given connection open write transaction for database: typedb
+    Given connection open schema transaction for database: typedb
     Given get answers of typeql read query
       """
       match $x owns start-date;
@@ -363,7 +361,7 @@ Feature: TypeQL Undefine Query
       """
     Given transaction commits
 
-    Given connection open write transaction for database: typedb
+    Given connection open schema transaction for database: typedb
     Given get answers of typeql read query
       """
       match $x owns employment-reference @key;
@@ -398,7 +396,7 @@ Feature: TypeQL Undefine Query
     Given transaction commits
 
     Given transaction closes
-    Given connection open write transaction for database: typedb
+    Given connection open schema transaction for database: typedb
     Then typeql schema query; fails
       """
       undefine
@@ -428,14 +426,14 @@ Feature: TypeQL Undefine Query
     Given transaction commits
 
     Given transaction closes
-    Given connection open write transaction for database: typedb
+    Given connection open schema transaction for database: typedb
     Then typeql schema query; fails
       """
       undefine employment;
       """
 
     When transaction closes
-    When connection open write transaction for database: typedb
+    When connection open schema transaction for database: typedb
     When typeql write query
       """
       match
@@ -446,7 +444,7 @@ Feature: TypeQL Undefine Query
     Then transaction commits
 
     When transaction closes
-    When connection open write transaction for database: typedb
+    When connection open schema transaction for database: typedb
     When typeql schema query
       """
       undefine employment;
@@ -499,7 +497,7 @@ Feature: TypeQL Undefine Query
       """
     Given transaction commits
 
-    Given connection open write transaction for database: typedb
+    Given connection open schema transaction for database: typedb
     Given get answers of typeql read query
       """
       match $x label <attr>;
@@ -558,7 +556,7 @@ Feature: TypeQL Undefine Query
       """
     Given transaction commits
 
-    Given connection open write transaction for database: typedb
+    Given connection open schema transaction for database: typedb
     Given get answers of typeql read query
       """
       match first-name plays $x;
@@ -590,7 +588,7 @@ Feature: TypeQL Undefine Query
       """
     Given transaction commits
 
-    Given connection open write transaction for database: typedb
+    Given connection open schema transaction for database: typedb
     Given get answers of typeql read query
       """
       match $x owns locale;
@@ -623,7 +621,7 @@ Feature: TypeQL Undefine Query
       """
     Given transaction commits
 
-    Given connection open write transaction for database: typedb
+    Given connection open schema transaction for database: typedb
     Given get answers of typeql read query
       """
       match $x owns name-id @key;
@@ -654,7 +652,7 @@ Feature: TypeQL Undefine Query
       """
     Given transaction commits
 
-    Given connection open write transaction for database: typedb
+    Given connection open schema transaction for database: typedb
     When typeql schema query
       """
       undefine
@@ -695,14 +693,14 @@ Feature: TypeQL Undefine Query
     Given transaction commits
 
     Given transaction closes
-    Given connection open write transaction for database: typedb
+    Given connection open schema transaction for database: typedb
     Then typeql schema query; fails
       """
       undefine name;
       """
 
     When transaction closes
-    When connection open write transaction for database: typedb
+    When connection open schema transaction for database: typedb
     When typeql write query
       """
       match
@@ -713,7 +711,7 @@ Feature: TypeQL Undefine Query
     Then transaction commits
 
     When transaction closes
-    When connection open write transaction for database: typedb
+    When connection open schema transaction for database: typedb
     When typeql schema query
       """
       undefine name;
@@ -786,7 +784,7 @@ Feature: TypeQL Undefine Query
       """
     Given transaction commits
 
-    Given connection open write transaction for database: typedb
+    Given connection open schema transaction for database: typedb
     Given typeql write query
       """
       match
@@ -797,7 +795,7 @@ Feature: TypeQL Undefine Query
     Given transaction commits
 
     Given transaction closes
-    Given connection open write transaction for database: typedb
+    Given connection open schema transaction for database: typedb
     When typeql schema query
       """
       undefine
@@ -880,7 +878,7 @@ Feature: TypeQL Undefine Query
     Given transaction commits
 
     Given transaction closes
-    Given connection open write transaction for database: typedb
+    Given connection open schema transaction for database: typedb
     Then typeql schema query; fails
       """
       undefine employment relates employer;
@@ -899,7 +897,7 @@ Feature: TypeQL Undefine Query
     Given transaction commits
 
     Given transaction closes
-    Given connection open write transaction for database: typedb
+    Given connection open schema transaction for database: typedb
     When typeql schema query
       """
       undefine employment relates employer;
@@ -923,7 +921,7 @@ Feature: TypeQL Undefine Query
       """
     Given transaction commits
 
-    When connection open write transaction for database: typedb
+    When connection open schema transaction for database: typedb
     When typeql schema query
       """
       undefine employment relates employer;
@@ -961,7 +959,7 @@ Feature: TypeQL Undefine Query
       """
     Given transaction commits
 
-    Given connection open write transaction for database: typedb
+    Given connection open schema transaction for database: typedb
     Given typeql write query
       """
       match
@@ -972,7 +970,7 @@ Feature: TypeQL Undefine Query
     Given transaction commits
 
     Given transaction closes
-    Given connection open write transaction for database: typedb
+    Given connection open schema transaction for database: typedb
     When typeql schema query
       """
       undefine person plays employment:employee;
@@ -1017,7 +1015,7 @@ Feature: TypeQL Undefine Query
     """
     Given transaction commits
 
-    Given connection open write transaction for database: typedb
+    Given connection open schema transaction for database: typedb
     Given typeql schema query; fails
     """
     undefine
@@ -1037,7 +1035,7 @@ Feature: TypeQL Undefine Query
     Given transaction commits
 
     Given transaction closes
-    Given connection open write transaction for database: typedb
+    Given connection open schema transaction for database: typedb
     Then typeql schema query; fails
       """
       undefine person plays employment:employee;
@@ -1090,7 +1088,7 @@ Feature: TypeQL Undefine Query
       """
     Then transaction commits
 
-    When connection open write transaction for database: typedb
+    When connection open schema transaction for database: typedb
     Then typeql schema query; fails
       """
       undefine child owns name;
@@ -1145,7 +1143,7 @@ Feature: TypeQL Undefine Query
     Given transaction commits
 
     Given transaction closes
-    Given connection open write transaction for database: typedb
+    Given connection open schema transaction for database: typedb
     When typeql schema query
       """
       undefine person owns name;
@@ -1170,7 +1168,7 @@ Feature: TypeQL Undefine Query
     Given transaction commits
 
     Given transaction closes
-    Given connection open write transaction for database: typedb
+    Given connection open schema transaction for database: typedb
     Then typeql schema query; fails
       """
       undefine person owns name;
@@ -1187,7 +1185,7 @@ Feature: TypeQL Undefine Query
     Given transaction commits
 
     Given transaction closes
-    Given connection open write transaction for database: typedb
+    Given connection open schema transaction for database: typedb
     Then typeql schema query; fails
       """
       undefine person owns email;
@@ -1212,7 +1210,7 @@ Feature: TypeQL Undefine Query
 #      """
 #    Given transaction commits
 #
-#    When connection open write transaction for database: typedb
+#    When connection open schema transaction for database: typedb
 #    Then rules contain: a-rule
 #    When typeql schema query
 #      """
@@ -1255,7 +1253,7 @@ Feature: TypeQL Undefine Query
 #      | n                 |
 #      | attr:name:Samuel  |
 #    Given transaction closes
-#    Given connection open write transaction for database: typedb
+#    Given connection open schema transaction for database: typedb
 #    When typeql schema query
 #      """
 #      undefine rule samuel-email-rule;
@@ -1296,7 +1294,7 @@ Feature: TypeQL Undefine Query
 #    Given transaction commits
 #
 #    Given transaction closes
-#    Given connection open write transaction for database: typedb
+#    Given connection open schema transaction for database: typedb
 #    Given get answers of typeql read query
 #      """
 #      match
@@ -1337,7 +1335,7 @@ Feature: TypeQL Undefine Query
 #    """
 #    Given transaction commits
 #
-#    Given connection open write transaction for database: typedb
+#    Given connection open schema transaction for database: typedb
 #
 #    Given typeql schema query; fails
 #    """
@@ -1363,7 +1361,7 @@ Feature: TypeQL Undefine Query
 #    """
 #    Given transaction commits
 #
-#    Given connection open write transaction for database: typedb
+#    Given connection open schema transaction for database: typedb
 #
 #    Given typeql schema query; fails
 #    """
@@ -1388,7 +1386,7 @@ Feature: TypeQL Undefine Query
 #    """
 #    Given transaction commits
 #
-#    Given connection open write transaction for database: typedb
+#    Given connection open schema transaction for database: typedb
 #
 #    Given typeql schema query; fails
 #    """
@@ -1412,7 +1410,7 @@ Feature: TypeQL Undefine Query
 #    """
 #    Given transaction commits
 #
-#    Given connection open write transaction for database: typedb
+#    Given connection open schema transaction for database: typedb
 #
 #    Given typeql schema query; fails
 #    """
@@ -1441,7 +1439,7 @@ Feature: TypeQL Undefine Query
       """
 
     Given transaction closes
-    Given connection open write transaction for database: typedb
+    Given connection open schema transaction for database: typedb
     Given typeql schema query
       """
       undefine abstract-type abstract;
@@ -1501,7 +1499,7 @@ Feature: TypeQL Undefine Query
       """
     Given transaction commits
 
-    Given connection open write transaction for database: typedb
+    Given connection open schema transaction for database: typedb
     When typeql schema query
       """
       undefine abstract-type @abstract;
@@ -1531,7 +1529,7 @@ Feature: TypeQL Undefine Query
       """
     Given transaction commits
 
-    Given connection open write transaction for database: typedb
+    Given connection open schema transaction for database: typedb
     When typeql schema query
       """
       undefine

--- a/query/language/undefine.feature
+++ b/query/language/undefine.feature
@@ -54,9 +54,8 @@ Feature: TypeQL Undefine Query
       | x                   |
       | label:abstract-type |
 
-
-    # TODO: Error or not?
-#  Scenario: when undefining 'sub' on an entity type, specifying a type that isn't really its supertype errors
+# TODO: Implement
+#  Scenario: undefining non-existing entity type sub errors
 #    When typeql schema query; fails
 #      """
 #      undefine sub abstract-type from person;
@@ -258,7 +257,6 @@ Feature: TypeQL Undefine Query
       | x                   |
       | label:abstract-type |
 
-
   ##################
   # RELATION TYPES #
   ##################
@@ -282,6 +280,13 @@ Feature: TypeQL Undefine Query
       """
       match relation $x;
       """
+
+# TODO: Complete
+#  Scenario: undefining non-existing relation type sub errors
+#    When typeql schema query; fails
+#      """
+#      undefine sub abstract-type from person;
+#      """
 
 
 # TODO: This will be fixed when the owns executor is fixed...
@@ -612,7 +617,6 @@ Feature: TypeQL Undefine Query
       | x               |
       | label:email     |
 
-
   #############################
   # RELATED ROLES ('RELATES') #
   #############################
@@ -806,22 +810,20 @@ Feature: TypeQL Undefine Query
       """
     Then transaction commits
 
-# TODO: Strange random failure (same in match.feature)
-#    When connection open read transaction for database: typedb
-#    When get answers of typeql read query
-#      """
-#      match $x label part-time; $x relates $role;
-#      """
-#    Then uniquely identify answer concepts
-#      | x               | role                      |
-#      | label:part-time | label:employment:employee |
+    When connection open read transaction for database: typedb
+    When get answers of typeql read query
+      """
+      match $x label part-time; $x relates $role;
+      """
+    Then uniquely identify answer concepts
+      | x               | role                      |
+      | label:part-time | label:employment:employee |
 
   # TODO
   Scenario: removing a role from a super relation type also removes roles that specialise it in its subtypes (?)
 
   # TODO
   Scenario: after undefining a sub-role from a relation type, it is gone and the type is left with just its parent role (?)
-
 
   ############################
   # PLAYABLE ROLES ('PLAYS') #
@@ -921,7 +923,6 @@ Feature: TypeQL Undefine Query
       """
       undefine plays employment:employee from person;
       """
-
 
   ########################
   # ATTRIBUTE OWNERSHIPS #
@@ -1273,12 +1274,12 @@ Feature: TypeQL Undefine Query
 ##      name-to-undefine;
 ##    """
 
-  ####################
-  # TYPE ANNOTATIONS #
-  ####################
+  ###############
+  # ANNOTATIONS #
+  ###############
 
   Scenario: undefining a type as abstract converts an abstract to a concrete type, allowing creation of instances
-    # TODO: Uncomment when annotations queries are implemented
+    # TODO: Uncomment when "match @..." is implemented
 #    Given typeql read query; fails with a message containing: "empty-set for some variable"
 #      """
 #      match
@@ -1303,7 +1304,7 @@ Feature: TypeQL Undefine Query
     Given transaction commits
 
     Given connection open write transaction for database: typedb
-    # TODO: Uncomment when annotations queries are implemented
+    # TODO: Uncomment when "match @..." is implemented
 #    When get answers of typeql read query
 #      """
 #      match
@@ -1334,7 +1335,7 @@ Feature: TypeQL Undefine Query
       """
     Then transaction commits
 
-    # TODO: Uncomment when annotations queries are implemented
+    # TODO: Uncomment when "match @..." is implemented
 #    When connection open read transaction for database: typedb
 #    When get answers of typeql read query
 #      """
@@ -1360,7 +1361,7 @@ Feature: TypeQL Undefine Query
       undefine @abstract from abstract-type;
       """
 
-    # TODO: Uncomment when annotations queries are implemented
+    # TODO: Uncomment when "match @..." is implemented
 #    When connection open read transaction for database: typedb
 #    When get answers of typeql read query
 #      """
@@ -1390,7 +1391,7 @@ Feature: TypeQL Undefine Query
       """
     Then transaction commits
 
-    # TODO: Uncomment when annotations queries are implemented
+    # TODO: Uncomment when "match @..." is implemented
 #    When connection open read transaction for database: typedb
 #    When get answers of typeql read query
 #      """
@@ -1401,11 +1402,7 @@ Feature: TypeQL Undefine Query
 #    Then answer size is: 1
 
 
-  ##########################
-  # CAPABILITY ANNOTATIONS #
-  ##########################
-  # TODO: Write tests
-
+  # TODO: Write tests for capabilities, extend existing
 
   ###################
   # COMPLEX QUERIES #

--- a/query/language/undefine.feature
+++ b/query/language/undefine.feature
@@ -9,71 +9,68 @@ Feature: TypeQL Undefine Query
     Given typedb starts
     Given connection opens with default authentication
     Given connection is open: true
-    Given connection has 0 databases
-    Given connection create database: typedb
-    Given connection open schema session for database: typedb
-    Given session opens transaction of type: write
+    Given connection reset database: typedb
+    Given connection open schema transaction for database: typedb
 
     Given typeql schema query
       """
       define
-      person sub entity, plays employment:employee, owns name, owns email @key;
-      employment sub relation, relates employee, relates employer;
-      name sub attribute, value string;
-      email sub attribute, value string, regex ".+@\w+\..+";
-      abstract-type sub entity, abstract;
+      entity person, plays employment:employee, owns name, owns email @key;
+      relation employment, relates employee, relates employer;
+      attribute name, value string;
+      attribute email, value string @regex(".+@\w+\..+");
+      entity abstract-type @abstract;
       """
     Given transaction commits
 
-    Given session opens transaction of type: write
+    Given connection open schema transaction for database: typedb
 
 
   ################
   # ENTITY TYPES #
   ################
 
-  Scenario: calling 'undefine' with 'sub entity' on a subtype of 'entity' deletes it
+  Scenario: calling 'undefine' with entity on an entity deletes it
     Given get answers of typeql read query
       """
-      match $x sub entity;
+      match entity $x;
       """
     Given uniquely identify answer concepts
       | x                   |
       | label:abstract-type |
       | label:person        |
-      | label:entity        |
     When typeql schema query
       """
-      undefine person sub entity;
+      undefine person;
       """
     Then transaction commits
 
-    When session opens transaction of type: read
+    When connection open read transaction for database: typedb
     When get answers of typeql read query
       """
-      match $x sub entity;
+      match entity $x;
       """
     Then uniquely identify answer concepts
       | x                   |
       | label:abstract-type |
-      | label:entity        |
 
 
-  Scenario: when undefining 'sub' on an entity type, specifying a type that isn't really its supertype throws
-    When typeql schema query; throws exception
+    # TODO: Error or not?
+  Scenario: when undefining 'sub' on an entity type, specifying a type that isn't really its supertype errors
+    When typeql schema query; fails
       """
-      undefine person sub relation;
+      undefine sub abstract-type from person;
       """
 
 
   Scenario: a sub-entity type can be removed using 'sub' with its direct supertype, and its parent is preserved
     Given typeql schema query
       """
-      define child sub person;
+      define entity child sub person;
       """
     Given transaction commits
 
-    When session opens transaction of type: write
+    When connection open write transaction for database: typedb
     Given get answers of typeql read query
       """
       match $x sub person;
@@ -84,11 +81,11 @@ Feature: TypeQL Undefine Query
       | label:child  |
     When typeql schema query
       """
-      undefine child sub person;
+      undefine sub person from child;
       """
     Then transaction commits
 
-    When session opens transaction of type: read
+    When connection open read transaction for database: typedb
     When get answers of typeql read query
       """
       match $x sub person;
@@ -101,11 +98,11 @@ Feature: TypeQL Undefine Query
   Scenario: undefining a type 'sub' an indirect supertype should still remove that type
     Given typeql schema query
       """
-      define child sub person;
+      define entity child sub person;
       """
     Given transaction commits
 
-    When session opens transaction of type: read
+    When connection open read transaction for database: typedb
     When get answers of typeql read query
       """
       match $x sub person;
@@ -114,14 +111,14 @@ Feature: TypeQL Undefine Query
       | x            |
       | label:person |
       | label:child  |
-    When session opens transaction of type: write
+    When connection open write transaction for database: typedb
     When typeql schema query
       """
-      undefine child sub entity;
+      undefine child;
       """
     Then transaction commits
 
-    When session opens transaction of type: read
+    When connection open read transaction for database: typedb
     When get answers of typeql read query
       """
       match $x sub person;
@@ -131,38 +128,38 @@ Feature: TypeQL Undefine Query
       | label:person |
 
 
-  Scenario: undefining a supertype throws an error if subtypes exist
+  Scenario: undefining a supertype errors if subtypes exist
     Given typeql schema query
       """
-      define child sub person;
+      define entity child sub person;
       """
     Given transaction commits
 
-    When session opens transaction of type: write
-    Then typeql schema query; throws exception
+    When connection open write transaction for database: typedb
+    Then typeql schema query; fails
       """
-      undefine person sub entity;
+      undefine person;
       """
 
 
   Scenario: removing a playable role from a super entity type also removes it from its subtypes
     Given typeql schema query
       """
-      define child sub person;
+      define entity child sub person;
       """
     Given transaction commits
 
-    When session opens transaction of type: write
+    When connection open write transaction for database: typedb
     When typeql schema query
       """
       undefine person plays employment:employee;
       """
     Then transaction commits
 
-    When session opens transaction of type: read
+    When connection open read transaction for database: typedb
     When get answers of typeql read query
       """
-      match $x type child; $x plays employment:employee;
+      match $x label child; $x plays employment:employee;
       """
     Then answer size is: 0
 
@@ -170,21 +167,21 @@ Feature: TypeQL Undefine Query
   Scenario: removing an attribute ownership from a super entity type also removes it from its subtypes
     Given typeql schema query
       """
-      define child sub person;
+      define entity child sub person;
       """
     Given transaction commits
 
-    When session opens transaction of type: write
+    When connection open write transaction for database: typedb
     When typeql schema query
       """
       undefine person owns name;
       """
     Then transaction commits
 
-    When session opens transaction of type: read
+    When connection open read transaction for database: typedb
     When get answers of typeql read query
       """
-      match $x type child; $x owns name;
+      match $x label child; $x owns name;
       """
     Then answer size is: 0
 
@@ -192,57 +189,53 @@ Feature: TypeQL Undefine Query
   Scenario: removing a key ownership from a super entity type also removes it from its subtypes
     Given typeql schema query
       """
-      define child sub person;
+      define entity child sub person;
       """
     Given transaction commits
 
-    When session opens transaction of type: write
+    When connection open write transaction for database: typedb
     When typeql schema query
       """
       undefine person owns email;
       """
     Then transaction commits
 
-    When session opens transaction of type: read
+    When connection open read transaction for database: typedb
     When get answers of typeql read query
       """
-      match $x type child; $x owns email @key;
+      match $x label child; $x owns email @key;
       """
     Then answer size is: 0
 
   Scenario: all existing instances of an entity type must be deleted in order to undefine it
     Given get answers of typeql read query
       """
-      match $x sub entity;
+      match entity $x;
       """
     Given uniquely identify answer concepts
       | x                   |
       | label:abstract-type |
       | label:person        |
-      | label:entity        |
     Given transaction commits
 
-    Given connection close all sessions
-    Given connection open data session for database: typedb
-    Given session opens transaction of type: write
-    Given typeql insert
+    Given transaction closes
+    Given connection open write transaction for database: typedb
+    Given typeql write query
       """
       insert $x isa person, has name "Victor", has email "victor@vaticle.com";
       """
     Given transaction commits
 
-    Given connection close all sessions
-    Given connection open schema session for database: typedb
-    When session opens transaction of type: write
-    Then typeql schema query; throws exception
+    Given transaction closes
+    When connection open write transaction for database: typedb
+    Then typeql schema query; fails
       """
-      undefine person sub entity;
+      undefine person;
       """
 
-    When connection close all sessions
-    When connection open data session for database: typedb
-    When session opens transaction of type: write
-    When typeql delete
+    When transaction closes
+    When connection open write transaction for database: typedb
+    When typeql write query
       """
       match
         $x isa person;
@@ -251,24 +244,22 @@ Feature: TypeQL Undefine Query
       """
     Then transaction commits
 
-    When connection close all sessions
-    When connection open schema session for database: typedb
-    When session opens transaction of type: write
+    When transaction closes
+    When connection open write transaction for database: typedb
     When typeql schema query
       """
-      undefine person sub entity;
+      undefine person;
       """
     Then transaction commits
 
-    When session opens transaction of type: read
+    When connection open read transaction for database: typedb
     When get answers of typeql read query
       """
-      match $x sub entity;
+      match entity $x;
       """
     Then uniquely identify answer concepts
       | x                   |
       | label:abstract-type |
-      | label:entity        |
 
 
   ##################
@@ -278,39 +269,36 @@ Feature: TypeQL Undefine Query
   Scenario: undefining a relation type removes it
     Given get answers of typeql read query
       """
-      match $x sub relation;
+      match relation $x;
       """
     Given uniquely identify answer concepts
       | x                |
       | label:employment |
-      | label:relation   |
     When typeql schema query
       """
-      undefine employment sub relation;
+      undefine employment;
       """
     Then transaction commits
 
-    When session opens transaction of type: read
+    When connection open read transaction for database: typedb
     When get answers of typeql read query
       """
-      match $x sub relation;
+      match relation $x;
       """
-    Then uniquely identify answer concepts
-      | x              |
-      | label:relation |
+    Then answer size is: 0
 
 
   Scenario: removing playable roles from a super relation type also removes them from its subtypes
     Given typeql schema query
       """
       define
-      employment-terms sub relation, relates employment;
+      relation employment-terms, relates employment;
       employment plays employment-terms:employment;
       contract-employment sub employment;
       """
     Given transaction commits
 
-    Given session opens transaction of type: write
+    Given connection open write transaction for database: typedb
     Given get answers of typeql read query
       """
       match contract-employment plays $x;
@@ -324,7 +312,7 @@ Feature: TypeQL Undefine Query
       """
     Then transaction commits
 
-    When session opens transaction of type: read
+    When connection open read transaction for database: typedb
     When get answers of typeql read query
       """
       match contract-employment plays $x;
@@ -336,13 +324,13 @@ Feature: TypeQL Undefine Query
     Given typeql schema query
       """
       define
-      start-date sub attribute, value datetime;
+      attribute start-date, value datetime;
       employment owns start-date;
-      contract-employment sub employment;
+      relation contract-employment sub employment;
       """
     Given transaction commits
 
-    Given session opens transaction of type: write
+    Given connection open write transaction for database: typedb
     Given get answers of typeql read query
       """
       match $x owns start-date;
@@ -357,7 +345,7 @@ Feature: TypeQL Undefine Query
       """
     Then transaction commits
 
-    When session opens transaction of type: read
+    When connection open read transaction for database: typedb
     When get answers of typeql read query
       """
       match $x owns start-date;
@@ -369,13 +357,13 @@ Feature: TypeQL Undefine Query
     Given typeql schema query
       """
       define
-      employment-reference sub attribute, value string;
+      attribute employment-reference, value string;
       employment owns employment-reference @key;
-      contract-employment sub employment;
+      relation contract-employment sub employment;
       """
     Given transaction commits
 
-    Given session opens transaction of type: write
+    Given connection open write transaction for database: typedb
     Given get answers of typeql read query
       """
       match $x owns employment-reference @key;
@@ -390,7 +378,7 @@ Feature: TypeQL Undefine Query
       """
     Then transaction commits
 
-    When session opens transaction of type: read
+    When connection open read transaction for database: typedb
     When get answers of typeql read query
       """
       match $x owns employment-reference @key;
@@ -398,11 +386,10 @@ Feature: TypeQL Undefine Query
     Then answer size is: 0
 
 
-  Scenario: undefining a relation type throws on commit if it has existing instances
-    Given connection close all sessions
-    Given connection open data session for database: typedb
-    Given session opens transaction of type: write
-    Given typeql insert
+  Scenario: undefining a relation type errors on commit if it has existing instances
+    Given transaction closes
+    Given connection open write transaction for database: typedb
+    Given typeql write query
       """
       insert
       $p isa person, has name "Harald", has email "harald@vaticle.com";
@@ -410,32 +397,29 @@ Feature: TypeQL Undefine Query
       """
     Given transaction commits
 
-    Given connection close all sessions
-    Given connection open schema session for database: typedb
-    Given session opens transaction of type: write
-    Then typeql schema query; throws exception
+    Given transaction closes
+    Given connection open write transaction for database: typedb
+    Then typeql schema query; fails
       """
       undefine
       employment relates employee;
       employment relates employer;
       person plays employment:employee;
-      employment sub relation;
+      employment;
       """
 
 
   Scenario: all existing instances of a relation type must be deleted in order to undefine it
     Given get answers of typeql read query
       """
-      match $x sub relation;
+      match relation $x;
       """
     Given uniquely identify answer concepts
       | x                |
       | label:employment |
-      | label:relation   |
-    Given connection close all sessions
-    Given connection open data session for database: typedb
-    Given session opens transaction of type: write
-    Given typeql insert
+    Given transaction closes
+    Given connection open write transaction for database: typedb
+    Given typeql write query
       """
       insert
       $p isa person, has name "Harald", has email "harald@vaticle.com";
@@ -443,18 +427,16 @@ Feature: TypeQL Undefine Query
       """
     Given transaction commits
 
-    Given connection close all sessions
-    Given connection open schema session for database: typedb
-    Given session opens transaction of type: write
-    Then typeql schema query; throws exception
+    Given transaction closes
+    Given connection open write transaction for database: typedb
+    Then typeql schema query; fails
       """
-      undefine employment sub relation;
+      undefine employment;
       """
 
-    When connection close all sessions
-    When connection open data session for database: typedb
-    When session opens transaction of type: write
-    When typeql delete
+    When transaction closes
+    When connection open write transaction for database: typedb
+    When typeql write query
       """
       match
         $r isa employment;
@@ -463,30 +445,27 @@ Feature: TypeQL Undefine Query
       """
     Then transaction commits
 
-    When connection close all sessions
-    When connection open schema session for database: typedb
-    When session opens transaction of type: write
+    When transaction closes
+    When connection open write transaction for database: typedb
     When typeql schema query
       """
-      undefine employment sub relation;
+      undefine employment;
       """
     Then transaction commits
 
-    When session opens transaction of type: read
+    When connection open read transaction for database: typedb
     When get answers of typeql read query
       """
-      match $x sub relation;
+      match relation $x;
       """
-    Then uniquely identify answer concepts
-      | x              |
-      | label:relation |
+    Then answer size is: 0
 
 
   Scenario: undefining a relation type automatically detaches any possible roleplayers
     Given get answers of typeql read query
       """
       match
-        $x type person;
+        $x label person;
         $x plays $y;
 
       """
@@ -495,19 +474,260 @@ Feature: TypeQL Undefine Query
       | label:person | label:employment:employee |
     When typeql schema query
       """
-      undefine employment sub relation;
+      undefine employment;
       """
     Then transaction commits
 
-    When session opens transaction of type: read
+    When connection open read transaction for database: typedb
     When get answers of typeql read query
       """
       match
-        $x type person;
+        $x label person;
         $x plays $y;
 
       """
     Then answer size is: 0
+
+  ###################
+  # ATTRIBUTE TYPES #
+  ###################
+
+  Scenario Outline: undefining attribute on an attribute type with value type '<value_type>' removes it
+    Given typeql schema query
+      """
+      define attribute <attr>, value <value_type>;
+      """
+    Given transaction commits
+
+    Given connection open write transaction for database: typedb
+    Given get answers of typeql read query
+      """
+      match $x label <attr>;
+      """
+    Given answer size is: 1
+    When typeql schema query
+      """
+      undefine <attr>;
+      """
+    Then transaction commits
+
+    When connection open read transaction for database: typedb
+    Then typeql read query; fails
+      """
+      match $x label <attr>;
+      """
+    Examples:
+      | value_type | attr       |
+      | string     | colour     |
+      | long       | age        |
+      | double     | height     |
+      | boolean    | is-awake   |
+      | datetime   | birth-date |
+
+
+  Scenario: undefining a regex on an attribute type removes the regex constraints on the attribute
+    When typeql schema query
+      """
+      undefine email regex ".+@\w+\..+";
+      """
+    Then transaction commits
+
+    When transaction closes
+    When connection open write transaction for database: typedb
+    When typeql write query
+      """
+      insert $x "not-email-regex" isa email;
+      """
+    Then transaction commits
+
+    When connection open read transaction for database: typedb
+    When get answers of typeql read query
+      """
+      match $x isa email;
+      """
+    Then answer size is: 1
+
+
+  Scenario: removing playable roles from a super attribute type also removes them from its subtypes
+    Given typeql schema query
+      """
+      define
+      employment relates manager-name;
+      attribute abstract-name, abstract, value string, plays employment:manager-name;
+      attribute first-name sub abstract-name;
+      """
+    Given transaction commits
+
+    Given connection open write transaction for database: typedb
+    Given get answers of typeql read query
+      """
+      match first-name plays $x;
+      """
+    Given uniquely identify answer concepts
+      | x                             |
+      | label:employment:manager-name |
+    When typeql schema query
+      """
+      undefine abstract-name plays employment:manager-name;
+      """
+    Then transaction commits
+
+    When connection open read transaction for database: typedb
+    When get answers of typeql read query
+      """
+      match first-name plays $x;
+      """
+    Then answer size is: 0
+
+
+  Scenario: removing attribute ownerships from a super attribute type also removes them from its subtypes
+    Given typeql schema query
+      """
+      define
+      attribute locale, value string;
+      attribute abstract-name @abstract, value string, owns locale;
+      attribute first-name sub abstract-name;
+      """
+    Given transaction commits
+
+    Given connection open write transaction for database: typedb
+    Given get answers of typeql read query
+      """
+      match $x owns locale;
+      """
+    Given uniquely identify answer concepts
+      | x                   |
+      | label:abstract-name |
+      | label:first-name    |
+    When typeql schema query
+      """
+      undefine abstract-name owns locale;
+      """
+    Then transaction commits
+
+    When connection open read transaction for database: typedb
+    When get answers of typeql read query
+      """
+      match $x owns locale;
+      """
+    Then answer size is: 0
+
+
+  Scenario: removing a key ownership from a super attribute type also removes it from its subtypes
+    Given typeql schema query
+      """
+      define
+      attribute name-id, value long;
+      attribute abstract-name @abstract, value string, owns name-id @key;
+      attribute first-name sub abstract-name;
+      """
+    Given transaction commits
+
+    Given connection open write transaction for database: typedb
+    Given get answers of typeql read query
+      """
+      match $x owns name-id @key;
+      """
+    Given uniquely identify answer concepts
+      | x                   |
+      | label:abstract-name |
+      | label:first-name    |
+    When typeql schema query
+      """
+      undefine abstract-name owns name-id;
+      """
+    Then transaction commits
+
+    When connection open read transaction for database: typedb
+    When get answers of typeql read query
+      """
+      match $x owns name-id @key;
+      """
+    Then answer size is: 0
+
+
+  Scenario: an attribute and its self-ownership can be removed simultaneously
+    Given typeql schema query
+      """
+      define
+      name owns name;
+      """
+    Given transaction commits
+
+    Given connection open write transaction for database: typedb
+    When typeql schema query
+      """
+      undefine
+      name owns name;
+      attribute name;
+      """
+    Then transaction commits
+
+    When connection open read transaction for database: typedb
+    Then typeql read query; fails
+      """
+      match $x label name;
+      """
+
+
+  Scenario: undefining the value type of an attribute errors
+    When typeql schema query; fails
+      """
+      undefine name value string;
+      """
+
+
+  Scenario: all existing instances of an attribute type must be deleted in order to undefine it
+    Given get answers of typeql read query
+      """
+      match attribute $x;
+      """
+    Given uniquely identify answer concepts
+      | x               |
+      | label:name      |
+      | label:email     |
+    Given transaction closes
+    Given connection open write transaction for database: typedb
+    Given typeql write query
+      """
+      insert $x "Colette" isa name;
+      """
+    Given transaction commits
+
+    Given transaction closes
+    Given connection open write transaction for database: typedb
+    Then typeql schema query; fails
+      """
+      undefine name;
+      """
+
+    When transaction closes
+    When connection open write transaction for database: typedb
+    When typeql write query
+      """
+      match
+        $x isa name;
+      delete
+        $x isa name;
+      """
+    Then transaction commits
+
+    When transaction closes
+    When connection open write transaction for database: typedb
+    When typeql schema query
+      """
+      undefine name;
+      """
+    Then transaction commits
+
+    When connection open read transaction for database: typedb
+    When get answers of typeql read query
+      """
+      match attribute $x;
+      """
+    Then uniquely identify answer concepts
+      | x               |
+      | label:email     |
 
 
   #############################
@@ -529,7 +749,7 @@ Feature: TypeQL Undefine Query
       """
     Then transaction commits
 
-    When session opens transaction of type: read
+    When connection open read transaction for database: typedb
     When get answers of typeql read query
       """
       match employment relates $x;
@@ -546,7 +766,7 @@ Feature: TypeQL Undefine Query
       """
     Then transaction commits
 
-    When session opens transaction of type: read
+    When connection open read transaction for database: typedb
     When get answers of typeql read query
       """
       match $x plays employment:employee;
@@ -556,10 +776,9 @@ Feature: TypeQL Undefine Query
   #TODO: test is not working
   @ignore
   Scenario: after removing a role from a relation type, relation instances can no longer be created with that role
-    Given connection close all sessions
-    Given connection open data session for database: typedb
-    Given session opens transaction of type: write
-    Given typeql insert
+    Given transaction closes
+    Given connection open write transaction for database: typedb
+    Given typeql write query
       """
       insert
       $p isa person, has email "ganesh@vaticle.com";
@@ -567,8 +786,8 @@ Feature: TypeQL Undefine Query
       """
     Given transaction commits
 
-    Given session opens transaction of type: write
-    Given typeql delete
+    Given connection open write transaction for database: typedb
+    Given typeql write query
       """
       match
         $r isa employment;
@@ -577,9 +796,8 @@ Feature: TypeQL Undefine Query
       """
     Given transaction commits
 
-    Given connection close all sessions
-    Given connection open schema session for database: typedb
-    Given session opens transaction of type: write
+    Given transaction closes
+    Given connection open write transaction for database: typedb
     When typeql schema query
       """
       undefine
@@ -588,15 +806,14 @@ Feature: TypeQL Undefine Query
       """
     Then transaction commits
 
-    When connection close all sessions
-    When connection open data session for database: typedb
-    When session opens transaction of type: write
+    When transaction closes
+    When connection open write transaction for database: typedb
     When get answers of typeql read query
       """
       match $x relates employee;
       """
     Then answer size is: 0
-    Then typeql insert; throws exception
+    Then typeql write query; fails
       """
       match
         $p isa person, has email "ganesh@vaticle.com";
@@ -605,21 +822,21 @@ Feature: TypeQL Undefine Query
       """
 
 
-  Scenario: removing all roles from a relation type without undefining the relation type throws on commit
+  Scenario: removing all roles from a relation type without undefining the relation type errors on commit
     When typeql schema query
       """
       undefine
       employment relates employee;
       employment relates employer;
       """
-    Then transaction commits; throws exception
+    Then transaction commits; fails
 
 
   Scenario: undefining a role type automatically detaches any possible roleplayers
     Given get answers of typeql read query
       """
       match
-        $x type person;
+        $x label person;
         $x plays $y;
 
       """
@@ -632,29 +849,28 @@ Feature: TypeQL Undefine Query
       """
     Then transaction commits
 
-    When session opens transaction of type: read
+    When connection open read transaction for database: typedb
     When get answers of typeql read query
       """
       match
-        $x type person;
+        $x label person;
         $x plays $y;
 
       """
     Then answer size is: 0
 
 
-  Scenario: removing a role throws an error if it is played by existing roleplayers in relations
+  Scenario: removing a role errors if it is played by existing roleplayers in relations
     Given typeql schema query
       """
       define
-      company sub entity, owns name, plays employment:employer;
+      entity company, owns name, plays employment:employer;
       """
     Given transaction commits
 
-    Given connection close all sessions
-    Given connection open data session for database: typedb
-    Given session opens transaction of type: write
-    Given typeql insert
+    Given transaction closes
+    Given connection open write transaction for database: typedb
+    Given typeql write query
       """
       insert
       $p isa person, has name "Ada", has email "ada@vaticle.com";
@@ -663,20 +879,18 @@ Feature: TypeQL Undefine Query
       """
     Given transaction commits
 
-    Given connection close all sessions
-    Given connection open schema session for database: typedb
-    Given session opens transaction of type: write
-    Then typeql schema query; throws exception
+    Given transaction closes
+    Given connection open write transaction for database: typedb
+    Then typeql schema query; fails
       """
       undefine employment relates employer;
       """
 
 
   Scenario: a role that is not played in any existing instance of its relation type can be safely removed
-    Given connection close all sessions
-    Given connection open data session for database: typedb
-    Given session opens transaction of type: write
-    Given typeql insert
+    Given transaction closes
+    Given connection open write transaction for database: typedb
+    Given typeql write query
       """
       insert
       $p isa person, has name "Vijay", has email "vijay@vaticle.com";
@@ -684,16 +898,15 @@ Feature: TypeQL Undefine Query
       """
     Given transaction commits
 
-    Given connection close all sessions
-    Given connection open schema session for database: typedb
-    Given session opens transaction of type: write
+    Given transaction closes
+    Given connection open write transaction for database: typedb
     When typeql schema query
       """
       undefine employment relates employer;
       """
     Then transaction commits
 
-    When session opens transaction of type: read
+    When connection open read transaction for database: typedb
     When get answers of typeql read query
       """
       match employment relates $x;
@@ -706,21 +919,21 @@ Feature: TypeQL Undefine Query
   Scenario: removing a role from a super relation type also removes it from its subtypes
     Given typeql schema query
       """
-      define part-time sub employment;
+      define relation part-time sub employment;
       """
     Given transaction commits
 
-    When session opens transaction of type: write
+    When connection open write transaction for database: typedb
     When typeql schema query
       """
       undefine employment relates employer;
       """
     Then transaction commits
 
-    When session opens transaction of type: read
+    When connection open read transaction for database: typedb
     When get answers of typeql read query
       """
-      match $x type part-time; $x relates $role;
+      match $x label part-time; $x relates $role;
       """
     Then uniquely identify answer concepts
       | x               | role                      |
@@ -738,10 +951,9 @@ Feature: TypeQL Undefine Query
   ############################
 
   Scenario: after undefining a playable role from a type, the type can no longer play the role
-    Given connection close all sessions
-    Given connection open data session for database: typedb
-    Given session opens transaction of type: write
-    Given typeql insert
+    Given transaction closes
+    Given connection open write transaction for database: typedb
+    Given typeql write query
       """
       insert
       $p isa person, has email "ganesh@vaticle.com";
@@ -749,8 +961,8 @@ Feature: TypeQL Undefine Query
       """
     Given transaction commits
 
-    Given session opens transaction of type: write
-    Given typeql delete
+    Given connection open write transaction for database: typedb
+    Given typeql write query
       """
       match
         $r isa employment;
@@ -759,24 +971,22 @@ Feature: TypeQL Undefine Query
       """
     Given transaction commits
 
-    Given connection close all sessions
-    Given connection open schema session for database: typedb
-    Given session opens transaction of type: write
+    Given transaction closes
+    Given connection open write transaction for database: typedb
     When typeql schema query
       """
       undefine person plays employment:employee;
       """
     Then transaction commits
 
-    When connection close all sessions
-    When connection open data session for database: typedb
-    When session opens transaction of type: write
+    When transaction closes
+    When connection open write transaction for database: typedb
     When get answers of typeql read query
       """
       match $x plays employment:employee;
       """
     Then answer size is: 0
-    Then typeql insert; throws exception
+    Then typeql write query; fails
       """
       match
         $p isa person, has email "ganesh@vaticle.com";
@@ -785,7 +995,7 @@ Feature: TypeQL Undefine Query
       """
 
 
-  Scenario: undefining a playable role that was not actually playable to begin with throws
+  Scenario: undefining a playable role that was not actually playable to begin with errors
     Given get answers of typeql read query
       """
       match person plays $x;
@@ -793,13 +1003,13 @@ Feature: TypeQL Undefine Query
     Given uniquely identify answer concepts
       | x                         |
       | label:employment:employee |
-    When typeql schema query; throws exception
+    When typeql schema query; fails
       """
       undefine person plays employment:employer;
       """
 
 
-  Scenario: undefining played inherited role types using alias role types throws
+  Scenario: undefining played inherited role types using alias role types errors
     Given typeql schema query
     """
     define
@@ -807,19 +1017,18 @@ Feature: TypeQL Undefine Query
     """
     Given transaction commits
 
-    Given session opens transaction of type: write
-    Given typeql schema query; throws exception
+    Given connection open write transaction for database: typedb
+    Given typeql schema query; fails
     """
     undefine
     person plays part-time-employment:employee;
     """
 
 
-  Scenario: removing a playable role throws an error if it is played by existing instances
-    Given connection close all sessions
-    Given connection open data session for database: typedb
-    Given session opens transaction of type: write
-    Given typeql insert
+  Scenario: removing a playable role errors an error if it is played by existing instances
+    Given transaction closes
+    Given connection open write transaction for database: typedb
+    Given typeql write query
       """
       insert
       $p isa person, has email "ganesh@vaticle.com";
@@ -827,263 +1036,12 @@ Feature: TypeQL Undefine Query
       """
     Given transaction commits
 
-    Given connection close all sessions
-    Given connection open schema session for database: typedb
-    Given session opens transaction of type: write
-    Then typeql schema query; throws exception
+    Given transaction closes
+    Given connection open write transaction for database: typedb
+    Then typeql schema query; fails
       """
       undefine person plays employment:employee;
       """
-
-
-  ###################
-  # ATTRIBUTE TYPES #
-  ###################
-
-  Scenario Outline: undefining 'sub attribute' on an attribute type with value type '<value_type>' removes it
-    Given typeql schema query
-      """
-      define <attr> sub attribute, value <value_type>;
-      """
-    Given transaction commits
-
-    Given session opens transaction of type: write
-    Given get answers of typeql read query
-      """
-      match $x type <attr>;
-      """
-    Given answer size is: 1
-    When typeql schema query
-      """
-      undefine <attr> sub attribute;
-      """
-    Then transaction commits
-
-    When session opens transaction of type: read
-    Then typeql throws exception
-      """
-      match $x type <attr>;
-      """
-
-    Examples:
-      | value_type | attr       |
-      | string     | colour     |
-      | long       | age        |
-      | double     | height     |
-      | boolean    | is-awake   |
-      | datetime   | birth-date |
-
-
-  Scenario: undefining a regex on an attribute type removes the regex constraints on the attribute
-    When typeql schema query
-      """
-      undefine email regex ".+@\w+\..+";
-      """
-    Then transaction commits
-
-    When connection close all sessions
-    When connection open data session for database: typedb
-    When session opens transaction of type: write
-    When typeql insert
-      """
-      insert $x "not-email-regex" isa email;
-      """
-    Then transaction commits
-
-    When session opens transaction of type: read
-    When get answers of typeql read query
-      """
-      match $x isa email;
-      """
-    Then answer size is: 1
-
-
-  Scenario: removing playable roles from a super attribute type also removes them from its subtypes
-    Given typeql schema query
-      """
-      define
-      employment relates manager-name;
-      abstract-name sub attribute, abstract, value string, plays employment:manager-name;
-      first-name sub abstract-name;
-      """
-    Given transaction commits
-
-    Given session opens transaction of type: write
-    Given get answers of typeql read query
-      """
-      match first-name plays $x;
-      """
-    Given uniquely identify answer concepts
-      | x                             |
-      | label:employment:manager-name |
-    When typeql schema query
-      """
-      undefine abstract-name plays employment:manager-name;
-      """
-    Then transaction commits
-
-    When session opens transaction of type: read
-    When get answers of typeql read query
-      """
-      match first-name plays $x;
-      """
-    Then answer size is: 0
-
-
-  Scenario: removing attribute ownerships from a super attribute type also removes them from its subtypes
-    Given typeql schema query
-      """
-      define
-      locale sub attribute, value string;
-      abstract-name sub attribute, abstract, value string, owns locale;
-      first-name sub abstract-name;
-      """
-    Given transaction commits
-
-    Given session opens transaction of type: write
-    Given get answers of typeql read query
-      """
-      match $x owns locale;
-      """
-    Given uniquely identify answer concepts
-      | x                   |
-      | label:abstract-name |
-      | label:first-name    |
-    When typeql schema query
-      """
-      undefine abstract-name owns locale;
-      """
-    Then transaction commits
-
-    When session opens transaction of type: read
-    When get answers of typeql read query
-      """
-      match $x owns locale;
-      """
-    Then answer size is: 0
-
-
-  Scenario: removing a key ownership from a super attribute type also removes it from its subtypes
-    Given typeql schema query
-      """
-      define
-      name-id sub attribute, value long;
-      abstract-name sub attribute, abstract, value string, owns name-id @key;
-      first-name sub abstract-name;
-      """
-    Given transaction commits
-
-    Given session opens transaction of type: write
-    Given get answers of typeql read query
-      """
-      match $x owns name-id @key;
-      """
-    Given uniquely identify answer concepts
-      | x                   |
-      | label:abstract-name |
-      | label:first-name    |
-    When typeql schema query
-      """
-      undefine abstract-name owns name-id;
-      """
-    Then transaction commits
-
-    When session opens transaction of type: read
-    When get answers of typeql read query
-      """
-      match $x owns name-id @key;
-      """
-    Then answer size is: 0
-
-
-  Scenario: an attribute and its self-ownership can be removed simultaneously
-    Given typeql schema query
-      """
-      define
-      name owns name;
-      """
-    Given transaction commits
-
-    Given session opens transaction of type: write
-    When typeql schema query
-      """
-      undefine
-      name owns name;
-      name sub attribute;
-      """
-    Then transaction commits
-
-    When session opens transaction of type: read
-    Then typeql throws exception
-      """
-      match $x type name;
-      """
-
-
-  Scenario: undefining the value type of an attribute throws an error
-    When typeql schema query; throws exception
-      """
-      undefine name value string;
-      """
-
-
-  Scenario: all existing instances of an attribute type must be deleted in order to undefine it
-    Given get answers of typeql read query
-      """
-      match $x sub attribute;
-      """
-    Given uniquely identify answer concepts
-      | x               |
-      | label:name      |
-      | label:email     |
-      | label:attribute |
-    Given connection close all sessions
-    Given connection open data session for database: typedb
-    Given session opens transaction of type: write
-    Given typeql insert
-      """
-      insert $x "Colette" isa name;
-      """
-    Given transaction commits
-
-    Given connection close all sessions
-    Given connection open schema session for database: typedb
-    Given session opens transaction of type: write
-    Then typeql schema query; throws exception
-      """
-      undefine name sub attribute;
-      """
-
-    When connection close all sessions
-    When connection open data session for database: typedb
-    When session opens transaction of type: write
-    When typeql delete
-      """
-      match
-        $x isa name;
-      delete
-        $x isa name;
-      """
-    Then transaction commits
-
-    When connection close all sessions
-    When connection open schema session for database: typedb
-    When session opens transaction of type: write
-    When typeql schema query
-      """
-      undefine name sub attribute;
-      """
-    Then transaction commits
-
-    When session opens transaction of type: read
-    When get answers of typeql read query
-      """
-      match $x sub attribute;
-      """
-    Then uniquely identify answer concepts
-      | x               |
-      | label:email     |
-      | label:attribute |
 
 
   ########################
@@ -1095,7 +1053,7 @@ Feature: TypeQL Undefine Query
       """
       match
         $x owns name;
-        $x type person;
+        $x label person;
 
       """
     Given uniquely identify answer concepts
@@ -1107,33 +1065,33 @@ Feature: TypeQL Undefine Query
       """
     Then transaction commits
 
-    When session opens transaction of type: read
+    When connection open read transaction for database: typedb
     When get answers of typeql read query
       """
       match
         $x owns name;
-        $x type person;
+        $x label person;
 
       """
     Then answer size is: 0
 
 
-  Scenario: attempting to undefine an attribute ownership that was not actually owned to begin throws
-    When typeql schema query; throws exception
+  Scenario: attempting to undefine an attribute ownership that was not actually owned to begin errors
+    When typeql schema query; fails
       """
       undefine employment owns name;
       """
 
 
-  Scenario: attempting to undefine an attribute ownership inherited from a parent throws
+  Scenario: attempting to undefine an attribute ownership inherited from a parent errors
     Given typeql schema query
       """
-      define child sub person;
+      define entity child sub person;
       """
     Then transaction commits
 
-    When session opens transaction of type: write
-    Then typeql schema query; throws exception
+    When connection open write transaction for database: typedb
+    Then typeql schema query; fails
       """
       undefine child owns name;
       """
@@ -1146,7 +1104,7 @@ Feature: TypeQL Undefine Query
       """
     Then transaction commits
 
-    When session opens transaction of type: read
+    When connection open read transaction for database: typedb
     When get answers of typeql read query
       """
       match $x owns email;
@@ -1155,14 +1113,14 @@ Feature: TypeQL Undefine Query
 
 
   Scenario: writing '@key' when undefining a key ownership is not allowed
-    Then typeql schema query; throws exception
+    Then typeql schema query; fails
       """
       undefine person owns email @key;
       """
 
 
   Scenario: writing '@key' when undefining an attribute ownership is not allowed
-    Then typeql schema query; throws exception
+    Then typeql schema query; fails
       """
       undefine person owns name @key;
       """
@@ -1178,25 +1136,23 @@ Feature: TypeQL Undefine Query
       | label:person |
     Given transaction commits
 
-    Given connection close all sessions
-    Given connection open data session for database: typedb
-    Given session opens transaction of type: write
-    Given typeql insert
+    Given transaction closes
+    Given connection open write transaction for database: typedb
+    Given typeql write query
       """
       insert $x isa person, has email "anon@vaticle.com";
       """
     Given transaction commits
 
-    Given connection close all sessions
-    Given connection open schema session for database: typedb
-    Given session opens transaction of type: write
+    Given transaction closes
+    Given connection open write transaction for database: typedb
     When typeql schema query
       """
       undefine person owns name;
       """
     Then transaction commits
 
-    When session opens transaction of type: read
+    When connection open read transaction for database: typedb
     When get answers of typeql read query
       """
       match $x owns name;
@@ -1204,324 +1160,313 @@ Feature: TypeQL Undefine Query
     Then answer size is: 0
 
 
-  Scenario: removing an attribute ownership throws an error if it is owned by existing instances
-    Given connection close all sessions
-    Given connection open data session for database: typedb
-    Given session opens transaction of type: write
-    Given typeql insert
+  Scenario: removing an attribute ownership errors if it is owned by existing instances
+    Given transaction closes
+    Given connection open write transaction for database: typedb
+    Given typeql write query
       """
       insert $x isa person, has name "Tomas", has email "tomas@vaticle.com";
       """
     Given transaction commits
 
-    Given connection close all sessions
-    Given connection open schema session for database: typedb
-    Given session opens transaction of type: write
-    Then typeql schema query; throws exception
+    Given transaction closes
+    Given connection open write transaction for database: typedb
+    Then typeql schema query; fails
       """
       undefine person owns name;
       """
 
 
-  Scenario: undefining a key ownership throws an error if it is owned by existing instances
-    Given connection close all sessions
-    Given connection open data session for database: typedb
-    Given session opens transaction of type: write
-    Given typeql insert
+  Scenario: undefining a key ownership errors if it is owned by existing instances
+    Given transaction closes
+    Given connection open write transaction for database: typedb
+    Given typeql write query
       """
       insert $x isa person, has name "Daniel", has email "daniel@vaticle.com";
       """
     Given transaction commits
 
-    Given connection close all sessions
-    Given connection open schema session for database: typedb
-    Given session opens transaction of type: write
-    Then typeql schema query; throws exception
+    Given transaction closes
+    Given connection open write transaction for database: typedb
+    Then typeql schema query; fails
       """
       undefine person owns email;
       """
 
 
-  #########
-  # RULES #
-  #########
+  #############
+  # FUNCTIONS #
+  #############
+# TODO: Write new tests for functions. Consider old Rules tests to be reimplemented if applicable
+#  Scenario: undefining a rule removes it
+#    Given typeql schema query
+#      """
+#      define
+#      entity company, plays employment:employer;
+#      rule a-rule:
+#      when {
+#        $c isa company; $y isa person;
+#      } then {
+#        (employer: $c, employee: $y) isa employment;
+#      };
+#      """
+#    Given transaction commits
+#
+#    When connection open write transaction for database: typedb
+#    Then rules contain: a-rule
+#    When typeql schema query
+#      """
+#      undefine rule a-rule;
+#      """
+#    Then transaction commits
+#
+#    When connection open read transaction for database: typedb
+#    Then rules do not contain: a-rule
+#
+#  Scenario: after undefining a rule, concepts previously inferred by that rule are no longer inferred
+#    Given typeql schema query
+#      """
+#      define
+#      rule samuel-email-rule:
+#      when {
+#        $x has email "samuel@vaticle.com";
+#      } then {
+#        $x has name "Samuel";
+#      };
+#      """
+#    Given transaction commits
+#
+#    Given transaction closes
+#    Given connection open write transaction for database: typedb
+#    Given typeql write query
+#      """
+#      insert $x isa person, has email "samuel@vaticle.com";
+#      """
+#    Given transaction commits
+#
+#    Given connection open read transaction for database: typedb
+#    Given get answers of typeql read query
+#      """
+#      match
+#        $x has name $n;
+#      get $n;
+#      """
+#    Given uniquely identify answer concepts
+#      | n                 |
+#      | attr:name:Samuel  |
+#    Given transaction closes
+#    Given connection open write transaction for database: typedb
+#    When typeql schema query
+#      """
+#      undefine rule samuel-email-rule;
+#      """
+#    Then transaction commits
+#
+#    When connection open read transaction for database: typedb
+#    When get answers of typeql read query
+#      """
+#      match
+#        $x has name $n;
+#      get $n;
+#      """
+#    Then answer size is: 0
+#
+#
+#  # TODO enable when we can do reasoning in a schema write transaction
+#  @ignore
+#  Scenario: when undefining a rule, concepts inferred by that rule can still be retrieved until the next commit
+#    Given typeql schema query
+#      """
+#      define
+#      rule samuel-email-rule:
+#      when {
+#        $x has email "samuel@vaticle.com";
+#      } then {
+#        $x has name "Samuel";
+#      };
+#      """
+#    Given transaction commits
+#
+#    Given transaction closes
+#    Given connection open write transaction for database: typedb
+#    Given typeql write query
+#      """
+#      insert $x isa person, has email "samuel@vaticle.com";
+#      """
+#    Given transaction commits
+#
+#    Given transaction closes
+#    Given connection open write transaction for database: typedb
+#    Given get answers of typeql read query
+#      """
+#      match
+#        $x has name $n;
+#      get $n;
+#      """
+#    Given uniquely identify answer concepts
+#      | n                 |
+#      | attr:name:Samuel  |
+#    When typeql schema query
+#      """
+#      undefine rule samuel-email-rule;
+#      """
+#
+#    When get answers of typeql read query
+#      """
+#      match
+#        $x has name $n;
+#      get $n;
+#      """
+#    Then uniquely identify answer concepts
+#      | n                 |
+#      | attr:name:Samuel  |
+#
+#  Scenario: You cannot undefine a type if it is used in a rule
+#    Given typeql schema query
+#    """
+#    define
+#
+#    entity type-to-undefine, owns name;
+#
+#    rule rule-referencing-type-to-undefine:
+#    when {
+#      $x isa type-to-undefine;
+#    } then {
+#      $x has name "dummy";
+#    };
+#    """
+#    Given transaction commits
+#
+#    Given connection open write transaction for database: typedb
+#
+#    Given typeql schema query; fails
+#    """
+#    undefine
+#      type-to-undefine;
+#    """
+#
+#  Scenario: You cannot undefine a type if it is used in a negation in a rule
+#    Given typeql schema query
+#    """
+#    define
+#    relation rel, relates rol;
+#    entity other-type, owns name, plays rel:rol;
+#    entity type-to-undefine, owns name, plays rel:rol;
+#
+#    rule rule-referencing-type-to-undefine:
+#    when {
+#      $x isa other-type;
+#      not { ($x, $y) isa relation; $y isa type-to-undefine; };
+#    } then {
+#      $x has name "dummy";
+#    };
+#    """
+#    Given transaction commits
+#
+#    Given connection open write transaction for database: typedb
+#
+#    Given typeql schema query; fails
+#    """
+#    undefine
+#      type-to-undefine;
+#    """
+#
+#  Scenario: You cannot undefine a type if it is used in any disjunction in a rule
+#    Given typeql schema query
+#    """
+#    define
+#
+#    entity type-to-undefine, owns name;
+#
+#    rule rule-referencing-type-to-undefine:
+#    when {
+#      $x has name $y;
+#      { $x isa person; } or { $x isa type-to-undefine; };
+#    } then {
+#      $x has name "dummy";
+#    };
+#    """
+#    Given transaction commits
+#
+#    Given connection open write transaction for database: typedb
+#
+#    Given typeql schema query; fails
+#    """
+#    undefine
+#      type-to-undefine;
+#    """
+#
+#  Scenario: You cannot undefine a type if it is used in the then of a rule
+#    Given typeql schema query
+#    """
+#    define
+#    attribute name-to-undefine, value string;
+#    entity some-type, owns name-to-undefine;
+#
+#    rule rule-referencing-type-to-undefine:
+#    when {
+#      $x isa some-type;
+#    } then {
+#      $x has name-to-undefine "dummy";
+#    };
+#    """
+#    Given transaction commits
+#
+#    Given connection open write transaction for database: typedb
+#
+#    Given typeql schema query; fails
+#    """
+#    undefine
+#      name-to-undefine;
+#    """
 
-  Scenario: undefining a rule removes it
-    Given typeql schema query
-      """
-      define
-      company sub entity, plays employment:employer;
-      rule a-rule:
-      when {
-        $c isa company; $y isa person;
-      } then {
-        (employer: $c, employee: $y) isa employment;
-      };
-      """
-    Given transaction commits
-
-    When session opens transaction of type: write
-    Then rules contain: a-rule
-    When typeql schema query
-      """
-      undefine rule a-rule;
-      """
-    Then transaction commits
-
-    When session opens transaction of type: read
-    Then rules do not contain: a-rule
-
-  Scenario: after undefining a rule, concepts previously inferred by that rule are no longer inferred
-    Given typeql schema query
-      """
-      define
-      rule samuel-email-rule:
-      when {
-        $x has email "samuel@vaticle.com";
-      } then {
-        $x has name "Samuel";
-      };
-      """
-    Given transaction commits
-
-    Given connection close all sessions
-    Given connection open data session for database: typedb
-    Given session opens transaction of type: write
-    Given typeql insert
-      """
-      insert $x isa person, has email "samuel@vaticle.com";
-      """
-    Given transaction commits
-
-    Given session opens transaction of type: read
-    Given get answers of typeql read query
-      """
-      match
-        $x has name $n;
-      get $n;
-      """
-    Given uniquely identify answer concepts
-      | n                 |
-      | attr:name:Samuel  |
-    Given connection close all sessions
-    Given connection open schema session for database: typedb
-    Given session opens transaction of type: write
-    When typeql schema query
-      """
-      undefine rule samuel-email-rule;
-      """
-    Then transaction commits
-
-    When session opens transaction of type: read
-    When get answers of typeql read query
-      """
-      match
-        $x has name $n;
-      get $n;
-      """
-    Then answer size is: 0
-
-
-  # TODO enable when we can do reasoning in a schema write transaction
-  @ignore
-  Scenario: when undefining a rule, concepts inferred by that rule can still be retrieved until the next commit
-    Given typeql schema query
-      """
-      define
-      rule samuel-email-rule:
-      when {
-        $x has email "samuel@vaticle.com";
-      } then {
-        $x has name "Samuel";
-      };
-      """
-    Given transaction commits
-
-    Given connection close all sessions
-    Given connection open data session for database: typedb
-    Given session opens transaction of type: write
-    Given typeql insert
-      """
-      insert $x isa person, has email "samuel@vaticle.com";
-      """
-    Given transaction commits
-
-    Given connection close all sessions
-    Given connection open schema session for database: typedb
-    Given session opens transaction of type: write
-    Given get answers of typeql read query
-      """
-      match
-        $x has name $n;
-      get $n;
-      """
-    Given uniquely identify answer concepts
-      | n                 |
-      | attr:name:Samuel  |
-    When typeql schema query
-      """
-      undefine rule samuel-email-rule;
-      """
-
-    When get answers of typeql read query
-      """
-      match
-        $x has name $n;
-      get $n;
-      """
-    Then uniquely identify answer concepts
-      | n                 |
-      | attr:name:Samuel  |
-
-  Scenario: You cannot undefine a type if it is used in a rule
-    Given typeql schema query
-    """
-    define
-
-    type-to-undefine sub entity, owns name;
-
-    rule rule-referencing-type-to-undefine:
-    when {
-      $x isa type-to-undefine;
-    } then {
-      $x has name "dummy";
-    };
-    """
-    Given transaction commits
-
-    Given session opens transaction of type: write
-
-    Given typeql schema query; throws exception
-    """
-    undefine
-      type-to-undefine sub entity;
-    """
-
-  Scenario: You cannot undefine a type if it is used in a negation in a rule
-    Given typeql schema query
-    """
-    define
-    rel sub relation, relates rol;
-    other-type sub entity, owns name, plays rel:rol;
-    type-to-undefine sub entity, owns name, plays rel:rol;
-
-    rule rule-referencing-type-to-undefine:
-    when {
-      $x isa other-type;
-      not { ($x, $y) isa relation; $y isa type-to-undefine; };
-    } then {
-      $x has name "dummy";
-    };
-    """
-    Given transaction commits
-
-    Given session opens transaction of type: write
-
-    Given typeql schema query; throws exception
-    """
-    undefine
-      type-to-undefine sub entity;
-    """
-
-  Scenario: You cannot undefine a type if it is used in any disjunction in a rule
-    Given typeql schema query
-    """
-    define
-
-    type-to-undefine sub entity, owns name;
-
-    rule rule-referencing-type-to-undefine:
-    when {
-      $x has name $y;
-      { $x isa person; } or { $x isa type-to-undefine; };
-    } then {
-      $x has name "dummy";
-    };
-    """
-    Given transaction commits
-
-    Given session opens transaction of type: write
-
-    Given typeql schema query; throws exception
-    """
-    undefine
-      type-to-undefine sub entity;
-    """
-
-  Scenario: You cannot undefine a type if it is used in the then of a rule
-    Given typeql schema query
-    """
-    define
-    name-to-undefine sub attribute, value string;
-    some-type sub entity, owns name-to-undefine;
-
-    rule rule-referencing-type-to-undefine:
-    when {
-      $x isa some-type;
-    } then {
-      $x has name-to-undefine "dummy";
-    };
-    """
-    Given transaction commits
-
-    Given session opens transaction of type: write
-
-    Given typeql schema query; throws exception
-    """
-    undefine
-      name-to-undefine sub entity;
-    """
-
-  ############
-  # ABSTRACT #
-  ############
+  ####################
+  # TYPE ANNOTATIONS #
+  ####################
 
   Scenario: undefining a type as abstract converts an abstract to a concrete type, allowing creation of instances
     Given get answers of typeql read query
       """
       match
-        $x type abstract-type;
+        $x label abstract-type;
         not { $x abstract; };
 
       """
     Given answer size is: 0
-    Given connection close all sessions
-    Given connection open data session for database: typedb
-    Given session opens transaction of type: write
-    Given typeql insert; throws exception
+    Given transaction closes
+    Given connection open write transaction for database: typedb
+    Given typeql write query; fails
       """
       insert $x isa abstract-type;
       """
 
-    Given connection close all sessions
-    Given connection open schema session for database: typedb
-    Given session opens transaction of type: write
+    Given transaction closes
+    Given connection open write transaction for database: typedb
     Given typeql schema query
       """
       undefine abstract-type abstract;
       """
     Given transaction commits
 
-    Given connection close all sessions
-    Given connection open data session for database: typedb
-    Given session opens transaction of type: write
+    Given transaction closes
+    Given connection open write transaction for database: typedb
     When get answers of typeql read query
       """
       match
-        $x type abstract-type;
+        $x label abstract-type;
         not { $x abstract; };
 
       """
     Then uniquely identify answer concepts
       | x                   |
       | label:abstract-type |
-    When typeql insert
+    When typeql write query
       """
       insert $x isa abstract-type;
       """
     Then transaction commits
 
-    When session opens transaction of type: read
+    When connection open read transaction for database: typedb
     When get answers of typeql read query
       """
       match $x isa abstract-type;
@@ -1536,11 +1481,11 @@ Feature: TypeQL Undefine Query
       """
     Then transaction commits
 
-    When session opens transaction of type: read
+    When connection open read transaction for database: typedb
     When get answers of typeql read query
       """
       match
-        $x type person;
+        $x label person;
         not { $x abstract; };
 
       """
@@ -1552,22 +1497,22 @@ Feature: TypeQL Undefine Query
   Scenario: an abstract type can be changed into a concrete type even if has an abstract child type
     Given typeql schema query
       """
-      define sub-abstract-type sub abstract-type, abstract;
+      define entity sub-abstract-type @abstract, sub abstract-type;
       """
     Given transaction commits
 
-    Given session opens transaction of type: write
+    Given connection open write transaction for database: typedb
     When typeql schema query
       """
-      undefine abstract-type abstract;
+      undefine abstract-type @abstract;
       """
     Then transaction commits
 
-    When session opens transaction of type: read
+    When connection open read transaction for database: typedb
     When get answers of typeql read query
       """
       match
-        $x type abstract-type;
+        $x label abstract-type;
         not { $x abstract; };
 
       """
@@ -1580,13 +1525,13 @@ Feature: TypeQL Undefine Query
     Given typeql schema query
       """
       define
-      person abstract;
-      vehicle-registration sub attribute, value string, abstract;
+      person @abstract;
+      attribute vehicle-registration @abstract, value string;
       person owns vehicle-registration;
       """
     Given transaction commits
 
-    Given session opens transaction of type: write
+    Given connection open write transaction for database: typedb
     When typeql schema query
       """
       undefine
@@ -1594,15 +1539,21 @@ Feature: TypeQL Undefine Query
       """
     Then transaction commits
 
-    When session opens transaction of type: read
+    When connection open read transaction for database: typedb
     When get answers of typeql read query
       """
       match
-        $x type vehicle-registration;
+        $x label vehicle-registration;
         not { $x abstract; };
 
       """
     Then answer size is: 1
+
+
+  ##########################
+  # CAPABILITY ANNOTATIONS #
+  ##########################
+  # TODO: Write tests
 
 
   ###################
@@ -1612,121 +1563,107 @@ Feature: TypeQL Undefine Query
   Scenario: a type and an attribute type that it owns can be removed simultaneously
     Given get answers of typeql read query
       """
-      match $x sub entity;
+      match entity $x;
       """
     Given uniquely identify answer concepts
       | x                   |
       | label:person        |
       | label:abstract-type |
-      | label:entity        |
     Given get answers of typeql read query
       """
-      match $x sub attribute;
+      match attribute $x;
       """
     Given uniquely identify answer concepts
       | x               |
       | label:name      |
       | label:email     |
-      | label:attribute |
     When typeql schema query
       """
       undefine
-      person sub entity, owns name;
-      name sub attribute;
+      entity person, owns name;
+      attribute name;
       """
     Then transaction commits
 
-    When session opens transaction of type: read
+    When connection open read transaction for database: typedb
     When get answers of typeql read query
       """
-      match $x sub entity;
+      match entity $x;
       """
     Then uniquely identify answer concepts
       | x                   |
       | label:abstract-type |
-      | label:entity        |
     When get answers of typeql read query
       """
-      match $x sub attribute;
+      match attribute $x;
       """
     Then uniquely identify answer concepts
       | x               |
       | label:email     |
-      | label:attribute |
 
   Scenario: a type, a relation type that it plays in and an attribute type that it owns can be removed simultaneously
     Given get answers of typeql read query
       """
-      match $x sub entity;
+      match entity $x;
       """
     Given uniquely identify answer concepts
       | x                   |
       | label:person        |
       | label:abstract-type |
-      | label:entity        |
     Given get answers of typeql read query
       """
-      match $x sub relation;
+      match relation $x;
       """
     Given uniquely identify answer concepts
       | x                |
       | label:employment |
-      | label:relation   |
     Given get answers of typeql read query
       """
-      match $x sub attribute;
+      match attribute $x;
       """
     Given uniquely identify answer concepts
       | x               |
       | label:name      |
       | label:email     |
-      | label:attribute |
     Given get answers of typeql read query
       """
-      match $x sub relation:role;
+      match $_ relates $x;
       """
     Given uniquely identify answer concepts
       | x                         |
       | label:employment:employee |
       | label:employment:employer |
-      | label:relation:role       |
     When typeql schema query
       """
       undefine
-      person sub entity, owns name, owns email, plays employment:employee;
-      employment sub relation, relates employee, relates employer;
-      name sub attribute;
+      entity person, owns name, owns email, plays employment:employee;
+      relation employment, relates employee, relates employer;
+      attribute name;
       """
     Then transaction commits
 
-    When session opens transaction of type: read
+    When connection open read transaction for database: typedb
     When get answers of typeql read query
       """
-      match $x sub entity;
+      match entity $x;
       """
     Then uniquely identify answer concepts
       | x                   |
       | label:abstract-type |
-      | label:entity        |
     When get answers of typeql read query
       """
-      match $x sub relation;
+      match relation $x;
       """
-    Then uniquely identify answer concepts
-      | x              |
-      | label:relation |
+    Then answer size is: 0
     When get answers of typeql read query
       """
-      match $x sub attribute;
+      match attribute $x;
       """
     Then uniquely identify answer concepts
       | x               |
       | label:email     |
-      | label:attribute |
     When get answers of typeql read query
       """
-      match $x sub relation:role;
+      match $_ relates $x;
       """
-    Then uniquely identify answer concepts
-      | x                   |
-      | label:relation:role |
+    Then answer size is: 0


### PR DESCRIPTION
## Usage and product changes
We update all the existing `undefine` tests to use the new 3.0 `undefine` queries, add new steps to test new 3.0 functionality (new annotations, specific errors returned for query safety), and remove some of the excessive tests (mostly non-implemented ones) for cases already covered in concept BDDs.

Additionally, we cover the missing cases for `match` queries:
* transitive owns/plays/relates;
* value;
* as.

## Implementation
Several todos are left for `match` queries that should verify that the un/re/-definitions are successful, but are not implemented in 3.0 for now. Unique kinds of these TODOs are highlighted by comments of this PR.
