### PR TITLE
Add a test for driver with database background creation

### DIFF
--- a/driver/driver.feature
+++ b/driver/driver.feature
@@ -205,7 +205,7 @@ Feature: TypeDB Driver
 #    """
 
 
-  Scenario: Driver can get databases created by other drivers in parallel
+  Scenario: Driver can sees databases updates done by other drivers in background
     Then connection does not have database: newbie
     Then connection open schema transaction for database: newbie; fails with a message containing: "The database 'newbie' does not exist"
     # Consider refactoring of how we manage multiple drivers
@@ -214,6 +214,22 @@ Feature: TypeDB Driver
     Then connection has database: newbie
     Then connection open schema transaction for database: newbie
     Then transaction commits
+    When connection closes
+
+    When connection opens with default authentication
+    Then connection has database: newbie
+    Then connection open schema transaction for database: newbie
+    When transaction closes
+    Then connection has database: newbie
+
+    When in background, connection delete database: newbie
+    Then connection does not have database: newbie
+    Then connection open schema transaction for database: newbie; fails with a message containing: "The database 'newbie' does not exist"
+    When connection closes
+
+    When connection opens with default authentication
+    Then connection does not have database: newbie
+    Then connection open schema transaction for database: newbie; fails with a message containing: "The database 'newbie' does not exist"
 
 
   Scenario: Driver processes database management errors correctly

--- a/driver/driver.feature
+++ b/driver/driver.feature
@@ -66,6 +66,8 @@ Feature: TypeDB Driver
   # DATABASES #
   #############
 
+  # TODO: Explicitly test "databases().all()" interfaces. Make sure that "has" uses "contains" in drivers instead.
+
   Scenario: Driver cannot delete non-existing database
     Given connection does not have database: does-not-exist
     Then connection delete database: does-not-exist; fails with a message containing: "Database 'does-not-exist' not found"
@@ -205,22 +207,28 @@ Feature: TypeDB Driver
 #    """
 
 
-  Scenario: Driver can sees databases updates done by other drivers in background
+  Scenario: Driver sees databases updates done by other drivers in background
     Then connection does not have database: newbie
     Then connection open schema transaction for database: newbie; fails with a message containing: "Database 'newbie' not found"
     # Consider refactoring of how we manage multiple drivers
     # if we use "background" steps more not to duplicate everything
     When in background, connection create database: newbie
-    Then connection has database: newbie
+    Then connection has databases:
+      | newbie |
+      | typedb |
     Then connection open schema transaction for database: newbie
     Then transaction commits
     When connection closes
 
     When connection opens with default authentication
-    Then connection has database: newbie
+    Then connection has databases:
+      | newbie |
+      | typedb |
     Then connection open schema transaction for database: newbie
     When transaction closes
-    Then connection has database: newbie
+    Then connection has databases:
+      | newbie |
+      | typedb |
 
     When in background, connection delete database: newbie
     Then connection does not have database: newbie

--- a/driver/driver.feature
+++ b/driver/driver.feature
@@ -205,6 +205,17 @@ Feature: TypeDB Driver
 #    """
 
 
+  Scenario: Driver can get databases created by other drivers in parallel
+    Then connection does not have database: newbie
+    Then connection open schema transaction for database: newbie; fails with a message containing: "The database 'newbie' does not exist"
+    # Consider refactoring of how we manage multiple drivers
+    # if we use "background" steps more not to duplicate everything
+    When in background, connection create database: newbie
+    Then connection has database: newbie
+    Then connection open schema transaction for database: newbie
+    Then transaction commits
+
+
   Scenario: Driver processes database management errors correctly
     Given connection open schema transaction for database: typedb
     Then connection create database with empty name; fails with a message containing: "is not a valid database name"

--- a/driver/driver.feature
+++ b/driver/driver.feature
@@ -68,7 +68,7 @@ Feature: TypeDB Driver
 
   Scenario: Driver cannot delete non-existing database
     Given connection does not have database: does-not-exist
-    Then connection delete database: does-not-exist; fails with a message containing: "The database 'does-not-exist' does not exist"
+    Then connection delete database: does-not-exist; fails with a message containing: "Database 'does-not-exist' not found"
     Then connection does not have database: does-not-exist
 
   Scenario: Driver can create and delete databases
@@ -207,7 +207,7 @@ Feature: TypeDB Driver
 
   Scenario: Driver can sees databases updates done by other drivers in background
     Then connection does not have database: newbie
-    Then connection open schema transaction for database: newbie; fails with a message containing: "The database 'newbie' does not exist"
+    Then connection open schema transaction for database: newbie; fails with a message containing: "Database 'newbie' not found"
     # Consider refactoring of how we manage multiple drivers
     # if we use "background" steps more not to duplicate everything
     When in background, connection create database: newbie
@@ -243,11 +243,11 @@ Feature: TypeDB Driver
   Scenario: Driver cannot open transaction to non-existing database
     Given connection does not have database: does-not-exist
     Then transaction is open: false
-    Then connection open schema transaction for database: does-not-exist; fails with a message containing: "The database 'does-not-exist' does not exist"
+    Then connection open schema transaction for database: does-not-exist; fails with a message containing: "Database 'does-not-exist' not found"
     Then transaction is open: false
-    Then connection open write transaction for database: does-not-exist; fails with a message containing: "The database 'does-not-exist' does not exist"
+    Then connection open write transaction for database: does-not-exist; fails with a message containing: "Database 'does-not-exist' not found"
     Then transaction is open: false
-    Then connection open read transaction for database: does-not-exist; fails with a message containing: "The database 'does-not-exist' does not exist"
+    Then connection open read transaction for database: does-not-exist; fails with a message containing: "Database 'does-not-exist' not found"
     Then transaction is open: false
 
 

--- a/driver/driver.feature
+++ b/driver/driver.feature
@@ -224,12 +224,12 @@ Feature: TypeDB Driver
 
     When in background, connection delete database: newbie
     Then connection does not have database: newbie
-    Then connection open schema transaction for database: newbie; fails with a message containing: "The database 'newbie' does not exist"
+    Then connection open schema transaction for database: newbie; fails with a message containing: "Database 'newbie' not found"
     When connection closes
 
     When connection opens with default authentication
     Then connection does not have database: newbie
-    Then connection open schema transaction for database: newbie; fails with a message containing: "The database 'newbie' does not exist"
+    Then connection open schema transaction for database: newbie; fails with a message containing: "Database 'newbie' not found"
 
 
   Scenario: Driver processes database management errors correctly


### PR DESCRIPTION
## Usage and product changes
We encountered a bug when the Rust driver crashed on transaction opening for a database created by another driver in background. 
To test such cases with multiple drivers working in parallel, we add a BDD scenario describing this situation.

## Implementation
We don't want to overcomplicate the implementation of the drivers BDDs by managing multiple parallel driver connections as we don't have many things to test in this setup at the moment. That's why we introduce a new `in background,` category of steps, which means "create a new temporary driver and do something without affecting the main connection".

