### PR TITLE
Update BDDs for TypeQL syntax changes

### DIFF
--- a/concept/migration/data-validation.feature
+++ b/concept/migration/data-validation.feature
@@ -186,7 +186,7 @@ Feature: Data validation
     When transaction commits
     Examples:
       | value-type  | value           |
-      | long        | 1               |
+      | integer        | 1               |
       | double      | 1.0             |
       | decimal     | 1.0             |
       | string      | "alice"         |
@@ -223,7 +223,7 @@ Feature: Data validation
     When transaction commits
     Examples:
       | value-type  | value           |
-      | long        | 1               |
+      | integer        | 1               |
       | double      | 1.0             |
       | decimal     | 1.0             |
       | string      | "alice"         |
@@ -794,7 +794,7 @@ Feature: Data validation
     When relation(parentship) create role: child
     When relation(parentship) get role(child) set ordering: ordered
     When create attribute type: id
-    When attribute(id) set value type: long
+    When attribute(id) set value type: integer
     When relation(parentship) set owns: id
     When relation(parentship) get owns(id) set annotation: @key
     When create entity type: person
@@ -854,7 +854,7 @@ Feature: Data validation
 
   Scenario: Owns cannot change ordering if it has role instances for entity type
     When create attribute type: id
-    When attribute(id) set value type: long
+    When attribute(id) set value type: integer
     When create attribute type: name
     When attribute(name) set value type: string
     When create attribute type: email
@@ -904,7 +904,7 @@ Feature: Data validation
     When attribute(name) put instance with value: "bob"
     Then transaction commits
     When connection open schema transaction for database: typedb
-    Then attribute(name) set value type: long; fails
+    Then attribute(name) set value type: integer; fails
     Then attribute(name) set value type: double; fails
     Then attribute(name) set value type: decimal; fails
     Then attribute(name) set value type: datetime; fails

--- a/concept/migration/migration.feature
+++ b/concept/migration/migration.feature
@@ -617,7 +617,7 @@ Feature: Schema migration
 
   Scenario: Unowned attribute data is cleaned up if @independent is unset and is persistent if @independent exists
     When create attribute type: attr0
-    When attribute(attr0) set value type: long
+    When attribute(attr0) set value type: integer
     When attribute(attr0) set annotation: @abstract
     When create attribute type: attr1
     When attribute(attr1) set supertype: attr0
@@ -691,7 +691,7 @@ Feature: Schema migration
 
     When connection open schema transaction for database: typedb
     When create attribute type: attr01
-    When attribute(attr01) set value type: long
+    When attribute(attr01) set value type: integer
     When attribute(attr01) set annotation: @abstract
     Then attribute(attr1) set supertype: attr01; fails
     Then attribute(attr2) set supertype: attr01; fails

--- a/concept/thing/attribute.feature
+++ b/concept/thing/attribute.feature
@@ -17,7 +17,7 @@ Feature: Concept Attribute
     Given attribute(is-alive) set value type: boolean
     Given attribute(is-alive) set annotation: @independent
     Given create attribute type: age
-    Given attribute(age) set value type: long
+    Given attribute(age) set value type: integer
     Given attribute(age) set annotation: @independent
     Given create attribute type: score
     Given attribute(score) set value type: double
@@ -61,7 +61,7 @@ Feature: Concept Attribute
     Examples:
       | attr              | type        | value                                                                              |
       | is-alive          | boolean     | true                                                                               |
-      | age               | long        | 21                                                                                 |
+      | age               | integer        | 21                                                                                 |
       | score             | double      | 123.456                                                                            |
       | name              | string      | alice                                                                              |
       | name              | string      | very-long-string-with_@strangESymßo¬s¡2)*(()˚¬ª#08uj!@%@£^%*&%(*@!_++±§≥≤<>?:😎資料庫 |
@@ -81,7 +81,7 @@ Feature: Concept Attribute
     Examples:
       | attr              | type        | value                                                                              |
       | is-alive          | boolean     | true                                                                               |
-      | age               | long        | 21                                                                                 |
+      | age               | integer        | 21                                                                                 |
       | score             | double      | 123.456                                                                            |
       | name              | string      | alice                                                                              |
       | name              | string      | very-long-string-with_@strangESymßo¬s¡2)*(()˚¬ª#08uj!@%@£^%*&%(*@!_++±§≥≤<>?:😎資料庫 |
@@ -116,7 +116,7 @@ Feature: Concept Attribute
     Examples:
       | attr              | type        | value                              |
       | is-alive          | boolean     | true                               |
-      | age               | long        | 21                                 |
+      | age               | integer        | 21                                 |
       | score             | double      | 123.456                            |
       | name              | string      | alice                              |
       | birth-date        | date        | 1990-01-01                         |
@@ -163,7 +163,7 @@ Feature: Concept Attribute
 
     When connection open schema transaction for database: typedb
     When create attribute type: ephemeral
-    When attribute(ephemeral) set value type: long
+    When attribute(ephemeral) set value type: integer
     When transaction commits
 
     When connection open write transaction for database: typedb
@@ -223,8 +223,8 @@ Feature: Concept Attribute
     Then attribute $fail does not exist
     Examples:
       | value-type  | values-args                               | fail-val                      | suc-val                       |
-      | long        | 1, 5, 4                                   | 2                             | 1                             |
-      | long        | 1                                         | 2                             | 1                             |
+      | integer        | 1, 5, 4                                   | 2                             | 1                             |
+      | integer        | 1                                         | 2                             | 1                             |
       | double      | 1.1, 1.5, 0.01                            | 0.1                           | 0.01                          |
       | double      | 0.01                                      | 0.1                           | 0.01                          |
       | double      | 0.01, 0.0001                              | 0.001                         | 0.0001                        |
@@ -272,11 +272,11 @@ Feature: Concept Attribute
     Then attribute $fail does not exist
     Examples:
       | value-type  | range-args                                                           | fail-val                          | suc-val                           |
-      | long        | 1..3                                                                 | 0                                 | 1                                 |
-      | long        | 1..3                                                                 | -1                                | 2                                 |
-      | long        | 1..3                                                                 | 4                                 | 3                                 |
-      | long        | -1..1                                                                | -2                                | 0                                 |
-      | long        | -1..1                                                                | 2                                 | -1                                |
+      | integer        | 1..3                                                                 | 0                                 | 1                                 |
+      | integer        | 1..3                                                                 | -1                                | 2                                 |
+      | integer        | 1..3                                                                 | 4                                 | 3                                 |
+      | integer        | -1..1                                                                | -2                                | 0                                 |
+      | integer        | -1..1                                                                | 2                                 | -1                                |
       | double      | 0.01..0.1                                                            | 0.001                             | 0.01                              |
       | double      | 0.01..0.1                                                            | 0.11                              | 0.0111111                         |
       | double      | -0.01..0.1                                                           | -0.011                            | 0.01                              |

--- a/concept/thing/has.feature
+++ b/concept/thing/has.feature
@@ -216,8 +216,8 @@ Feature: Concept Ownership
     Then entity $p get has(limited-value) do not contain: $fail
     Examples:
       | value-type  | values-args                               | fail-val                      | suc-val                       |
-      | long        | 1, 5, 4                                   | 2                             | 1                             |
-      | long        | 1                                         | 2                             | 1                             |
+      | integer        | 1, 5, 4                                   | 2                             | 1                             |
+      | integer        | 1                                         | 2                             | 1                             |
       | double      | 1.1, 1.5, 0.01                            | 0.1                           | 0.01                          |
       | double      | 0.01                                      | 0.1                           | 0.01                          |
       | double      | 0.01, 0.0001                              | 0.001                         | 0.0001                        |
@@ -269,11 +269,11 @@ Feature: Concept Ownership
     Then entity $p get has(limited-value) do not contain: $fail
     Examples:
       | value-type  | range-args                                                           | fail-val                          | suc-val                           |
-      | long        | 1..3                                                                 | 0                                 | 1                                 |
-      | long        | 1..3                                                                 | -1                                | 2                                 |
-      | long        | 1..3                                                                 | 4                                 | 3                                 |
-      | long        | -1..1                                                                | -2                                | 0                                 |
-      | long        | -1..1                                                                | 2                                 | -1                                |
+      | integer        | 1..3                                                                 | 0                                 | 1                                 |
+      | integer        | 1..3                                                                 | -1                                | 2                                 |
+      | integer        | 1..3                                                                 | 4                                 | 3                                 |
+      | integer        | -1..1                                                                | -2                                | 0                                 |
+      | integer        | -1..1                                                                | 2                                 | -1                                |
       | double      | 0.01..0.1                                                            | 0.001                             | 0.01                              |
       | double      | 0.01..0.1                                                            | 0.11                              | 0.0111111                         |
       | double      | -0.01..0.1                                                           | -0.011                            | 0.01                              |

--- a/concept/type/attributetype.feature
+++ b/concept/type/attributetype.feature
@@ -51,7 +51,7 @@ Feature: Concept Attribute Type
     Then attribute(name) get value type declared: <value-type>
     Examples:
       | value-type  |
-      | long        |
+      | integer        |
       | string      |
       | boolean     |
       | double      |
@@ -89,7 +89,7 @@ Feature: Concept Attribute Type
     Then create attribute type: name; fails
     Examples:
       | value-type    |
-      | long          |
+      | integer          |
       | string        |
       | boolean       |
       | double        |
@@ -138,7 +138,7 @@ Feature: Concept Attribute Type
       | age  |
     Examples:
       | value-type-1 | value-type-2 |
-      | string       | long         |
+      | string       | integer         |
       | boolean      | double       |
       | decimal      | datetime-tz  |
       | datetime     | duration     |
@@ -147,7 +147,7 @@ Feature: Concept Attribute Type
     When create attribute type: is-open
     When attribute(is-open) set value type: boolean
     When create attribute type: age
-    When attribute(age) set value type: long
+    When attribute(age) set value type: integer
     When create attribute type: rating
     When attribute(rating) set value type: double
     When create attribute type: name
@@ -191,7 +191,7 @@ Feature: Concept Attribute Type
     When create attribute type: is-open
     When attribute(is-open) set value type: boolean
     When create attribute type: age
-    When attribute(age) set value type: long
+    When attribute(age) set value type: integer
     When create attribute type: rating
     When attribute(rating) set value type: double
     When create attribute type: name
@@ -237,10 +237,10 @@ Feature: Concept Attribute Type
     Then attribute(name) get declared annotations contain: @<annotation>
     Examples:
       | value-type  | annotation                              | annotation-category |
-      | long        | abstract                                | abstract            |
-      | long        | independent                             | independent         |
-      | long        | values(1)                               | values              |
-      | long        | range(1..3)                             | range               |
+      | integer        | abstract                                | abstract            |
+      | integer        | independent                             | independent         |
+      | integer        | values(1)                               | values              |
+      | integer        | range(1..3)                             | range               |
       | string      | abstract                                | abstract            |
       | string      | independent                             | independent         |
       | string      | regex("\S+")                            | regex               |
@@ -332,7 +332,7 @@ Feature: Concept Attribute Type
       | decimal    | independent  | independent         |
       | string     | regex("\S+") | regex               |
       | string     | values("1")  | values              |
-      | long       | range(1..3)  | range               |
+      | integer       | range(1..3)  | range               |
 
   Scenario Outline: Attribute type cannot set supertype with the same @<annotation> until it is explicitly unset from type
     When create attribute type: name
@@ -380,7 +380,7 @@ Feature: Concept Attribute Type
       | decimal    | independent  | independent         |
       | string     | regex("\S+") | regex               |
       | string     | values("1")  | values              |
-      | long       | range(1..3)  | range               |
+      | integer       | range(1..3)  | range               |
 
   Scenario Outline: Attribute type loses inherited @<annotation> if supertype is unset
     When create attribute type: name
@@ -431,7 +431,7 @@ Feature: Concept Attribute Type
       | decimal    | independent  |
       | string     | regex("\S+") |
       | string     | values("1")  |
-      | long       | range(1..3)  |
+      | integer       | range(1..3)  |
 
   Scenario Outline: Attribute type cannot set redundant duplicated @<annotation> while inheriting it
     When create attribute type: name
@@ -459,7 +459,7 @@ Feature: Concept Attribute Type
       | decimal    | independent  | independent         |
       | string     | regex("\S+") | regex               |
       | string     | values("1")  | values              |
-      | long       | range(1..3)  | range               |
+      | integer       | range(1..3)  | range               |
 
 ########################
 # @abstract
@@ -784,16 +784,16 @@ Feature: Concept Attribute Type
     Then attribute(first-name) set supertype: name; fails
     Examples:
       | value-type-1  | value-type-2    |
-      | long          | string          |
-      | long          | boolean         |
-      | long          | double          |
-      | long          | decimal         |
-      | long          | date            |
-      | long          | datetime        |
-      | long          | datetime-tz     |
-      | long          | duration        |
-      | long          | custom-struct   |
-      | string        | long            |
+      | integer          | string          |
+      | integer          | boolean         |
+      | integer          | double          |
+      | integer          | decimal         |
+      | integer          | date            |
+      | integer          | datetime        |
+      | integer          | datetime-tz     |
+      | integer          | duration        |
+      | integer          | custom-struct   |
+      | string        | integer            |
       | boolean       | string          |
       | double        | datetime-tz     |
       | decimal       | datetime        |
@@ -801,7 +801,7 @@ Feature: Concept Attribute Type
       | datetime      | date            |
       | datetime-tz   | double          |
       | duration      | boolean         |
-      | custom-struct | long            |
+      | custom-struct | integer            |
       | custom-struct | string          |
       | custom-struct | boolean         |
       | custom-struct | double          |
@@ -841,24 +841,24 @@ Feature: Concept Attribute Type
     Then attribute(first-name) get value type: <value-type-2>
     Examples:
       | value-type-1  | value-type-2    |
-      | long          | string          |
-      | long          | boolean         |
-      | long          | double          |
-      | long          | decimal         |
-      | long          | date            |
-      | long          | datetime        |
-      | long          | datetime-tz     |
-      | long          | duration        |
-      | long          | custom-struct   |
+      | integer          | string          |
+      | integer          | boolean         |
+      | integer          | double          |
+      | integer          | decimal         |
+      | integer          | date            |
+      | integer          | datetime        |
+      | integer          | datetime-tz     |
+      | integer          | duration        |
+      | integer          | custom-struct   |
       | string        | boolean         |
       | boolean       | string          |
       | double        | datetime        |
       | decimal       | datetime-tz     |
       | date          | decimal         |
-      | datetime      | long            |
+      | datetime      | integer            |
       | datetime-tz   | double          |
       | duration      | date            |
-      | custom-struct | long            |
+      | custom-struct | integer            |
       | custom-struct | string          |
       | custom-struct | boolean         |
       | custom-struct | double          |
@@ -947,24 +947,24 @@ Feature: Concept Attribute Type
     Then attribute(sub-first-name) get value type is none
     Examples:
       | value-type-1  | value-type-2    |
-      | long          | string          |
-      | long          | boolean         |
-      | long          | double          |
-      | long          | decimal         |
-      | long          | date            |
-      | long          | datetime        |
-      | long          | datetime-tz     |
-      | long          | duration        |
-      | long          | custom-struct   |
+      | integer          | string          |
+      | integer          | boolean         |
+      | integer          | double          |
+      | integer          | decimal         |
+      | integer          | date            |
+      | integer          | datetime        |
+      | integer          | datetime-tz     |
+      | integer          | duration        |
+      | integer          | custom-struct   |
       | string        | datetime-tz     |
       | boolean       | date            |
       | double        | datetime        |
       | decimal       | double          |
       | date          | string          |
-      | datetime      | long            |
+      | datetime      | integer            |
       | datetime-tz   | decimal         |
       | duration      | boolean         |
-      | custom-struct | long            |
+      | custom-struct | integer            |
       | custom-struct | string          |
       | custom-struct | boolean         |
       | custom-struct | double          |
@@ -1006,7 +1006,7 @@ Feature: Concept Attribute Type
     Then attribute(first-name) get value type: <value-type>
     Examples:
       | value-type    |
-      | long          |
+      | integer          |
       | string        |
       | boolean       |
       | double        |
@@ -1031,7 +1031,7 @@ Feature: Concept Attribute Type
     Then attribute(name) get value type is none
     Examples:
       | value-type    |
-      | long          |
+      | integer          |
       | string        |
       | boolean       |
       | double        |
@@ -1056,7 +1056,7 @@ Feature: Concept Attribute Type
     Then attribute(name) get value type is none
     Examples:
       | value-type    |
-      | long          |
+      | integer          |
       | string        |
       | boolean       |
       | double        |
@@ -1082,7 +1082,7 @@ Feature: Concept Attribute Type
     Then attribute(first-name) get value type: <value-type>
     Examples:
       | value-type    |
-      | long          |
+      | integer          |
       | string        |
       | boolean       |
       | double        |
@@ -1120,7 +1120,7 @@ Feature: Concept Attribute Type
     Then attribute(first-name) get declared annotations contain: @abstract
     Examples:
       | value-type    |
-      | long          |
+      | integer          |
       | string        |
       | boolean       |
       | double        |
@@ -1342,7 +1342,7 @@ Feature: Concept Attribute Type
     Then attribute(email) get declared annotations is empty
     Examples:
       | value-type    | arg     |
-      | long          | "value" |
+      | integer          | "value" |
       | boolean       | "value" |
       | double        | "value" |
       | decimal       | "value" |
@@ -1534,7 +1534,7 @@ Feature: Concept Attribute Type
     When attribute(custom-attribute) set value type: string
     When attribute(custom-attribute) set annotation: @regex("\S+")
     Then attribute(custom-attribute) unset value type; fails
-    Then attribute(custom-attribute) set value type: long; fails
+    Then attribute(custom-attribute) set value type: integer; fails
     Then attribute(custom-attribute) set value type: boolean; fails
     Then attribute(custom-attribute) set value type: double; fails
     Then attribute(custom-attribute) set value type: decimal; fails
@@ -1555,7 +1555,7 @@ Feature: Concept Attribute Type
     When connection open schema transaction for database: typedb
     Then attribute(custom-attribute) get constraints contain: @regex("\S+")
     Then attribute(custom-attribute) unset value type; fails
-    Then attribute(custom-attribute) set value type: long; fails
+    Then attribute(custom-attribute) set value type: integer; fails
     Then attribute(custom-attribute) set value type: boolean; fails
     Then attribute(custom-attribute) set value type: double; fails
     Then attribute(custom-attribute) set value type: decimal; fails
@@ -1589,7 +1589,7 @@ Feature: Concept Attribute Type
     Then attribute(email) get declared annotations do not contain: @independent
     Examples:
       | value-type    |
-      | long          |
+      | integer          |
       | string        |
       | boolean       |
       | double        |
@@ -1742,13 +1742,13 @@ Feature: Concept Attribute Type
     Then attribute(email) get declared annotations do not contain: @values(<args>)
     Examples:
       | value-type  | args                                                                                                                                                                                                                                                                                                                                                                                                 |
-      | long        | 0                                                                                                                                                                                                                                                                                                                                                                                                    |
-      | long        | 1                                                                                                                                                                                                                                                                                                                                                                                                    |
-      | long        | -1                                                                                                                                                                                                                                                                                                                                                                                                   |
-      | long        | 1, 2                                                                                                                                                                                                                                                                                                                                                                                                 |
-      | long        | -9223372036854775808, 9223372036854775807                                                                                                                                                                                                                                                                                                                                                            |
-      | long        | 2, 1, 3, 4, 5, 6, 7, 9, 10, 11, 55, -1, -654321, 123456                                                                                                                                                                                                                                                                                                                                              |
-      | long        | 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 97, 98, 99 |
+      | integer        | 0                                                                                                                                                                                                                                                                                                                                                                                                    |
+      | integer        | 1                                                                                                                                                                                                                                                                                                                                                                                                    |
+      | integer        | -1                                                                                                                                                                                                                                                                                                                                                                                                   |
+      | integer        | 1, 2                                                                                                                                                                                                                                                                                                                                                                                                 |
+      | integer        | -9223372036854775808, 9223372036854775807                                                                                                                                                                                                                                                                                                                                                            |
+      | integer        | 2, 1, 3, 4, 5, 6, 7, 9, 10, 11, 55, -1, -654321, 123456                                                                                                                                                                                                                                                                                                                                              |
+      | integer        | 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 97, 98, 99 |
       | string      | ""                                                                                                                                                                                                                                                                                                                                                                                                   |
       | string      | "1"                                                                                                                                                                                                                                                                                                                                                                                                  |
       | string      | "福"                                                                                                                                                                                                                                                                                                                                                                                                  |
@@ -1871,7 +1871,7 @@ Feature: Concept Attribute Type
     Then attribute(name) get constraints do not contain: @values(<reset-args>)
     Examples:
       | value-type  | init-args       | reset-args      |
-      | long        | 1, 5            | 7, 9            |
+      | integer        | 1, 5            | 7, 9            |
       | double      | 1.1, 1.5        | -8.0, 88.3      |
       | decimal     | -8.0, 88.3      | 1.1, 1.5        |
       | string      | "s"             | "not s"         |
@@ -1891,10 +1891,10 @@ Feature: Concept Attribute Type
     Then attribute(name) get constraints is empty
     Examples:
       | value-type  | arg0                        | arg1                         | arg2                         |
-      | long        | 1                           | 1                            | 1                            |
-      | long        | 1                           | 1                            | 2                            |
-      | long        | 1                           | 2                            | 1                            |
-      | long        | 1                           | 2                            | 2                            |
+      | integer        | 1                           | 1                            | 1                            |
+      | integer        | 1                           | 1                            | 2                            |
+      | integer        | 1                           | 2                            | 1                            |
+      | integer        | 1                           | 2                            | 2                            |
       | double      | 0.1                         | 0.0001                       | 0.0001                       |
       | decimal     | 0.1                         | 0.0001                       | 0.0001                       |
       | string      | "stringwithoutdifferences"  | "stringwithoutdifferences"   | "stringWITHdifferences"      |
@@ -1984,7 +1984,7 @@ Feature: Concept Attribute Type
     Then attribute(specialised-name) get declared annotations do not contain: @values(<args>)
     Examples:
       | value-type  | args                                                                         | args-specialise                            |
-      | long        | 1, 10, 20, 30                                                                | 10, 30                                     |
+      | integer        | 1, 10, 20, 30                                                                | 10, 30                                     |
       | double      | 1.0, 2.0, 3.0, 4.5                                                           | 2.0                                        |
       | decimal     | 0.0, 1.0                                                                     | 0.0                                        |
       | string      | "john", "John", "Johnny", "johnny"                                           | "John", "Johnny"                           |
@@ -2018,7 +2018,7 @@ Feature: Concept Attribute Type
     Then attribute(specialised-name) get declared annotations do not contain: @values(<args>)
     Examples:
       | value-type  | args                                                                         | args-specialise          |
-      | long        | 1, 10, 20, 30                                                                | 10, 31                   |
+      | integer        | 1, 10, 20, 30                                                                | 10, 31                   |
       | double      | 1.0, 2.0, 3.0, 4.5                                                           | 2.001                    |
       | decimal     | 0.0, 1.0                                                                     | 0.01                     |
       | string      | "john", "John", "Johnny", "johnny"                                           | "Jonathan"               |
@@ -2037,18 +2037,18 @@ Feature: Concept Attribute Type
     When attribute(surname) set annotation: @values("only this string is allowed")
     When transaction commits
     When connection open schema transaction for database: typedb
-    Then attribute(name) set value type: long; fails
-    Then attribute(surname) set value type: long; fails
+    Then attribute(name) set value type: integer; fails
+    Then attribute(surname) set value type: integer; fails
     When attribute(surname) unset annotation: @values
     Then attribute(surname) unset value type; fails
-    When attribute(surname) set value type: long
-    When attribute(name) set value type: long
+    When attribute(surname) set value type: integer
+    When attribute(name) set value type: integer
     When attribute(surname) unset value type
     When attribute(surname) set annotation: @values(1, 2, 3)
     When transaction commits
     When connection open schema transaction for database: typedb
     Then attribute(surname) get constraints contain: @values(1, 2, 3)
-    Then attribute(surname) get value type: long
+    Then attribute(surname) get value type: integer
     When attribute(name) set annotation: @values(1, 2, 3)
     When attribute(surname) unset annotation: @values
     Then attribute(surname) get constraints contain: @values(1, 2, 3)
@@ -2056,7 +2056,7 @@ Feature: Concept Attribute Type
     When transaction commits
     When connection open read transaction for database: typedb
     Then attribute(surname) get constraints contain: @values(1, 2, 3)
-    Then attribute(surname) get value type: long
+    Then attribute(surname) get value type: integer
 
 ########################
 # @range
@@ -2122,11 +2122,11 @@ Feature: Concept Attribute Type
     Then attribute(email) get declared annotations do not contain: @range(<arg0>..)
     Examples:
       | value-type  | arg0                              | arg1                                                  |
-      | long        | 0                                 | 1                                                     |
-      | long        | 1                                 | 2                                                     |
-      | long        | 0                                 | 2                                                     |
-      | long        | -1                                | 1                                                     |
-      | long        | -9223372036854775808              | 9223372036854775807                                   |
+      | integer        | 0                                 | 1                                                     |
+      | integer        | 1                                 | 2                                                     |
+      | integer        | 0                                 | 2                                                     |
+      | integer        | -1                                | 1                                                     |
+      | integer        | -9223372036854775808              | 9223372036854775807                                   |
       | string      | "A"                               | "a"                                                   |
       | string      | "a"                               | "z"                                                   |
       | string      | "A"                               | "福"                                                   |
@@ -2237,7 +2237,7 @@ Feature: Concept Attribute Type
     Then attribute(name) get declared annotations is empty
     Examples:
       | value-type  | arg0                     |
-      | long        | 1                        |
+      | integer        | 1                        |
       | double      | 1.0                      |
       | decimal     | 1.0                      |
       | string      | "123"                    |
@@ -2277,7 +2277,7 @@ Feature: Concept Attribute Type
     Then attribute(name) get declared annotations do not contain: @range(<reset-args>)
     Examples:
       | value-type  | init-args                        | reset-args                       |
-      | long        | 1..5                             | 7..9                             |
+      | integer        | 1..5                             | 7..9                             |
       | double      | 1.1..1.5                         | -8.0..88.3                       |
       | decimal     | -8.0..88.3                       | 1.1..1.5                         |
       | string      | "S".."s"                         | "not s".."xxxxxxxxx"             |
@@ -2370,7 +2370,7 @@ Feature: Concept Attribute Type
     Then attribute(specialised-name) get declared annotations do not contain: @range(<args>)
     Examples:
       | value-type  | args                             | args-specialise                           |
-      | long        | 1..10                            | 1..5                                      |
+      | integer        | 1..10                            | 1..5                                      |
       | double      | 1.0..10.0                        | 2.0..10.0                                 |
       | decimal     | 0.0..1.0                         | 0.0..0.999999                             |
       | string      | "A".."Z"                         | "J".."Z"                                  |
@@ -2402,7 +2402,7 @@ Feature: Concept Attribute Type
     Then attribute(specialised-name) get declared annotations do not contain: @range(<args>)
     Examples:
       | value-type  | args                             | args-specialise                           |
-      | long        | 1..10                            | -1..5                                     |
+      | integer        | 1..10                            | -1..5                                     |
       | double      | 1.0..10.0                        | 0.0..150.0                                |
       | decimal     | 0.0..1.0                         | -0.0001..0.999999                         |
       | string      | "A".."Z"                         | "A".."z"                                  |
@@ -2419,18 +2419,18 @@ Feature: Concept Attribute Type
     When attribute(surname) set annotation: @range("a start".."finish line")
     When transaction commits
     When connection open schema transaction for database: typedb
-    Then attribute(name) set value type: long; fails
-    Then attribute(surname) set value type: long; fails
+    Then attribute(name) set value type: integer; fails
+    Then attribute(surname) set value type: integer; fails
     When attribute(surname) unset annotation: @range
     Then attribute(surname) unset value type; fails
-    When attribute(surname) set value type: long
-    When attribute(name) set value type: long
+    When attribute(surname) set value type: integer
+    When attribute(name) set value type: integer
     When attribute(surname) unset value type
     When attribute(surname) set annotation: @range(1..3)
     When transaction commits
     When connection open schema transaction for database: typedb
     Then attribute(surname) get constraints contain: @range(1..3)
-    Then attribute(surname) get value type: long
+    Then attribute(surname) get value type: integer
     When attribute(name) set annotation: @range(1..3)
     When attribute(surname) unset annotation: @range
     Then attribute(surname) get constraints contain: @range(1..3)
@@ -2438,7 +2438,7 @@ Feature: Concept Attribute Type
     When transaction commits
     When connection open read transaction for database: typedb
     Then attribute(surname) get constraints contain: @range(1..3)
-    Then attribute(surname) get value type: long
+    Then attribute(surname) get value type: integer
 
 ########################
 # @annotations combinations:
@@ -2496,7 +2496,7 @@ Feature: Concept Attribute Type
       | abstract         | values(1, 2)       | abstract              | values                | double      |
       | abstract         | range(1.0..2.0)    | abstract              | range                 | decimal     |
       | abstract         | regex("s")         | abstract              | regex                 | string      |
-      | independent      | values(1, 2)       | independent           | values                | long        |
+      | independent      | values(1, 2)       | independent           | values                | integer        |
       | independent      | range(false..true) | independent           | range                 | boolean     |
       | independent      | regex("s")         | independent           | regex                 | string      |
       | values(1.0, 2.0) | range(1.0..2.0)    | values                | range                 | double      |
@@ -2549,7 +2549,7 @@ Feature: Concept Attribute Type
     Then struct(passport) get field(name) is optional: false
     Examples:
       | value-type    |
-      | long          |
+      | integer          |
       | string        |
       | boolean       |
       | double        |
@@ -2583,7 +2583,7 @@ Feature: Concept Attribute Type
     Then struct(passport) get field(name) is optional: false
     Examples:
       | value-type-1  | value-type-2  |
-      | long          | string        |
+      | integer          | string        |
       | string        | boolean       |
       | boolean       | double        |
       | double        | decimal       |
@@ -2592,7 +2592,7 @@ Feature: Concept Attribute Type
       | datetime      | datetime-tz   |
       | datetime-tz   | duration      |
       | duration      | custom-struct |
-      | custom-struct | long          |
+      | custom-struct | integer          |
 
   Scenario Outline: Struct can be created with one optional field, including another struct
     When create struct: passport
@@ -2612,7 +2612,7 @@ Feature: Concept Attribute Type
     Then struct(passport) get field(name) is optional: true
     Examples:
       | value-type    |
-      | long          |
+      | integer          |
       | string        |
       | boolean       |
       | double        |
@@ -2660,7 +2660,7 @@ Feature: Concept Attribute Type
     Then struct(passport) get field(middle-name) is optional: true
     Examples:
       | value-type-1  | value-type-2  |
-      | long          | string        |
+      | integer          | string        |
       | string        | boolean       |
       | boolean       | double        |
       | double        | decimal       |
@@ -2669,7 +2669,7 @@ Feature: Concept Attribute Type
       | datetime      | datetime-tz   |
       | datetime-tz   | duration      |
       | duration      | custom-struct |
-      | custom-struct | long          |
+      | custom-struct | integer          |
 
   Scenario: Struct without fields can be deleted
     When create struct: passport
@@ -2749,7 +2749,7 @@ Feature: Concept Attribute Type
       | not-name |
     Examples:
       | value-type    |
-      | long          |
+      | integer          |
       | string        |
       | boolean       |
       | double        |
@@ -2772,7 +2772,7 @@ Feature: Concept Attribute Type
     Then struct(table) delete field: name; fails
     Examples:
       | value-type    |
-      | long          |
+      | integer          |
       | string        |
       | date          |
       | custom-struct |
@@ -2794,7 +2794,7 @@ Feature: Concept Attribute Type
     Then struct(passport) create field: name, with value type: string; fails
     Then struct(passport) create field: birthday, with value type: datetime; fails
     Then struct(passport) create field: name, with value type: datetime; fails
-    Then struct(passport) create field: birthday, with value type: long; fails
+    Then struct(passport) create field: birthday, with value type: integer; fails
     When transaction commits
     When connection open read transaction for database: typedb
     Then struct(passport) exists

--- a/concept/type/owns-annotations.feature
+++ b/concept/type/owns-annotations.feature
@@ -109,7 +109,7 @@ Feature: Concept Owns Annotations
     When create attribute type: name
     When attribute(name) set value type: string
     When create attribute type: age
-    When attribute(age) set value type: long
+    When attribute(age) set value type: integer
     When <root-type>(<type-name>) set owns: email
     When <root-type>(<type-name>) get owns(email) set annotation: @<annotation>
     When <root-type>(<type-name>) set owns: username
@@ -1172,7 +1172,7 @@ Feature: Concept Owns Annotations
     When attribute(name) set value type: string
     When attribute(name) set annotation: @abstract
     When create attribute type: age
-    When attribute(age) set value type: long
+    When attribute(age) set value type: integer
     When create attribute type: reference
     When attribute(reference) set value type: string
     When attribute(reference) set annotation: @abstract
@@ -1475,7 +1475,7 @@ Feature: Concept Owns Annotations
     Then entity(person) get owns is empty
     Examples:
       | value-type  |
-      | long        |
+      | integer        |
       | decimal     |
       | string      |
       | boolean     |
@@ -1499,7 +1499,7 @@ Feature: Concept Owns Annotations
     Then entity(person) get owns(custom-attribute) is key: true
     Examples:
       | value-type  |
-      | long        |
+      | integer        |
       | decimal     |
       | string      |
       | boolean     |
@@ -1579,7 +1579,7 @@ Feature: Concept Owns Annotations
     Then entity(person) get owns(custom-attribute) is key: true
     Examples:
       | value-type  |
-      | long        |
+      | integer        |
       | decimal     |
       | string      |
       | boolean     |
@@ -1725,7 +1725,7 @@ Feature: Concept Owns Annotations
 #    Then entity(person) get owns is empty
 #    Examples:
 #      | value-type | arg                            |
-#      | long       | LABEL                          |
+#      | integer       | LABEL                          |
 #      | decimal    | 1.5                            |
 #      | string     | label                          |
 #      | boolean    | lAbEl_Of_FoRmaT                |
@@ -1733,7 +1733,7 @@ Feature: Concept Owns Annotations
 #      | datetime   | l                              |
 #      | datetime-tz | l2                             |
 #      | duration   | trydigits2723andafter          |
-#      | long       | LABEL, LABEL2                  |
+#      | integer       | LABEL, LABEL2                  |
 #      | string     | label, label2                  |
 #      | boolean    | lAbEl_Of_FoRmaT, another_label |
 #      | datetime   | l, m, b, k, r, e2, ss, s, sss  |
@@ -1753,7 +1753,7 @@ Feature: Concept Owns Annotations
 #    When create attribute type: progress
 #    When attribute(progress) set value type: double
 #    When create attribute type: age
-#    When attribute(age) set value type: long
+#    When attribute(age) set value type: integer
 #    When <root-type>(<type-name>) set owns: first-name
 #    When <root-type>(<type-name>) get owns(first-name) set annotation: @subkey(primary)
 #    Then <root-type>(<type-name>) get owns(first-name) get constraints contain: @subkey(primary)
@@ -1806,7 +1806,7 @@ Feature: Concept Owns Annotations
 #    Then entity(person) get owns(custom-attribute) get constraints contain: @subkey(LABEL)
 #    Examples:
 #      | value-type |
-#      | long       |
+#      | integer       |
 #      | decimal    |
 #      | string     |
 #      | boolean    |
@@ -1821,7 +1821,7 @@ Feature: Concept Owns Annotations
 #    When create attribute type: surname
 #    When attribute(surname) set value type: string
 #    When create attribute type: age
-#    When attribute(age) set value type: long
+#    When attribute(age) set value type: integer
 #    When entity(person) set owns: name
 #    When entity(person) get owns(name) set annotation: @subkey(NAME-AGE)
 #    When entity(person) get owns(name) set annotation: @subkey(FULL-NAME)
@@ -1858,7 +1858,7 @@ Feature: Concept Owns Annotations
 #
 #  Scenario: Owns cannot set @subkey annotation for incorrect arguments
 #    When create attribute type: custom-attribute
-#    When attribute(custom-attribute) set value type: long
+#    When attribute(custom-attribute) set value type: integer
 #    When entity(person) set owns: custom-attribute
 #    Then entity(person) get owns(custom-attribute) set annotation: @subkey("LABEL"); fails
 #    Then entity(person) get owns(custom-attribute) set annotation: @subkey(福); fails
@@ -1884,7 +1884,7 @@ Feature: Concept Owns Annotations
 #    Then entity(person) get owns(custom-attribute) get constraints contain: @subkey(LABEL)
 #    Examples:
 #      | value-type |
-#      | long       |
+#      | integer       |
 #      | string     |
 #      | boolean    |
 #      | decimal    |
@@ -1923,7 +1923,7 @@ Feature: Concept Owns Annotations
     Then entity(person) get owns is empty
     Examples:
       | value-type  |
-      | long        |
+      | integer        |
       | decimal     |
       | string      |
       | boolean     |
@@ -1947,7 +1947,7 @@ Feature: Concept Owns Annotations
     Then entity(person) get owns(custom-attribute) get constraints contain: @unique
     Examples:
       | value-type  |
-      | long        |
+      | integer        |
       | decimal     |
       | string      |
       | boolean     |
@@ -2039,7 +2039,7 @@ Feature: Concept Owns Annotations
     Then entity(person) get owns is empty
     Examples:
       | value-type  |
-      | long        |
+      | integer        |
       | decimal     |
       | string      |
       | boolean     |
@@ -2075,13 +2075,13 @@ Feature: Concept Owns Annotations
     Then entity(person) get owns is empty
     Examples:
       | value-type  | args                                                                                                                                                                                                                                                                                                                                                                                                 |
-      | long        | 0                                                                                                                                                                                                                                                                                                                                                                                                    |
-      | long        | 1                                                                                                                                                                                                                                                                                                                                                                                                    |
-      | long        | -1                                                                                                                                                                                                                                                                                                                                                                                                   |
-      | long        | 1, 2                                                                                                                                                                                                                                                                                                                                                                                                 |
-      | long        | -9223372036854775808, 9223372036854775807                                                                                                                                                                                                                                                                                                                                                            |
-      | long        | 2, 1, 3, 4, 5, 6, 7, 9, 10, 11, 55, -1, -654321, 123456                                                                                                                                                                                                                                                                                                                                              |
-      | long        | 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 97, 98, 99 |
+      | integer        | 0                                                                                                                                                                                                                                                                                                                                                                                                    |
+      | integer        | 1                                                                                                                                                                                                                                                                                                                                                                                                    |
+      | integer        | -1                                                                                                                                                                                                                                                                                                                                                                                                   |
+      | integer        | 1, 2                                                                                                                                                                                                                                                                                                                                                                                                 |
+      | integer        | -9223372036854775808, 9223372036854775807                                                                                                                                                                                                                                                                                                                                                            |
+      | integer        | 2, 1, 3, 4, 5, 6, 7, 9, 10, 11, 55, -1, -654321, 123456                                                                                                                                                                                                                                                                                                                                              |
+      | integer        | 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 97, 98, 99 |
       | string      | ""                                                                                                                                                                                                                                                                                                                                                                                                   |
       | string      | "1"                                                                                                                                                                                                                                                                                                                                                                                                  |
       | string      | "福"                                                                                                                                                                                                                                                                                                                                                                                                  |
@@ -2196,7 +2196,7 @@ Feature: Concept Owns Annotations
     Then entity(person) get owns(custom-attribute) get constraints contain: @values(<args>)
     Examples:
       | value-type  | args                             |
-      | long        | 1, 2                             |
+      | integer        | 1, 2                             |
       | double      | 1.0, 2.0                         |
       | decimal     | 1.0, 2.0                         |
       | string      | "str", "str another"             |
@@ -2220,7 +2220,7 @@ Feature: Concept Owns Annotations
     Then entity(person) get owns(custom-attribute) get constraints do not contain: @values(<args>)
     Examples:
       | value-type  | args            | reset-args      |
-      | long        | 1, 5            | 7, 9            |
+      | integer        | 1, 5            | 7, 9            |
       | double      | 1.1, 1.5        | -8.0, 88.3      |
       | decimal     | -8.0, 88.3      | 1.1, 1.5        |
       | string      | "s"             | "not s"         |
@@ -2344,7 +2344,7 @@ Feature: Concept Owns Annotations
     Then entity(player) get owns(second-custom-attribute) get constraints contain: @values(<args>)
     Examples:
       | value-type  | args                                                                         | args-specialise                            |
-      | long        | 1, 10, 20, 30                                                                | 10, 30                                     |
+      | integer        | 1, 10, 20, 30                                                                | 10, 30                                     |
       | double      | 1.0, 2.0, 3.0, 4.5                                                           | 2.0                                        |
       | decimal     | 0.0, 1.0                                                                     | 0.0                                        |
       | string      | "john", "John", "Johnny", "johnny"                                           | "John", "Johnny"                           |
@@ -2434,7 +2434,7 @@ Feature: Concept Owns Annotations
     Then entity(player) get owns(second-custom-attribute) get constraints contain: @values(<args>)
     Examples:
       | value-type  | args                                                                         | args-specialise          |
-      | long        | 1, 10, 20, 30                                                                | 10, 31                   |
+      | integer        | 1, 10, 20, 30                                                                | 10, 31                   |
       | double      | 1.0, 2.0, 3.0, 4.5                                                           | 2.001                    |
       | decimal     | 0.0, 1.0                                                                     | 0.01                     |
       | string      | "john", "John", "Johnny", "johnny"                                           | "Jonathan"               |
@@ -2446,7 +2446,7 @@ Feature: Concept Owns Annotations
 
   Scenario Outline: Values can be narrowed for the same attribute for <root-type>'s owns
     When create attribute type: name
-    When attribute(name) set value type: long
+    When attribute(name) set value type: integer
     When <root-type>(<supertype-name>) set owns: name
     When <root-type>(<supertype-name>) get owns(name) set annotation: @values(0, 1, 2, 3, 4, 5)
     When <root-type>(<subtype-name>) set supertype: <supertype-name>
@@ -2577,18 +2577,18 @@ Feature: Concept Owns Annotations
     When entity(customer) get owns(surname) set annotation: @values("only this string is allowed")
     When transaction commits
     When connection open schema transaction for database: typedb
-    Then attribute(name) set value type: long; fails
-    Then attribute(surname) set value type: long; fails
+    Then attribute(name) set value type: integer; fails
+    Then attribute(surname) set value type: integer; fails
     When entity(customer) get owns(surname) unset annotation: @values
     Then attribute(surname) unset value type; fails
-    When attribute(surname) set value type: long
-    When attribute(name) set value type: long
+    When attribute(surname) set value type: integer
+    When attribute(name) set value type: integer
     When attribute(surname) unset value type
     When entity(customer) get owns(surname) set annotation: @values(1, 2, 3)
     When transaction commits
     When connection open schema transaction for database: typedb
     Then entity(customer) get owns(surname) get constraints contain: @values(1, 2, 3)
-    Then attribute(surname) get value type: long
+    Then attribute(surname) get value type: integer
     When entity(person) get owns(name) set annotation: @values(1, 2, 3)
     When entity(customer) get owns(surname) unset annotation: @values
     Then entity(customer) get constraints for owned attribute(surname) contain: @values(1, 2, 3)
@@ -2598,7 +2598,7 @@ Feature: Concept Owns Annotations
     When connection open read transaction for database: typedb
     Then entity(customer) get constraints for owned attribute(surname) contain: @values(1, 2, 3)
     Then entity(customer) get owns(surname) get constraints do not contain: @values(1, 2, 3)
-    Then attribute(surname) get value type: long
+    Then attribute(surname) get value type: integer
 
 ########################
 # @range
@@ -2663,11 +2663,11 @@ Feature: Concept Owns Annotations
     Then entity(person) get owns(custom-attribute) get constraint categories do not contain: @range
     Examples:
       | value-type  | arg0                              | arg1                                                  |
-      | long        | 0                                 | 1                                                     |
-      | long        | 1                                 | 2                                                     |
-      | long        | 0                                 | 2                                                     |
-      | long        | -1                                | 1                                                     |
-      | long        | -9223372036854775808              | 9223372036854775807                                   |
+      | integer        | 0                                 | 1                                                     |
+      | integer        | 1                                 | 2                                                     |
+      | integer        | 0                                 | 2                                                     |
+      | integer        | -1                                | 1                                                     |
+      | integer        | -9223372036854775808              | 9223372036854775807                                   |
       | string      | "A"                               | "a"                                                   |
       | string      | "a"                               | "z"                                                   |
       | string      | "A"                               | "福"                                                   |
@@ -2781,7 +2781,7 @@ Feature: Concept Owns Annotations
     Then entity(person) get owns(custom-attribute) get constraints contain: @range(<args>)
     Examples:
       | value-type  | args                             |
-      | long        | 1..2                             |
+      | integer        | 1..2                             |
       | double      | 1.0..2.0                         |
       | decimal     | 1.0..2.0                         |
       | string      | "str".."str another"             |
@@ -2813,7 +2813,7 @@ Feature: Concept Owns Annotations
     Then entity(person) get owns(custom-attribute) get constraints do not contain: @range(<reset-args>)
     Examples:
       | value-type  | args                             | reset-args                       |
-      | long        | 1..5                             | 7..9                             |
+      | integer        | 1..5                             | 7..9                             |
       | double      | 1.1..1.5                         | -8.0..88.3                       |
       | decimal     | -8.0..88.3                       | 1.1..1.5                         |
       | string      | "S".."s"                         | "not s".."xxxxxxxxx"             |
@@ -2832,7 +2832,7 @@ Feature: Concept Owns Annotations
     Then entity(person) get owns(custom-attribute) get constraint categories do not contain: @range
     Examples:
       | value-type  | arg0                     | args                     |
-      | long        | 1                        | 1                        |
+      | integer        | 1                        | 1                        |
       | double      | 1.0                      | 1.0                      |
       | decimal     | 1.0                      | 1.0                      |
       | string      | "123"                    | "123"                    |
@@ -2955,7 +2955,7 @@ Feature: Concept Owns Annotations
     Then entity(player) get owns(second-custom-attribute) get constraints contain: @range(<args>)
     Examples:
       | value-type  | args                             | args-specialise                           |
-      | long        | 1..10                            | 1..5                                      |
+      | integer        | 1..10                            | 1..5                                      |
       | double      | 1.0..10.0                        | 2.0..10.0                                 |
       | decimal     | 0.0..1.0                         | 0.0..0.999999                             |
       | string      | "A".."Z"                         | "J".."Z"                                  |
@@ -3043,7 +3043,7 @@ Feature: Concept Owns Annotations
     Then entity(player) get owns(second-custom-attribute) get constraints contain: @range(<args>)
     Examples:
       | value-type  | args                             | args-specialise                           |
-      | long        | 1..10                            | -1..5                                     |
+      | integer        | 1..10                            | -1..5                                     |
       | double      | 1.0..10.0                        | 0.0..150.0                                |
       | decimal     | 0.0..1.0                         | -0.0001..0.999999                         |
       | string      | "A".."Z"                         | "A".."z"                                  |
@@ -3053,7 +3053,7 @@ Feature: Concept Owns Annotations
 
   Scenario Outline: Range can be narrowed for the same attribute for <root-type>'s owns
     When create attribute type: name
-    When attribute(name) set value type: long
+    When attribute(name) set value type: integer
     When <root-type>(<supertype-name>) set owns: name
     When <root-type>(<supertype-name>) get owns(name) set annotation: @range(0..5)
     When <root-type>(<subtype-name>) set supertype: <supertype-name>
@@ -3184,18 +3184,18 @@ Feature: Concept Owns Annotations
     When entity(customer) get owns(surname) set annotation: @range("a start".."finish line")
     When transaction commits
     When connection open schema transaction for database: typedb
-    Then attribute(name) set value type: long; fails
-    Then attribute(surname) set value type: long; fails
+    Then attribute(name) set value type: integer; fails
+    Then attribute(surname) set value type: integer; fails
     When entity(customer) get owns(surname) unset annotation: @range
     Then attribute(surname) unset value type; fails
-    When attribute(surname) set value type: long
-    When attribute(name) set value type: long
+    When attribute(surname) set value type: integer
+    When attribute(name) set value type: integer
     When attribute(surname) unset value type
     When entity(customer) get owns(surname) set annotation: @range(1..3)
     When transaction commits
     When connection open schema transaction for database: typedb
     Then entity(customer) get owns(surname) get constraints contain: @range(1..3)
-    Then attribute(surname) get value type: long
+    Then attribute(surname) get value type: integer
     When entity(person) get owns(name) set annotation: @range(1..3)
     When entity(customer) get owns(surname) unset annotation: @range
     Then entity(customer) get owns(surname) get constraints do not contain: @range(1..3)
@@ -3205,7 +3205,7 @@ Feature: Concept Owns Annotations
     When connection open read transaction for database: typedb
     Then entity(customer) get owns(surname) get constraints do not contain: @range(1..3)
     Then entity(customer) get constraints for owned attribute(surname) contain: @range(1..3)
-    Then attribute(surname) get value type: long
+    Then attribute(surname) get value type: integer
 
 ########################
 # @card
@@ -3233,7 +3233,7 @@ Feature: Concept Owns Annotations
     Then entity(person) get owns(custom-attribute-2) get cardinality: @card(0..)
     Examples:
       | value-type  |
-      | long        |
+      | integer        |
       | double      |
       | decimal     |
       | string      |
@@ -3321,7 +3321,7 @@ Feature: Concept Owns Annotations
     Then entity(person) get owns is empty
     Examples:
       | value-type    | arg0                | arg1                |
-      | long          | 0                   | 1                   |
+      | integer          | 0                   | 1                   |
       | string        | 0                   | 10                  |
       | boolean       | 0                   | 9223372036854775807 |
       | double        | 1                   | 10                  |
@@ -3342,8 +3342,8 @@ Feature: Concept Owns Annotations
     Then entity(person) get owns(custom-attribute) get constraints contain: @card(<arg>..<arg>)
     Examples:
       | value-type    | arg  |
-      | long          | 1    |
-      | long          | 9999 |
+      | integer          | 1    |
+      | integer          | 9999 |
       | string        | 8888 |
       | boolean       | 7777 |
       | double        | 666  |
@@ -3366,7 +3366,7 @@ Feature: Concept Owns Annotations
     Then entity(person) get owns(custom-attribute) get declared annotation categories do not contain: @card
     Examples:
       | value-type |
-      | long       |
+      | integer       |
 
   Scenario: Owns can have @card annotation for none value type
     When create attribute type: custom-attribute
@@ -3397,7 +3397,7 @@ Feature: Concept Owns Annotations
     Then entity(person) get owns(custom-attribute) get constraints contain: @card(<args>)
     Examples:
       | value-type | args |
-      | long       | 1..2 |
+      | integer       | 1..2 |
       | duration   | 0..9 |
 
   Scenario Outline: Owns can reset @card annotations
@@ -3444,7 +3444,7 @@ Feature: Concept Owns Annotations
     Then entity(person) get owns(custom-attribute) get constraints contain: @card(<args>)
     Examples:
       | value-type  | args | reset-args |
-      | long        | 2..5 | 7..9       |
+      | integer        | 2..5 | 7..9       |
       | double      | 2..5 | 0..1       |
       | decimal     | 2..5 | 0..        |
       | string      | 2..5 | 4..        |
@@ -3592,7 +3592,7 @@ Feature: Concept Owns Annotations
     Then relation(description) get owns(second-custom-attribute) get declared annotations do not contain: @card(<args-specialise>)
     Examples:
       | value-type  | args       | args-specialise |
-      | long        | 0..        | 0..10000        |
+      | integer        | 0..        | 0..10000        |
       | double      | 0..10      | 0..2            |
       | decimal     | 0..2       | 1..2            |
       | string      | 1..        | 1..1            |
@@ -3677,7 +3677,7 @@ Feature: Concept Owns Annotations
     Then relation(description) get constraints for owned attribute(second-custom-attribute) do not contain: @card(<args-specialise>)
     Examples:
       | value-type  | args       | args-specialise |
-      | long        | 0..10000   | 0..10001        |
+      | integer        | 0..10000   | 0..10001        |
       | double      | 0..10      | 1..11           |
       | string      | 1..        | 0..2            |
       | decimal     | 2..2       | 1..1            |
@@ -3995,7 +3995,7 @@ Feature: Concept Owns Annotations
 #    Then <root-type>(<supertype-name>) get owns(ordered-custom-attribute-2) get cardinality: @card(0..)
 #    Examples:
 #      | root-type | supertype-name | subtype-name | value-type |
-#      | entity    | person         | customer     | long       |
+#      | entity    | person         | customer     | integer       |
 #      | relation  | description    | registration | string     |
 
     # TODO: We (temporarily) don't revalidate cardinality narrowing in schema!
@@ -4617,7 +4617,7 @@ Feature: Concept Owns Annotations
     Then <root-type>(<type-name>) get constraints for owned attribute(custom-attribute-ordered) do not contain: @distinct
     Examples:
       | root-type | type-name   | value-type |
-      | entity    | person      | long       |
+      | entity    | person      | integer       |
       | relation  | description | string     |
 
   Scenario Outline: Ordered owns for <root-type> can set @distinct annotation for <value-type> value type and unset it
@@ -4647,7 +4647,7 @@ Feature: Concept Owns Annotations
     Then <root-type>(<type-name>) get owns is empty
     Examples:
       | root-type | type-name   | value-type    |
-      | entity    | person      | long          |
+      | entity    | person      | integer          |
       | entity    | person      | string        |
       | entity    | person      | boolean       |
       | entity    | person      | double        |
@@ -4657,7 +4657,7 @@ Feature: Concept Owns Annotations
       | entity    | person      | datetime-tz   |
       | entity    | person      | duration      |
       | entity    | person      | custom-struct |
-      | relation  | description | long          |
+      | relation  | description | integer          |
       | relation  | description | string        |
       | relation  | description | boolean       |
       | relation  | description | double        |
@@ -4698,7 +4698,7 @@ Feature: Concept Owns Annotations
     Then entity(person) get owns(custom-attribute) get constraints contain: @distinct
     Examples:
       | value-type |
-      | long       |
+      | integer       |
       | decimal    |
 
   Scenario Outline: <root-type> types can redeclare owns as owns with @distinct
@@ -4747,7 +4747,7 @@ Feature: Concept Owns Annotations
     Examples:
       | root-type | type-name   | value-type |
       | entity    | person      | string     |
-      | entity    | person      | long       |
+      | entity    | person      | integer       |
       | relation  | description | datetime   |
       | relation  | description | duration   |
 
@@ -4783,7 +4783,7 @@ Feature: Concept Owns Annotations
     Examples:
       | root-type | type-name   | value-type |
       | entity    | person      | string     |
-      | entity    | person      | long       |
+      | entity    | person      | integer       |
       | relation  | description | datetime   |
       | relation  | description | duration   |
 
@@ -4910,7 +4910,7 @@ Feature: Concept Owns Annotations
     Then entity(person) get owns(custom-attribute) get constraint categories do not contain: @regex
     Examples:
       | value-type    |
-      | long          |
+      | integer          |
       | boolean       |
       | double        |
       | decimal       |
@@ -5078,7 +5078,7 @@ Feature: Concept Owns Annotations
     When entity(person) set owns: custom-attribute
     When entity(person) get owns(custom-attribute) set annotation: @regex("\S+")
     Then attribute(custom-attribute) unset value type; fails
-    Then attribute(custom-attribute) set value type: long; fails
+    Then attribute(custom-attribute) set value type: integer; fails
     Then attribute(custom-attribute) set value type: boolean; fails
     Then attribute(custom-attribute) set value type: double; fails
     Then attribute(custom-attribute) set value type: decimal; fails
@@ -5098,7 +5098,7 @@ Feature: Concept Owns Annotations
     When connection open schema transaction for database: typedb
     Then entity(person) get owns(custom-attribute) get constraints contain: @regex("\S+")
     Then attribute(custom-attribute) unset value type; fails
-    Then attribute(custom-attribute) set value type: long; fails
+    Then attribute(custom-attribute) set value type: integer; fails
     Then attribute(custom-attribute) set value type: boolean; fails
     Then attribute(custom-attribute) set value type: double; fails
     Then attribute(custom-attribute) set value type: decimal; fails
@@ -5156,13 +5156,13 @@ Feature: Concept Owns Annotations
       | key                           | regex("s")      | key                   | regex                 | string      |
       | key                           | regex("s")      | key                   | regex                 | string      |
       # TODO: subkey is not implemented
-#      | key                               | subkey(L)          | key                   | subkey                | long        |
+#      | key                               | subkey(L)          | key                   | subkey                | integer        |
 #      | subkey(L)                         | unique             | subkey                | unique                | duration    |
-#      | subkey(L)                         | values(1, 2)       | subkey                | values                | long        |
+#      | subkey(L)                         | values(1, 2)       | subkey                | values                | integer        |
 #      | subkey(L)                         | range(false..true) | subkey                | range                 | boolean     |
-#      | subkey(L)                         | card(0..1)         | subkey                | card                  | long        |
+#      | subkey(L)                         | card(0..1)         | subkey                | card                  | integer        |
 #      | subkey(L)                         | regex("s")         | subkey                | regex                 | string      |
-      | unique                        | values(1, 2)    | unique                | values                | long        |
+      | unique                        | values(1, 2)    | unique                | values                | integer        |
       | unique                        | range(1.0..2.0) | unique                | range                 | decimal     |
       | unique                        | card(0..1)      | unique                | card                  | decimal     |
       | unique                        | regex("s")      | unique                | regex                 | string      |
@@ -5210,19 +5210,19 @@ Feature: Concept Owns Annotations
     Examples:
     # TODO: Move to "cannot" test if something is wrong here.
       | annotation-1                  | annotation-2    | annotation-category-1 | annotation-category-2 | value-type  |
-      | unique                        | values(1, 2)    | unique                | values                | long        |
+      | unique                        | values(1, 2)    | unique                | values                | integer        |
       | unique                        | range(1.0..2.0) | unique                | range                 | decimal     |
-      | unique                        | card(0..1)      | unique                | card                  | long        |
+      | unique                        | card(0..1)      | unique                | card                  | integer        |
       | unique                        | regex("s")      | unique                | regex                 | string      |
       | unique                        | distinct        | unique                | distinct              | string      |
       | values(2024-05-06+0100)       | card(0..1)      | values                | card                  | datetime-tz |
-      | values(1, 2)                  | distinct        | values                | distinct              | long        |
+      | values(1, 2)                  | distinct        | values                | distinct              | integer        |
       | values(1.0, 2.0)              | range(1.0..2.0) | values                | range                 | decimal     |
       | values("str")                 | regex("s")      | values                | regex                 | string      |
       | range(2020-05-05..2025-05-05) | card(0..1)      | range                 | card                  | datetime    |
       | range(2020-05-05..2025-05-05) | distinct        | range                 | distinct              | date        |
       | card(0..1)                    | regex("s")      | card                  | regex                 | string      |
-      | card(0..1)                    | distinct        | card                  | distinct              | long        |
+      | card(0..1)                    | distinct        | card                  | distinct              | integer        |
       | regex("s")                    | distinct        | regex                 | distinct              | string      |
       | range("1".."2")               | regex("s")      | range                 | regex                 | string      |
 
@@ -5245,11 +5245,11 @@ Feature: Concept Owns Annotations
     Then relation(description) get owns(custom-attribute) get declared annotations do not contain: @<annotation-1>
     Examples:
       | annotation-1 | annotation-2 | value-type |
-      | key          | unique       | long       |
-      | key          | card(0..1)   | long       |
-      | key          | card(0..)    | long       |
-      | key          | card(1..1)   | long       |
-      | key          | card(2..5)   | long       |
+      | key          | unique       | integer       |
+      | key          | card(0..1)   | integer       |
+      | key          | card(0..)    | integer       |
+      | key          | card(1..1)   | integer       |
+      | key          | card(2..5)   | integer       |
 
   Scenario Outline: Ordered ownership cannot set @<annotation-1> and @<annotation-2> together for <value-type> value type
     When create attribute type: custom-attribute
@@ -5272,11 +5272,11 @@ Feature: Concept Owns Annotations
     Then relation(description) get owns(custom-attribute) get declared annotations do not contain: @<annotation-1>
     Examples:
       | annotation-1 | annotation-2 | value-type |
-      | key          | unique       | long       |
-      | key          | card(0..1)   | long       |
-      | key          | card(0..)    | long       |
-      | key          | card(1..1)   | long       |
-      | key          | card(2..5)   | long       |
+      | key          | unique       | integer       |
+      | key          | card(0..1)   | integer       |
+      | key          | card(0..)    | integer       |
+      | key          | card(1..1)   | integer       |
+      | key          | card(2..5)   | integer       |
 
   Scenario Outline: Annotation @key can be set if type has inherited cardinality that can be narrowed
     When create attribute type: name

--- a/concept/type/owns.feature
+++ b/concept/type/owns.feature
@@ -86,15 +86,15 @@ Feature: Concept Owns
     Then entity(person) get owns is empty
     Examples:
       | value-type    | value-type-2 |
-      | long          | string       |
+      | integer          | string       |
       | double        | datetime-tz  |
       | decimal       | datetime     |
       | string        | duration     |
-      | boolean       | long         |
+      | boolean       | integer         |
       | date          | decimal      |
       | datetime-tz   | double       |
       | duration      | boolean      |
-      | custom-struct | long         |
+      | custom-struct | integer         |
 
   Scenario Outline: Entity types can redeclare owning attributes with <value-type> value type
     When create attribute type: name
@@ -109,7 +109,7 @@ Feature: Concept Owns
     Then entity(person) set owns: email
     Examples:
       | value-type    |
-      | long          |
+      | integer          |
       | datetime      |
       | custom-struct |
 
@@ -241,15 +241,15 @@ Feature: Concept Owns
     Then relation(marriage) get owns is empty
     Examples:
       | value-type    | value-type-2 |
-      | long          | string       |
+      | integer          | string       |
       | double        | datetime-tz  |
       | decimal       | datetime     |
       | string        | duration     |
-      | boolean       | long         |
+      | boolean       | integer         |
       | date          | decimal      |
       | datetime-tz   | double       |
       | duration      | boolean      |
-      | custom-struct | long         |
+      | custom-struct | integer         |
 
   Scenario: The schema does not contain redundant owns declarations
     When create attribute type: attr0
@@ -479,7 +479,7 @@ Feature: Concept Owns
     Examples:
       | root-type | supertype-name | subtype-name | value-type |
       | entity    | person         | customer     | string     |
-      | entity    | person         | customer     | long       |
+      | entity    | person         | customer     | integer       |
       | relation  | description    | registration | string     |
       | relation  | description    | registration | datetime   |
 
@@ -521,7 +521,7 @@ Feature: Concept Owns
     Examples:
       | root-type | supertype-name | subtype-name | value-type |
       | entity    | person         | customer     | string     |
-      | relation  | description    | registration | long       |
+      | relation  | description    | registration | integer       |
 
     # TODO: Move to annotation tests
   Scenario Outline: <root-type> types can have multiple subtypes of attribute type affected by its constraints
@@ -640,15 +640,15 @@ Feature: Concept Owns
     Then entity(person) get owns is empty
     Examples:
       | value-type    | value-type-2 |
-      | long          | string       |
+      | integer          | string       |
       | double        | datetime-tz  |
       | decimal       | datetime     |
       | string        | duration     |
-      | boolean       | long         |
+      | boolean       | integer         |
       | date          | decimal      |
       | datetime-tz   | double       |
       | duration      | boolean      |
-      | custom-struct | long         |
+      | custom-struct | integer         |
 
   Scenario Outline: Entity types can redeclare ordered ownership
     When create attribute type: name
@@ -671,7 +671,7 @@ Feature: Concept Owns
     Then transaction commits
     Examples:
       | value-type    |
-      | long          |
+      | integer          |
       | double        |
       | decimal       |
       | string        |
@@ -765,7 +765,7 @@ Feature: Concept Owns
     Then relation(marriage) get owns is empty
     Examples:
       | value-type    | value-type-2 |
-      | long          | string       |
+      | integer          | string       |
       | double        | datetime-tz  |
       | custom-struct | decimal      |
 
@@ -792,7 +792,7 @@ Feature: Concept Owns
     Then transaction commits
     Examples:
       | value-type    |
-      | long          |
+      | integer          |
       | double        |
       | decimal       |
       | string        |
@@ -908,7 +908,7 @@ Feature: Concept Owns
     Examples:
       | root-type | supertype-name | subtype-name | value-type |
       | entity    | person         | customer     | string     |
-      | entity    | person         | customer     | long       |
+      | entity    | person         | customer     | integer       |
       | relation  | description    | registration | string     |
       | relation  | description    | registration | datetime   |
 
@@ -988,7 +988,7 @@ Feature: Concept Owns
     Examples:
       | root-type | supertype-name | subtype-name | value-type |
       | entity    | person         | customer     | string     |
-      | relation  | description    | registration | long       |
+      | relation  | description    | registration | integer       |
 
   Scenario Outline: Ownerships with subtypes and supertypes can change ordering only together for <root-type>
     When create attribute type: literal

--- a/concept/type/plays.feature
+++ b/concept/type/plays.feature
@@ -319,7 +319,7 @@ Feature: Concept Plays
 #    When create entity type: car
 #    When create relation type: credit
 #    When create attribute type: id
-#    When attribute(id) set value type: long
+#    When attribute(id) set value type: integer
 #    When relation(credit) create role: creditor
 #    When create relation type: marriage
 #    When relation(marriage) create role: spouse

--- a/driver/driver.feature
+++ b/driver/driver.feature
@@ -812,7 +812,7 @@ Feature: TypeDB Driver
       """
       match relation $r;
       """
-    Then typeql schema query; fails with a message containing: "Failed to execute define query"
+    Then typeql schema query; fails with a message containing: "The reserved keyword "entity" cannot be used as an identifier"
       """
       define entity entity;
       """
@@ -1561,7 +1561,7 @@ Feature: TypeDB Driver
     When get answers of typeql read query
       """
       match $_ isa person, has typed $v;
-      $value = $v;
+      let $value = $v;
       """
     Then answer type is: concept rows
     Then answer query type is: read
@@ -1735,7 +1735,7 @@ Feature: TypeDB Driver
       """
     When get answers of typeql read query
       """
-      match $_ isa person, has $a; $v = $a;
+      match $_ isa person, has $a; let $v = $a;
       fetch { "v": $v };
       """
     Then answer type is: concept documents
@@ -1778,7 +1778,7 @@ Feature: TypeDB Driver
     Given connection open write transaction for database: typedb
     Given typeql write query
       """
-      insert $a 25 isa age;  $n "John" isa name;
+      insert $a isa age 25;  $n isa name "John";
       """
 
     When get answers of typeql read query
@@ -1823,7 +1823,7 @@ Feature: TypeDB Driver
     Given connection open write transaction for database: typedb
     When get answers of typeql write query
       """
-      insert $dt 2023-05-01T00:00:00 isa dt;
+      insert $dt isa dt 2023-05-01T00:00:00;
       """
     Then answer get row(0) get attribute(dt) get value is: 2023-05-01T00:00:00
     Then answer get row(0) get attribute(dt) get value is not: 2023-04-30T13:30:00
@@ -1860,7 +1860,7 @@ Feature: TypeDB Driver
     Given connection open write transaction for database: typedb
     When get answers of typeql write query
       """
-      insert $dt 2023-05-01T00:00:00 Asia/Calcutta isa dt;
+      insert $dt isa dt 2023-05-01T00:00:00 Asia/Calcutta;
       """
     Then answer get row(0) get attribute(dt) get value is: 2023-05-01T00:00:00 Asia/Calcutta
     Then answer get row(0) get attribute(dt) get value is not: 2023-04-30T13:30:00 Asia/Calcutta

--- a/driver/driver.feature
+++ b/driver/driver.feature
@@ -144,7 +144,7 @@ Feature: TypeDB Driver
 #    """
 #    define
 #    entity person @abstract, owns age @card(1..1);
-#    attribute age, value long @range(0..150);
+#    attribute age, value integer @range(0..150);
 #    """
 #    Then connection get database(typedb) has schema:
 #    """
@@ -157,20 +157,20 @@ Feature: TypeDB Driver
 #    """
 #    define
 #    entity person @abstract, owns age @card(1..1);
-#    attribute age, value long @range(0..150);
+#    attribute age, value integer @range(0..150);
 #    """
 #    Then connection get database(typedb) has type schema:
 #    """
 #    define
 #    entity person @abstract, owns age @card(1..1);
-#    attribute age, value long @range(0..150);
+#    attribute age, value integer @range(0..150);
 #    """
 #
 #    When connection open schema transaction for database: typedb
 #    When typeql schema query
 #    """
 #    redefine
-#    attribute age, value long @range(0..);
+#    attribute age, value integer @range(0..);
 #    """
 #    When typeql schema query
 #    """
@@ -182,13 +182,13 @@ Feature: TypeDB Driver
 #    """
 #    define
 #    entity person @abstract, owns age @card(1..1);
-#    attribute age, value long @range(0..150);
+#    attribute age, value integer @range(0..150);
 #    """
 #    Then connection get database(typedb) has type schema:
 #    """
 #    define
 #    entity person @abstract, owns age @card(1..1);
-#    attribute age, value long @range(0..150);
+#    attribute age, value integer @range(0..150);
 #    """
 #    When transaction commits
 #    Then connection get database(typedb) has schema:
@@ -196,14 +196,14 @@ Feature: TypeDB Driver
 #    define
 #    entity person @abstract, owns age @card(1..1) @range(0..150);
 #    entity fictional-character owns age;
-#    attribute age, value long @range(0..);
+#    attribute age, value integer @range(0..);
 #    """
 #    Then connection get database(typedb) has type schema:
 #    """
 #    define
 #    entity person @abstract, owns age @card(1..1) @range(0..150);
 #    entity fictional-character owns age;
-#    attribute age, value long @range(0..);
+#    attribute age, value integer @range(0..);
 #    """
 
 
@@ -497,7 +497,7 @@ Feature: TypeDB Driver
 
     When typeql schema query
       """
-      define attribute age, value long;
+      define attribute age, value integer;
       """
     When get answers of typeql read query
       """
@@ -620,7 +620,7 @@ Feature: TypeDB Driver
       entity person owns id @key, owns name @card(0..);
       entity empty-person;
       entity nameless-person, owns name;
-      attribute id, value long;
+      attribute id, value integer;
       attribute name, value string;
       """
     When get answers of typeql read query
@@ -747,7 +747,7 @@ Feature: TypeDB Driver
         "single attribute type": {
             "kind": "attribute",
             "label": "id",
-            "value_type": "long"
+            "value_type": "integer"
         }
     }
     """
@@ -961,7 +961,7 @@ Feature: TypeDB Driver
     Then answer get row(0) get variable(p) try get value type is none
     Then answer get row(0) get variable(p) try get value is none
     Then answer get row(0) get variable(p) try get boolean is none
-    Then answer get row(0) get variable(p) try get long is none
+    Then answer get row(0) get variable(p) try get integer is none
     Then answer get row(0) get variable(p) try get double is none
     Then answer get row(0) get variable(p) try get decimal is none
     Then answer get row(0) get variable(p) try get string is none
@@ -1000,7 +1000,7 @@ Feature: TypeDB Driver
     Then answer get row(0) get variable(p) is relation: false
     Then answer get row(0) get variable(p) is attribute: false
     Then answer get row(0) get variable(p) is struct: false
-    Then answer get row(0) get variable(p) is long: false
+    Then answer get row(0) get variable(p) is integer: false
 
     Then answer get row(0) get variable(p) as relation type
     Then answer get row(0) get variable(p) try get label: parentship
@@ -1009,7 +1009,7 @@ Feature: TypeDB Driver
     Then answer get row(0) get variable(p) try get value type is none
     Then answer get row(0) get variable(p) try get value is none
     Then answer get row(0) get variable(p) try get boolean is none
-    Then answer get row(0) get variable(p) try get long is none
+    Then answer get row(0) get variable(p) try get integer is none
     Then answer get row(0) get variable(p) try get double is none
     Then answer get row(0) get variable(p) try get decimal is none
     Then answer get row(0) get variable(p) try get string is none
@@ -1056,7 +1056,7 @@ Feature: TypeDB Driver
     Then answer get row(0) get variable(p) try get value type is none
     Then answer get row(0) get variable(p) try get value is none
     Then answer get row(0) get variable(p) try get boolean is none
-    Then answer get row(0) get variable(p) try get long is none
+    Then answer get row(0) get variable(p) try get integer is none
     Then answer get row(0) get variable(p) try get double is none
     Then answer get row(0) get variable(p) try get decimal is none
     Then answer get row(0) get variable(p) try get string is none
@@ -1098,7 +1098,7 @@ Feature: TypeDB Driver
     Then answer get row(0) get variable(a) try get value type is none
     Then answer get row(0) get variable(a) try get value is none
     Then answer get row(0) get variable(a) try get boolean is none
-    Then answer get row(0) get variable(a) try get long is none
+    Then answer get row(0) get variable(a) try get integer is none
     Then answer get row(0) get variable(a) try get double is none
     Then answer get row(0) get variable(a) try get decimal is none
     Then answer get row(0) get variable(a) try get string is none
@@ -1115,7 +1115,7 @@ Feature: TypeDB Driver
 
     Then answer get row(0) get attribute type(a) try get value type is none
     Then answer get row(0) get attribute type(a) is boolean: false
-    Then answer get row(0) get attribute type(a) is long: false
+    Then answer get row(0) get attribute type(a) is integer: false
     Then answer get row(0) get attribute type(a) is double: false
     Then answer get row(0) get attribute type(a) is decimal: false
     Then answer get row(0) get attribute type(a) is string: false
@@ -1155,7 +1155,7 @@ Feature: TypeDB Driver
     Then answer get row(0) get variable(a) get label: typed
     Then answer get row(0) get variable(a) try get value is none
     Then answer get row(0) get variable(a) try get boolean is none
-    Then answer get row(0) get variable(a) try get long is none
+    Then answer get row(0) get variable(a) try get integer is none
     Then answer get row(0) get variable(a) try get double is none
     Then answer get row(0) get variable(a) try get decimal is none
     Then answer get row(0) get variable(a) try get string is none
@@ -1169,7 +1169,7 @@ Feature: TypeDB Driver
 
     Then answer get row(0) get attribute type(a) try get value type: <value-type>
     Then answer get row(0) get attribute type(a) is boolean: <is-boolean>
-    Then answer get row(0) get attribute type(a) is long: <is-long>
+    Then answer get row(0) get attribute type(a) is integer: <is-integer>
     Then answer get row(0) get attribute type(a) is double: <is-double>
     Then answer get row(0) get attribute type(a) is decimal: <is-decimal>
     Then answer get row(0) get attribute type(a) is string: <is-string>
@@ -1179,9 +1179,9 @@ Feature: TypeDB Driver
     Then answer get row(0) get attribute type(a) is duration: <is-duration>
     Then answer get row(0) get attribute type(a) is struct: <is-struct>
     Examples:
-      | value-type  | is-boolean | is-long | is-double | is-decimal | is-string | is-date | is-datetime | is-datetime-tz | is-duration | is-struct |
+      | value-type  | is-boolean | is-integer | is-double | is-decimal | is-string | is-date | is-datetime | is-datetime-tz | is-duration | is-struct |
       | boolean     | true       | false   | false     | false      | false     | false   | false       | false          | false       | false     |
-      | long        | false      | true    | false     | false      | false     | false   | false       | false          | false       | false     |
+      | integer        | false      | true    | false     | false      | false     | false   | false       | false          | false       | false     |
       | double      | false      | false   | true      | false      | false     | false   | false       | false          | false       | false     |
       | decimal     | false      | false   | false     | true       | false     | false   | false       | false          | false       | false     |
       | string      | false      | false   | false     | false      | true      | false   | false       | false          | false       | false     |
@@ -1205,7 +1205,7 @@ Feature: TypeDB Driver
         name value string,
         genre value film-genre,
         duration value duration,
-        reviews value long,
+        reviews value integer,
         score value double,
         revenue value decimal,
         premier value datetime,
@@ -1238,7 +1238,7 @@ Feature: TypeDB Driver
 
     Then answer get row(0) get attribute type(a) try get value type: film-properties
     Then answer get row(0) get attribute type(a) is boolean: false
-    Then answer get row(0) get attribute type(a) is long: false
+    Then answer get row(0) get attribute type(a) is integer: false
     Then answer get row(0) get attribute type(a) is double: false
     Then answer get row(0) get attribute type(a) is decimal: false
     Then answer get row(0) get attribute type(a) is string: false
@@ -1282,7 +1282,7 @@ Feature: TypeDB Driver
     Then answer get row(0) get variable(p) is struct: false
     Then answer get row(0) get variable(p) try get value is none
     Then answer get row(0) get variable(p) try get boolean is none
-    Then answer get row(0) get variable(p) try get long is none
+    Then answer get row(0) get variable(p) try get integer is none
     Then answer get row(0) get variable(p) try get double is none
     Then answer get row(0) get variable(p) try get decimal is none
     Then answer get row(0) get variable(p) try get string is none
@@ -1341,7 +1341,7 @@ Feature: TypeDB Driver
     Then answer get row(0) get variable(p) is boolean: false
     Then answer get row(0) get variable(p) try get value is none
     Then answer get row(0) get variable(p) try get boolean is none
-    Then answer get row(0) get variable(p) try get long is none
+    Then answer get row(0) get variable(p) try get integer is none
     Then answer get row(0) get variable(p) try get double is none
     Then answer get row(0) get variable(p) try get decimal is none
     Then answer get row(0) get variable(p) try get string is none
@@ -1412,7 +1412,7 @@ Feature: TypeDB Driver
     Then answer get row(0) get attribute(a) get type get value type: <value-type>
     Then answer get row(0) get attribute(a) get <value-type>
     Then answer get row(0) get attribute(a) is boolean: <is-boolean>
-    Then answer get row(0) get attribute(a) is long: <is-long>
+    Then answer get row(0) get attribute(a) is integer: <is-integer>
     Then answer get row(0) get attribute(a) is double: <is-double>
     Then answer get row(0) get attribute(a) is decimal: <is-decimal>
     Then answer get row(0) get attribute(a) is string: <is-string>
@@ -1430,9 +1430,9 @@ Feature: TypeDB Driver
     Then answer get row(0) get attribute(a) get value is not: <not-value>
     Then answer get row(0) get attribute(a) get <value-type> is not: <not-value>
     Examples:
-      | value-type  | value                                        | not-value                            | is-boolean | is-long | is-double | is-decimal | is-string | is-date | is-datetime | is-datetime-tz | is-duration |
+      | value-type  | value                                        | not-value                            | is-boolean | is-integer | is-double | is-decimal | is-string | is-date | is-datetime | is-datetime-tz | is-duration |
       | boolean     | true                                         | false                                | true       | false   | false     | false      | false     | false   | false       | false          | false       |
-      | long        | 12345090                                     | 0                                    | false      | true    | false     | false      | false     | false   | false       | false          | false       |
+      | integer        | 12345090                                     | 0                                    | false      | true    | false     | false      | false     | false   | false       | false          | false       |
       | double      | 0.0000000000000000001                        | 0.000000000000000001                 | false      | false   | true      | false      | false     | false   | false       | false          | false       |
       | double      | 2.01234567                                   | 2.01234568                           | false      | false   | true      | false      | false     | false   | false       | false          | false       |
       | decimal     | 1234567890.0001234567890                     | 1234567890.001234567890              | false      | false   | false     | true       | false     | false   | false       | false          | false       |
@@ -1467,7 +1467,7 @@ Feature: TypeDB Driver
 #        name value string,
 #        genre value film-genre,
 #        duration value duration,
-#        reviews value long,
+#        reviews value integer,
 #        score value double,
 #        revenue value decimal,
 #        premier value datetime,
@@ -1527,7 +1527,7 @@ Feature: TypeDB Driver
 #
 #    Then answer get row(0) get attribute(f) get type get value type: film-properties
 #    Then answer get row(0) get attribute(f) is boolean: false
-#    Then answer get row(0) get attribute(f) is long: false
+#    Then answer get row(0) get attribute(f) is integer: false
 #    Then answer get row(0) get attribute(f) is double: false
 #    Then answer get row(0) get attribute(f) is decimal: false
 #    Then answer get row(0) get attribute(f) is string: false
@@ -1585,7 +1585,7 @@ Feature: TypeDB Driver
     Then answer get row(0) get value(value) try get value type: <value-type>
     Then answer get row(0) get value(value) get value type: <value-type>
     Then answer get row(0) get value(value) is boolean: <is-boolean>
-    Then answer get row(0) get value(value) is long: <is-long>
+    Then answer get row(0) get value(value) is integer: <is-integer>
     Then answer get row(0) get value(value) is double: <is-double>
     Then answer get row(0) get value(value) is decimal: <is-decimal>
     Then answer get row(0) get value(value) is string: <is-string>
@@ -1603,9 +1603,9 @@ Feature: TypeDB Driver
     Then answer get row(0) get value(value) get is not: <not-value>
     Then answer get row(0) get value(value) get <value-type> is not: <not-value>
     Examples:
-      | value-type  | value                                        | not-value                            | is-boolean | is-long | is-double | is-decimal | is-string | is-date | is-datetime | is-datetime-tz | is-duration |
+      | value-type  | value                                        | not-value                            | is-boolean | is-integer | is-double | is-decimal | is-string | is-date | is-datetime | is-datetime-tz | is-duration |
       | boolean     | true                                         | false                                | true       | false   | false     | false      | false     | false   | false       | false          | false       |
-      | long        | 12345090                                     | 0                                    | false      | true    | false     | false      | false     | false   | false       | false          | false       |
+      | integer        | 12345090                                     | 0                                    | false      | true    | false     | false      | false     | false   | false       | false          | false       |
       | double      | 0.0000000000000000001                        | 0.000000000000000001                 | false      | false   | true      | false      | false     | false   | false       | false          | false       |
       | double      | 2.01234567                                   | 2.01234568                           | false      | false   | true      | false      | false     | false   | false       | false          | false       |
       | decimal     | 1234567890.0001234567890                     | 1234567890.001234567890              | false      | false   | false     | true       | false     | false   | false       | false          | false       |
@@ -1640,7 +1640,7 @@ Feature: TypeDB Driver
 #        name value string,
 #        genre value film-genre,
 #        duration value duration,
-#        reviews value long,
+#        reviews value integer,
 #        score value double,
 #        revenue value decimal,
 #        premier value datetime,
@@ -1690,7 +1690,7 @@ Feature: TypeDB Driver
 #    Then answer get row(0) get variable(v) as value
 #    Then answer get row(0) get value(v) get value type: film-properties
 #    Then answer get row(0) get value(v) is boolean: <is-boolean>
-#    Then answer get row(0) get value(v) is long: <is-long>
+#    Then answer get row(0) get value(v) is integer: <is-integer>
 #    Then answer get row(0) get value(v) is double: <is-double>
 #    Then answer get row(0) get value(v) is decimal: <is-decimal>
 #    Then answer get row(0) get value(v) is string: <is-string>
@@ -1752,7 +1752,7 @@ Feature: TypeDB Driver
     Examples:
       | value-type  | value                                       | expected                                      | not-expected                                 |
       | boolean     | true                                        | true                                          | false                                        |
-      | long        | 12345090                                    | 12345090                                      | 0                                            |
+      | integer        | 12345090                                    | 12345090                                      | 0                                            |
       | double      | 0.0000000001                                | 0.0000000001                                  | 0.000000001                                  |
       | double      | 2.01234567                                  | 2.01234567                                    | 2.01234568                                   |
       | decimal     | 1234567890.0001234567890                    | "1234567890.000123456789"                     | "1234567890.0001234567890"                   |
@@ -1772,7 +1772,7 @@ Feature: TypeDB Driver
     Given connection open schema transaction for database: typedb
     Given typeql schema query
       """
-      define attribute age @independent, value long; attribute name @independent, value string;
+      define attribute age @independent, value integer; attribute name @independent, value string;
       """
     Given transaction commits
     Given connection open write transaction for database: typedb
@@ -1809,7 +1809,7 @@ Feature: TypeDB Driver
     Then answer unwraps as ok; fails
     Then answer unwraps as concept documents; fails
     Then answer get row(0) get variable(n) as relation; fails with a message containing: "Invalid concept conversion"
-    Then answer get row(0) get attribute(n) get long; fails with a message containing: "Could not retrieve a 'long' value"
+    Then answer get row(0) get attribute(n) get integer; fails with a message containing: "Could not retrieve a 'integer' value"
 
 
   Scenario: Driver processes datetime values in different user time-zones identically

--- a/query/explanation/language.feature
+++ b/query/explanation/language.feature
@@ -173,7 +173,7 @@ Feature: TypeQL Reasoning Explanation
           value string;
 
       company-id sub attribute,
-          value long;
+          value integer;
 
       company sub entity,
           owns company-id @key,
@@ -222,7 +222,7 @@ Feature: TypeQL Reasoning Explanation
           value string;
 
       company-id sub attribute,
-          value long;
+          value integer;
 
       company sub entity,
           owns company-id @key,
@@ -271,7 +271,7 @@ Feature: TypeQL Reasoning Explanation
           value string;
 
       company-id sub attribute,
-          value long;
+          value integer;
 
       company sub entity,
           owns company-id @key,

--- a/query/explanation/reasoner.feature
+++ b/query/explanation/reasoner.feature
@@ -21,7 +21,7 @@ Feature: TypeQL Reasoning Explanation
       define
 
       name sub attribute, value string;
-      company-id sub attribute, value long;
+      company-id sub attribute, value integer;
 
       company sub entity,
         owns name,
@@ -76,7 +76,7 @@ Feature: TypeQL Reasoning Explanation
           value boolean;
 
       company-id sub attribute,
-          value long;
+          value integer;
 
       company sub entity,
           owns company-id @key,
@@ -215,7 +215,7 @@ Feature: TypeQL Reasoning Explanation
 
       name sub attribute, value string;
 
-      person-id sub attribute, value long;
+      person-id sub attribute, value integer;
 
       person sub entity,
           owns person-id @key,
@@ -314,7 +314,7 @@ Feature: TypeQL Reasoning Explanation
           value boolean;
 
       company-id sub attribute,
-          value long;
+          value integer;
 
       company sub entity,
           owns company-id @key,
@@ -377,7 +377,7 @@ Feature: TypeQL Reasoning Explanation
           value boolean;
 
       company-id sub attribute,
-          value long;
+          value integer;
 
       company sub entity,
           owns company-id @key,
@@ -443,7 +443,7 @@ Feature: TypeQL Reasoning Explanation
           value boolean;
 
       company-id sub attribute,
-          value long;
+          value integer;
 
       company sub entity,
           owns company-id @key,

--- a/query/functions/basic.feature
+++ b/query/functions/basic.feature
@@ -53,14 +53,14 @@ Feature: Basic Function Execution
       """
       match
        $x isa person, has name "Abigail";
-       $friend in people_pairs_with($x);
+       let $friend in people_pairs_with($x);
       """
     Then answer size is: 5
     Given get answers of typeql read query
       """
       match
        $x isa person;
-       $friend in people_pairs_with($x);
+       let $friend in people_pairs_with($x);
       """
     Then answer size is: 25
 
@@ -123,7 +123,7 @@ Feature: Basic Function Execution
     Given connection open read transaction for database: typedb
     Given get answers of typeql read query
       """
-      match $x1, $x2 in message-successor-pairs();
+      match let $x1, $x2 in message-successor-pairs();
       """
     # the (n-1)th triangle number, where n is the number of replies to the first post
     Then answer size is: 10
@@ -150,14 +150,14 @@ Feature: Basic Function Execution
     fun name_values() -> { string } :
     match
       $p isa person, has name $name_attr;
-      $name_value = $name_attr;
+      let $name_value = $name_attr;
     return { $name_value };
     """
     Given transaction commits
     When connection open read transaction for database: typedb
     When get answers of typeql read query
     """
-    match $p in all_persons();
+    match let $p in all_persons();
     """
     Then uniquely identify answer concepts
       | p         |
@@ -165,7 +165,7 @@ Feature: Basic Function Execution
       | key:ref:1 |
     When get answers of typeql read query
     """
-    match $name in name_values();
+    match let $name in name_values();
     """
     Then uniquely identify answer concepts
       | name               |
@@ -191,14 +191,14 @@ Feature: Basic Function Execution
     fun name_owners() -> { person, string } :
     match
       $p isa person, has name $name_attr;
-      $name_value = $name_attr;
+      let $name_value = $name_attr;
     return { $p, $name_value };
     """
     Given transaction commits
     When connection open read transaction for database: typedb
     When get answers of typeql read query
     """
-    match $person, $name in name_owners();
+    match let $person, $name in name_owners();
     """
     Then uniquely identify answer concepts
       | person    | name               |
@@ -235,8 +235,8 @@ Feature: Basic Function Execution
     When get answers of typeql read query
     """
     match
-     $name "Bob" isa name;
-     $person in persons_of_name_attribute($name);
+     $name isa name "Bob";
+     let $person in persons_of_name_attribute($name);
     """
     Then uniquely identify answer concepts
       | person    | name          |
@@ -245,8 +245,8 @@ Feature: Basic Function Execution
     When get answers of typeql read query
     """
     match
-     $name = "Bob";
-     $person in persons_of_name_value($name);
+     let $name = "Bob";
+     let $person in persons_of_name_value($name);
     """
     Then uniquely identify answer concepts
       | person    | name             |
@@ -276,7 +276,7 @@ Feature: Basic Function Execution
     fun name_value_of_person($p: person) -> string:
     match
       $p isa person, has name $name_attr;
-      $name_value = $name_attr;
+      let $name_value = $name_attr;
     return first $name_value;
 
     """
@@ -285,8 +285,8 @@ Feature: Basic Function Execution
     When get answers of typeql read query
     """
     match
-      $name "Bob" isa name;
-      $person = person_of_name($name);
+      $name isa name "Bob";
+      let $person = person_of_name($name);
     """
     Then uniquely identify answer concepts
       | person    | name            |
@@ -296,7 +296,7 @@ Feature: Basic Function Execution
     """
     match
       $person isa person;
-      $name = name_value_of_person($person);
+      let $name = name_value_of_person($person);
     """
     Then uniquely identify answer concepts
       | person    | name               |
@@ -312,7 +312,7 @@ Feature: Basic Function Execution
       define
       fun add($x: long, $y: long) -> { long }:
       match
-        $z = $x + $y;
+        let $z = $x + $y;
       return { $z };
       """
     Given transaction commits
@@ -320,7 +320,7 @@ Feature: Basic Function Execution
     Given connection open read transaction for database: typedb
     Given get answers of typeql read query
       """
-      match $z in add(2, 3);
+      match let $z in add(2, 3);
       """
     # the (n-1)th triangle number, where n is the number of replies to the first post
     Then uniquely identify answer concepts
@@ -345,7 +345,7 @@ Feature: Basic Function Execution
       fun ref_sum_and_sum_squares() -> long, long :
       match
         $ref isa ref;
-        $ref_2 = $ref * $ref;
+        let $ref_2 = $ref * $ref;
       return sum($ref), sum($ref_2);
       """
     Given transaction commits
@@ -353,7 +353,7 @@ Feature: Basic Function Execution
     Given connection open read transaction for database: typedb
     Given get answers of typeql read query
       """
-      match $sum, $squares in ref_sum_and_sum_squares();
+      match let $sum, $squares in ref_sum_and_sum_squares();
       """
     # the (n-1)th triangle number, where n is the number of replies to the first post
     Then uniquely identify answer concepts

--- a/query/functions/basic.feature
+++ b/query/functions/basic.feature
@@ -18,7 +18,7 @@ Feature: Basic Function Execution
       define
 
       entity person, owns name, owns ref @key;
-      attribute ref value long;
+      attribute ref value integer;
       attribute name value string;
       """
     Given transaction commits
@@ -310,7 +310,7 @@ Feature: Basic Function Execution
     Given typeql schema query
       """
       define
-      fun add($x: long, $y: long) -> { long }:
+      fun add($x: integer, $y: integer) -> { integer }:
       match
         let $z = $x + $y;
       return { $z };
@@ -325,7 +325,7 @@ Feature: Basic Function Execution
     # the (n-1)th triangle number, where n is the number of replies to the first post
     Then uniquely identify answer concepts
       | z            |
-      | value:long:5 |
+      | value:integer:5 |
 
 
   Scenario: A function can return a tuple of values derived from a reduce operation
@@ -342,7 +342,7 @@ Feature: Basic Function Execution
     Given typeql schema query
       """
       define
-      fun ref_sum_and_sum_squares() -> long, long :
+      fun ref_sum_and_sum_squares() -> integer, integer :
       match
         $ref isa ref;
         let $ref_2 = $ref * $ref;
@@ -358,5 +358,5 @@ Feature: Basic Function Execution
     # the (n-1)th triangle number, where n is the number of replies to the first post
     Then uniquely identify answer concepts
       | sum          | squares      |
-      | value:long:3 | value:long:5 |
+      | value:integer:3 | value:integer:5 |
 

--- a/query/functions/definition.feature
+++ b/query/functions/definition.feature
@@ -29,7 +29,7 @@ Feature: Function Definition
     define
     fun five() -> long :
     match
-      $five = 5;
+      let $five = 5;
     return first $five;
     """
     Given transaction commits
@@ -42,7 +42,7 @@ Feature: Function Definition
     define
     fun five() -> long :
     match
-      $five = 5;
+      let $five = 5;
     return first $five;
     """
     Given transaction commits
@@ -50,7 +50,7 @@ Feature: Function Definition
     Given connection open read transaction for database: typedb
     When get answers of typeql read query
     """
-    match $five = five();
+    match let $five = five();
     """
     Then answer size is: 1
     Given transaction closes
@@ -66,7 +66,7 @@ Feature: Function Definition
     Given connection open read transaction for database: typedb
     When typeql read query; fails with a message containing: "Could not resolve function with name 'five'."
     """
-    match $five = five();
+    match let $five = five();
     """
 
 
@@ -77,7 +77,7 @@ Feature: Function Definition
     define
     fun five() -> long :
     match
-      $five = 4;
+      let $five = 4;
     return first $five;
     """
     Given transaction commits
@@ -85,7 +85,7 @@ Feature: Function Definition
     Given connection open read transaction for database: typedb
     When get answers of typeql read query
     """
-    match $five = five();
+    match let $five = five();
     """
     Then uniquely identify answer concepts
       | five         |
@@ -98,7 +98,7 @@ Feature: Function Definition
     redefine
     fun five() -> long :
     match
-      $five = 5;
+      let $five = 5;
     return first $five;
     """
     Given transaction commits
@@ -106,7 +106,7 @@ Feature: Function Definition
     Given connection open read transaction for database: typedb
     When get answers of typeql read query
     """
-    match $five = five();
+    match let $five = five();
     """
     Then uniquely identify answer concepts
       | five         |
@@ -131,14 +131,14 @@ Feature: Function Definition
     define
     fun nickname_of($p: person) -> { nickname }:
     match
-      $dummy = $nickname;
+      let $dummy = $nickname;
       { $p has nickname $nickname; } or
-      { $nickname in default_nickname($p); };
+      { let $nickname in default_nickname($p); };
     return { $nickname };
 
     fun default_nickname($p: person) -> { nickname }:
     match
-      not { $ignored in nickname_of($p); }; # $p has no nickname
+      not { let $ignored in nickname_of($p); }; # $p has no nickname
       $nickname-mapping isa nickname-mapping;
       $p has name $name;
       $nickname-mapping has name $name;
@@ -152,15 +152,15 @@ Feature: Function Definition
     with
     fun nickname_of($p: person) -> { nickname }:
     match
-      $dummy = $nickname;
+      let $dummy = $nickname;
       { $p has nickname $nickname; } or
-      { $nickname in default_nickname($p); };
+      { let $nickname in default_nickname($p); };
     return { $nickname };
 
     with
     fun default_nickname($p: person) -> { nickname }:
     match
-      not { $ignored in nickname_of($p); }; # $p has no nickname
+      not { let $ignored in nickname_of($p); }; # $p has no nickname
       $nickname-mapping isa nickname-mapping;
       $p has name $name;
       $nickname-mapping has name $name;
@@ -169,7 +169,7 @@ Feature: Function Definition
 
     match
       $p isa person;
-      $nickname in nickname_of($p);
+      let $nickname in nickname_of($p);
     """
 
 
@@ -191,30 +191,30 @@ Feature: Function Definition
     define
     fun annual_reward($customer: person) -> {double}:
     match
-      $dummy = $reward;
-      { ($customer, $item) isa purchase; $reward in purchase_reward($item); } or
-      { $reward in special_rewards($customer); };
+      let $dummy = $reward;
+      { $purchase isa purchase ($customer, $item); let $reward in purchase_reward($item); } or
+      { let $reward in special_rewards($customer); };
     reduce $total_rewards = sum($reward);
     return { $total_rewards };
 
     fun purchase_reward($item: item) -> { double }:
     match
       $item has price $price;
-      $reward = 1.1 * $price;
+      let $reward = 1.1 * $price;
     return { $reward };
 
     fun special_rewards($customer: person) -> {double}:
     match
-       $joining_bonus = 1000;
-       $loyalty = loyalty_bonus($customer);
-       $total = $joining + $loyalty;
+       let $joining_bonus = 1000;
+       let $loyalty = loyalty_bonus($customer);
+       let $total = $joining + $loyalty;
     return { $total };
 
     fun loyalty_bonus($customer: person) ->  { double }:
     match
       $customer has joining-year $year;
-      $years-completed = (2024 - $year);
-      $loyalty-bonus = annual_reward($p) * (1 + $years-completed * 0.01); # An extra 1% per year!!!
+      let $years-completed = (2024 - $year);
+      let $loyalty-bonus = annual_reward($p) * (1 + $years-completed * 0.01); # An extra 1% per year!!!
     return { $loyalty-bonus };
     """
     Then transaction commits; fails with a message containing: "Detected a recursive cycle through a negation or reduction"
@@ -225,9 +225,9 @@ Feature: Function Definition
     with
     fun annual_reward($customer: person) -> {double}:
     match
-      $dummy = $reward;
-      { ($customer, $item) isa purchase; $reward in purchase_reward($item); } or
-      { $reward in special_rewards($customer); };
+      let $dummy = $reward;
+      { $purchase isa purchase ($customer, $item); let $reward in purchase_reward($item); } or
+      { let $reward in special_rewards($customer); };
     reduce $total_rewards = sum($reward);
     return { $total_rewards };
 
@@ -235,28 +235,28 @@ Feature: Function Definition
     fun purchase_reward($item: item) -> { double }:
     match
       $item has price $price;
-      $reward = 1.1 * $price;
+      let $reward = 1.1 * $price;
     return { $reward };
 
     with
     fun special_rewards($customer: person) -> {double}:
     match
-       $joining_bonus = 1000;
-       $loyalty = loyalty_bonus($customer);
-       $total = $joining + $loyalty;
+       let $joining_bonus = 1000;
+       let $loyalty = loyalty_bonus($customer);
+       let $total = $joining + $loyalty;
     return { $total };
 
     with
     fun loyalty_bonus($customer: person) ->  { double }:
     match
       $customer has joining-year $year;
-      $years-completed = (2024 - $year);
-      $loyalty-bonus = annual_reward($p) * (1 + $years-completed * 0.01); # An extra 1% per year!!!
+      let $years-completed = (2024 - $year);
+      let $loyalty-bonus = annual_reward($p) * (1 + $years-completed * 0.01); # An extra 1% per year!!!
     return { $loyalty-bonus };
 
     match
       $p isa person;
-      $reward in annual_reward($p);
+      let $reward in annual_reward($p);
     """
 
 
@@ -276,13 +276,13 @@ Feature: Function Definition
     define
     fun nickname_of($p: person) -> { nickname }:
     match
-      $nickname in default_nickname($p);
+      let $nickname in default_nickname($p);
     return { $nickname };
 
     fun default_nickname($p: person) -> { nickname }:
     match
       $p isa $t; # Avoid unused argument
-      $nickname "Steve" isa nickname;
+      $nickname isa nickname "Steve";
     return { $nickname };
     """
     Given transaction commits
@@ -311,13 +311,13 @@ Feature: Function Definition
     define
     fun nickname_of($p: person) -> { nickname }:
     match
-      $nickname in default_nickname($p);
+      let $nickname in default_nickname($p);
     return { $nickname };
 
     fun default_nickname($p: person) -> { nickname }:
     match
       $p isa $t; # Avoid unused argument
-      $nickname "Steve" isa nickname;
+      $nickname isa nickname "Steve";
     return { $nickname };
     """
     Given transaction commits
@@ -328,8 +328,8 @@ Feature: Function Definition
     fun default_nickname($p: person) -> { string }:
     match
       $p isa $t; # Avoid unused argument
-      $nickname_attr "Steve" isa nickname;
-      $nickname_value = $nickname_attr;
+      $nickname_attr isa nickname "Steve";
+      let $nickname_value = $nickname_attr;
     return { $nickname_value };
     """
     Then transaction commits; fails with a message containing: "Type checking all functions currently defined failed"

--- a/query/functions/definition.feature
+++ b/query/functions/definition.feature
@@ -27,7 +27,7 @@ Feature: Function Definition
     Given typeql schema query
     """
     define
-    fun five() -> long :
+    fun five() -> integer :
     match
       let $five = 5;
     return first $five;
@@ -40,7 +40,7 @@ Feature: Function Definition
     Given typeql schema query
     """
     define
-    fun five() -> long :
+    fun five() -> integer :
     match
       let $five = 5;
     return first $five;
@@ -75,7 +75,7 @@ Feature: Function Definition
     Given typeql schema query
     """
     define
-    fun five() -> long :
+    fun five() -> integer :
     match
       let $five = 4;
     return first $five;
@@ -89,14 +89,14 @@ Feature: Function Definition
     """
     Then uniquely identify answer concepts
       | five         |
-      | value:long:4 |
+      | value:integer:4 |
     Given transaction closes
 
     Given connection open schema transaction for database: typedb
     When typeql schema query
     """
     redefine
-    fun five() -> long :
+    fun five() -> integer :
     match
       let $five = 5;
     return first $five;
@@ -110,7 +110,7 @@ Feature: Function Definition
     """
     Then uniquely identify answer concepts
       | five         |
-      | value:long:5 |
+      | value:integer:5 |
     Given transaction closes
 
 

--- a/query/functions/movemetoquery-negation.feature
+++ b/query/functions/movemetoquery-negation.feature
@@ -39,7 +39,7 @@ Feature: Negation Resolution
         relates superior;
 
       name sub attribute, value string;
-      age sub attribute, value long;
+      age sub attribute, value integer;
       """
     # each scenario specialises the schema further
 

--- a/query/functions/negation.feature
+++ b/query/functions/negation.feature
@@ -41,7 +41,7 @@ Feature: Negation Resolution
         relates superior;
 
       name sub attribute, value string;
-      age sub attribute, value long;
+      age sub attribute, value integer;
       """
     # each scenario specialises the schema further
 

--- a/query/functions/recursion.feature
+++ b/query/functions/recursion.feature
@@ -74,7 +74,7 @@ Feature: Recursive Function Execution
 
       fun big_location_hierarchy_pairs() -> { place, place }:
       match
-        $x, $y in transitive_location_hierarchy_pairs();
+        let $x, $y in transitive_location_hierarchy_pairs();
         $x isa big-place;
         $y isa big-place;
       return {$x, $y};
@@ -88,7 +88,7 @@ Feature: Recursive Function Execution
 
       fun big_location_hierarchy_directed($x: big-place) -> { big-place }:
       match
-        $y in transitive_location_hierarchy_directed($x);
+        let $y in transitive_location_hierarchy_directed($x);
         $y isa big-place;
       return {$y};
       """
@@ -110,13 +110,13 @@ Feature: Recursive Function Execution
     Given connection open read transaction for database: typedb
     Given get answers of typeql read query
       """
-      match $x, $y in big_location_hierarchy_pairs();
+      match let $x, $y in big_location_hierarchy_pairs();
       """
     Then answer size is: 1
 
     Given get answers of typeql read query
       """
-      match $x isa big-place; $y in big_location_hierarchy_directed($x);
+      match $x isa big-place; let $y in big_location_hierarchy_directed($x);
       """
     Then answer size is: 1
 
@@ -141,7 +141,7 @@ Feature: Recursive Function Execution
          { (parent: $x, child: $y) isa parentship; } or
          {
             (parent: $x, child: $z) isa parentship;
-            $z, $y1 in ancestor_pairs();
+            let $z, $y1 in ancestor_pairs();
             $y is $y1;
           };
         return { $x, $y };
@@ -152,7 +152,7 @@ Feature: Recursive Function Execution
          { (parent: $x, child: $y) isa parentship; } or
          {
             (parent: $x, child: $z) isa parentship;
-            $y1 in ancestors_directed($z);
+            let $y1 in ancestors_directed($z);
             $y is $y1;
           };
         return { $y };
@@ -187,7 +187,7 @@ Feature: Recursive Function Execution
     Given get answers of typeql read query
       """
       match
-        $X, $Y in ancestor_pairs();
+        let $X, $Y in ancestor_pairs();
         $X has name 'aa';
         $Y has name $name;
       select $Y, $name;
@@ -204,7 +204,7 @@ Feature: Recursive Function Execution
       """
       match
         $X isa person, has name 'aa';
-        $Y in ancestors_directed($X);
+        let $Y in ancestors_directed($X);
         $Y has name $name;
       select $Y, $name;
       """
@@ -219,7 +219,7 @@ Feature: Recursive Function Execution
 
     Given get answers of typeql read query
       """
-      match $X, $Y in ancestor_pairs();
+      match let $X, $Y in ancestor_pairs();
       """
     Then answer size is: 10
     Then verify answer set is equivalent for query
@@ -264,7 +264,7 @@ Feature: Recursive Function Execution
           } or
         {
           (parent: $x1, child: $z) isa parentship;
-          $z, $y1 in ancestor_friendship_pairs();
+          let $z, $y1 in ancestor_friendship_pairs();
           $y is $y1; $x is $x1;
         };
         return { $x, $y };
@@ -278,7 +278,7 @@ Feature: Recursive Function Execution
           } or
         {
           (parent: $x, child: $z) isa parentship;
-          $z in ancestor_friendship_directed($y);
+          let $z in ancestor_friendship_directed($y);
         };
         return { $x };
       """
@@ -306,7 +306,7 @@ Feature: Recursive Function Execution
     Given get answers of typeql read query
       """
       match
-        $X, $Y in ancestor_friendship_pairs();
+        let $X, $Y in ancestor_friendship_pairs();
         $X has name 'a';
         $Y has name $name;
       select $Y;
@@ -323,7 +323,7 @@ Feature: Recursive Function Execution
     Given get answers of typeql read query
       """
       match
-        $X, $Y in ancestor_friendship_pairs();
+        let $X, $Y in ancestor_friendship_pairs();
         $Y has name 'd';
       select $X;
       """
@@ -338,7 +338,7 @@ Feature: Recursive Function Execution
     Given get answers of typeql read query
       """
       match
-        $X in ancestor_friendship_directed($Y);
+        let $X in ancestor_friendship_directed($Y);
         $Y has name 'd';
       select $X;
       """
@@ -376,7 +376,7 @@ Feature: Recursive Function Execution
       } or {
         (parent: $x1, child: $u) isa parentship;
         (parent: $y1, child: $v) isa parentship;
-        $u, $v in same_gen_pairs();
+        let $u, $v in same_gen_pairs();
         $x is $x1; $y is $y1;
       };
       return { $x, $y };
@@ -390,7 +390,7 @@ Feature: Recursive Function Execution
       } or {
         (parent: $x, child: $u) isa parentship;
         (parent: $y1, child: $v) isa parentship;
-        $u in same_gen_directed($v);
+        let $u in same_gen_directed($v);
         $y is $y1;
       };
       return { $y };
@@ -428,7 +428,7 @@ Feature: Recursive Function Execution
     Given get answers of typeql read query
       """
       match
-        $x, $y in same_gen_pairs();
+        let $x, $y in same_gen_pairs();
         $x has name 'a';
       select $y;
       """
@@ -444,7 +444,7 @@ Feature: Recursive Function Execution
       """
       match
         $x has name 'a';
-        $y in same_gen_directed($x);
+        let $y in same_gen_directed($x);
       select $y;
       """
     Then answer size is: 2
@@ -477,7 +477,7 @@ Feature: Recursive Function Execution
       fun ntc_pairs() -> { entity2, entity2 } :
       match
         $x isa q;
-        $x, $y in tc_pairs();
+        let $x, $y in tc_pairs();
       return { $x, $y };
 
       fun tc_pairs() -> { entity2, entity2 } :
@@ -486,7 +486,7 @@ Feature: Recursive Function Execution
         { (roleA: $x, roleB: $y) isa P; } or
         {
           (roleA: $x, roleB: $z) isa P;
-          $z, $y1 in tc_pairs();
+          let $z, $y1 in tc_pairs();
           $y is $y1;
         };
       return { $x, $y };
@@ -512,7 +512,7 @@ Feature: Recursive Function Execution
     Given get answers of typeql read query
     """
       match
-        $x, $y in ntc_pairs();
+        let $x, $y in ntc_pairs();
         $y has index 'a';
       select $x;
       """
@@ -563,14 +563,14 @@ Feature: Recursive Function Execution
         { (start: $x, end: $y) isa link; } or
         {
           (start: $x, end: $z) isa link;
-          $z, $y1 in reachable_pairs();
+          let $z, $y1 in reachable_pairs();
           $y1 is $y;
         };
       return {$x, $y};
 
       fun indirect_link_pairs() -> { traversable, traversable }:
         match
-          $x, $y in reachable_pairs();
+          let $x, $y in reachable_pairs();
           not {(start: $x, end: $y) isa link;};
         return { $x, $y };
 
@@ -579,7 +579,7 @@ Feature: Recursive Function Execution
           $x isa vertex;
           $y isa vertex;
           not {
-            $x1, $y1 in reachable_pairs();
+            let $x1, $y1 in reachable_pairs();
              $x is $x1; $y is $y1;
           };
         return { $x, $y };
@@ -591,14 +591,14 @@ Feature: Recursive Function Execution
         { (start: $x, end: $y) isa link; } or
         {
           (start: $x, end: $z) isa link;
-          $y1 in reachable_from($z);
+          let $y1 in reachable_from($z);
           $y1 is $y;
         };
       return { $y };
 
       fun indirect_link_from($x: traversable) -> { traversable }:
         match
-          $y in reachable_from($x);
+          let $y in reachable_from($x);
           not {(start: $x, end: $y) isa link;};
         return { $y };
 
@@ -607,7 +607,7 @@ Feature: Recursive Function Execution
           $x isa vertex;
           $y isa vertex;
           not {
-            $y1 in reachable_from($x);
+            let $y1 in reachable_from($x);
             $y is $y1;
           };
         return { $y };
@@ -634,7 +634,7 @@ Feature: Recursive Function Execution
     Given connection open read transaction for database: typedb
     Given get answers of typeql read query
       """
-      match $x, $y in reachable_pairs();
+      match let $x, $y in reachable_pairs();
       """
     Then answer size is: 7
     Then verify answer set is equivalent for query
@@ -655,7 +655,7 @@ Feature: Recursive Function Execution
         """
         match
         $x isa traversable;
-        $y in reachable_from($x);
+        let $y in reachable_from($x);
         """
     Then answer size is: 7
     Then verify answer set is equivalent for query
@@ -700,7 +700,7 @@ Feature: Recursive Function Execution
         { ($x, $y) isa link; } or
         {
           ($x, $z) isa link;
-          $z, $y1 in reachable_pairs();
+          let $z, $y1 in reachable_pairs();
           $y is $y1;
         };
       return { $x, $y };
@@ -712,7 +712,7 @@ Feature: Recursive Function Execution
         { ($x, $y) isa link; } or
         {
           ($x, $z) isa link;
-          $y1 in reachable_from($z);
+          let $y1 in reachable_from($z);
           $y is $y1;
         };
       return { $y };
@@ -742,7 +742,7 @@ Feature: Recursive Function Execution
     Given get answers of typeql read query
       """
       match
-        $x, $y in reachable_pairs();
+        let $x, $y in reachable_pairs();
         $x has index 'a';
       select $y;
       """
@@ -758,7 +758,7 @@ Feature: Recursive Function Execution
     Given get answers of typeql read query
       """
       match
-        $y in reachable_from($x);
+        let $y in reachable_from($x);
         $x has index 'a';
       select $y;
       """
@@ -799,10 +799,10 @@ Feature: Recursive Function Execution
       fun same_gen_pairs() -> { person, person }:
       match
         $x isa person; $y isa person;
-        { $x1, $y1 in sibling_pairs(); $x1 is $x; $y1 is $y; } or
+        { let $x1, $y1 in sibling_pairs(); $x1 is $x; $y1 is $y; } or
         {
           (parent: $x, child: $u) isa parentship;
-          $u, $v in same_gen_pairs();
+          let $u, $v in same_gen_pairs();
           (parent: $y, child: $v) isa parentship;
         };
       return { $x, $y };
@@ -824,7 +824,7 @@ Feature: Recursive Function Execution
         { $y1 in sibling_directed($x); $y is $y1; } or
         {
           (parent: $x, child: $u) isa parentship;
-          $v in same_gen_directed($u);
+          let $v in same_gen_directed($u);
           (parent: $y, child: $v) isa parentship;
         };
       return { $y };
@@ -862,7 +862,7 @@ Feature: Recursive Function Execution
       """
       match
         $x has name 'ann'; $y isa person;
-        $x, $y in same_gen_pairs();
+        let $x, $y in same_gen_pairs();
       select $y;
       """
     Then answer size is: 3
@@ -877,7 +877,7 @@ Feature: Recursive Function Execution
       """
       match
         $x has name 'ann'; $y isa person;
-        $y in same_gen_directed($x);
+        let $y in same_gen_directed($x);
       select $y;
       """
     Then answer size is: 3
@@ -926,7 +926,7 @@ Feature: Recursive Function Execution
       { (start: $x, end: $y) isa flat; } or
       {
         (start: $x, end: $x1) isa up;
-        $y1, $x1 in rev_sg_pairs();
+        let $y1, $x1 in rev_sg_pairs();
         (start: $y1, end: $y) isa down;
       };
       return {$x, $y};
@@ -938,7 +938,7 @@ Feature: Recursive Function Execution
       { (start: $x, end: $y) isa flat; } or
       {
         (start: $x, end: $x1) isa up;
-        $y1 in rev_sg_directed_to_bound($x1);
+        let $y1 in rev_sg_directed_to_bound($x1);
         (start: $y1, end: $y) isa down;
       };
       return {$y};
@@ -950,7 +950,7 @@ Feature: Recursive Function Execution
       { (start: $x, end: $y) isa flat; } or
       {
         (start: $x, end: $x1) isa up;
-        $x1 in rev_sg_directed_from_bound($y1);
+        let $x1 in rev_sg_directed_from_bound($y1);
         (start: $y1, end: $y) isa down;
       };
       return {$x};
@@ -1005,7 +1005,7 @@ Feature: Recursive Function Execution
     Given get answers of typeql read query
       """
       match
-        $x, $y in rev_sg_pairs();
+        let $x, $y in rev_sg_pairs();
         $x has name 'a';
       select $y;
       """
@@ -1019,7 +1019,7 @@ Feature: Recursive Function Execution
       """
     Given get answers of typeql read query
       """
-      match $x, $y in rev_sg_pairs();
+      match let $x, $y in rev_sg_pairs();
       """
     Then answer size is: 11
     Then verify answer set is equivalent for query
@@ -1039,7 +1039,7 @@ Feature: Recursive Function Execution
     Given get answers of typeql read query
       """
       match
-        $y in rev_sg_directed_from_bound($x);
+        let $y in rev_sg_directed_from_bound($x);
         $x has name 'a';
       select $y;
       """
@@ -1055,7 +1055,7 @@ Feature: Recursive Function Execution
       """
       match
       $x isa person;
-      $y in rev_sg_directed_from_bound($x);
+      let $y in rev_sg_directed_from_bound($x);
       """
     Then answer size is: 11
     Then verify answer set is equivalent for query
@@ -1075,7 +1075,7 @@ Feature: Recursive Function Execution
       """
       match
       $y isa person;
-      $x in rev_sg_directed_to_bound($y);
+      let $x in rev_sg_directed_to_bound($y);
       """
     Then answer size is: 11
     Then verify answer set is equivalent for query
@@ -1128,7 +1128,7 @@ Feature: Recursive Function Execution
          { (start: $x, end: $y) isa R1; } or
          {
             (start: $x, end: $z) isa R1;
-            $z, $y1 in q1_pairs();
+            let $z, $y1 in q1_pairs();
             $y is $y1;
          };
         return { $x, $y };
@@ -1139,14 +1139,14 @@ Feature: Recursive Function Execution
         { (start: $x, end: $y) isa R2; }
         or {
             (start: $x, end: $z) isa R2;
-            $z, $y1 in q2_pairs();
+            let $z, $y1 in q2_pairs();
             $y is $y1;
         };
         return { $x, $y };
 
       fun p_pairs() -> { entity2, entity2 }:
       match
-        $x, $y in q1_pairs();
+        let $x, $y in q1_pairs();
       return { $x, $y };
 
       # --- directed ---
@@ -1157,7 +1157,7 @@ Feature: Recursive Function Execution
          { (start: $x, end: $y) isa R1; } or
          {
             (start: $x, end: $z) isa R1;
-            $y1 in q1_directed($z);
+            let $y1 in q1_directed($z);
             $y is $y1;
          };
         return { $y };
@@ -1168,14 +1168,14 @@ Feature: Recursive Function Execution
         { (start: $x, end: $y) isa R2; }
         or {
             (start: $x, end: $z) isa R2;
-            $y1 in q2_directed($z);
+            let $y1 in q2_directed($z);
             $y is $y1;
         };
         return { $y };
 
       fun p_directed($x: entity2) -> { entity2 }:
       match
-        $y in q1_directed($x);
+        let $y in q1_directed($x);
       return { $y };
       """
     Given transaction commits
@@ -1276,7 +1276,7 @@ Feature: Recursive Function Execution
     Given get answers of typeql read query
       """
       match
-        $x, $y in q1_pairs();
+        let $x, $y in q1_pairs();
         $x has index 'a0';
       select $y;
       """
@@ -1289,7 +1289,7 @@ Feature: Recursive Function Execution
     Given get answers of typeql read query
       """
       match
-        $y in q1_directed($x);
+        let $y in q1_directed($x);
         $x has index 'a0';
       select $y;
       """
@@ -1326,22 +1326,22 @@ Feature: Recursive Function Execution
 
       fun p_pairs() -> {entity2, entity2}:
       match
-        $x in identity($x1);
-        $y in identity($y1);
+        let $x in identity($x1);
+        let $y in identity($y1);
         { (start: $x1, end: $y1) isa Q; } or
         {
           (start: $x1, end: $z1) isa Q;
-          $z1, $y1 in p_pairs();
+          let $z1, $y1 in p_pairs();
         };
       return { $x, $y };
 
       fun p_directed($x: entity2) -> {entity2}:
       match
-        $y in identity($y1);
+        let $y in identity($y1);
         { (start: $x, end: $y1) isa Q; } or
         {
           (start: $x, end: $z) isa Q;
-          $y1 in p_directed($z);
+          let $y1 in p_directed($z);
         };
       return { $y };
       """
@@ -1504,7 +1504,7 @@ Feature: Recursive Function Execution
     Given get answers of typeql read query
       """
       match
-        $x, $y in p_pairs();
+        let $x, $y in p_pairs();
         $x has index 'a0';
       select $y;
       """
@@ -1517,7 +1517,7 @@ Feature: Recursive Function Execution
     Given get answers of typeql read query
       """
       match
-        $y in p_directed($x);
+        let $y in p_directed($x);
         $x has index 'a0';
       select $y;
       """
@@ -1552,14 +1552,14 @@ Feature: Recursive Function Execution
       { (start: $x, end: $y) isa Q; } or
       {
         (start: $x, end: $z) isa Q;
-        $z, $y1 in p_pairs();
+        let $z, $y1 in p_pairs();
         $y is $y1;
       };
       return { $x, $y };
 
       fun s_pairs() -> { entity2, entity2 }:
       match
-        $x, $y in p_pairs();
+        let $x, $y in p_pairs();
       return { $x, $y };
 
       # --- directed ---
@@ -1569,14 +1569,14 @@ Feature: Recursive Function Execution
       { (start: $x, end: $y) isa Q; } or
       {
         (start: $x, end: $z) isa Q;
-        $y1 in p_directed($z);
+        let $y1 in p_directed($z);
         $y is $y1;
       };
       return { $y };
 
       fun s_directed($x: entity2) -> { entity2 }:
       match
-        $y in p_directed($x);
+        let $y in p_directed($x);
       return { $y };
       """
     Given transaction commits
@@ -1678,7 +1678,7 @@ Feature: Recursive Function Execution
     Given get answers of typeql read query
       """
       match
-        $x, $y in p_pairs();
+        let $x, $y in p_pairs();
         $x has index 'a';
       select $y;
       """
@@ -1690,7 +1690,7 @@ Feature: Recursive Function Execution
     Given get answers of typeql read query
       """
       match
-        $y in p_directed($x);
+        let $y in p_directed($x);
         $x has index 'a';
       select $y;
       """

--- a/query/functions/recursion.feature
+++ b/query/functions/recursion.feature
@@ -68,8 +68,8 @@ Feature: Recursive Function Execution
 
       fun transitive_location_hierarchy_pairs() -> { place, place }:
       match
-        (subordinate: $x, superior: $y) isa location-hierarchy;
-        (subordinate: $y, superior: $z) isa location-hierarchy;
+        location-hierarchy (subordinate: $x, superior: $y);
+        location-hierarchy (subordinate: $y, superior: $z);
       return {$x, $z};
 
       fun big_location_hierarchy_pairs() -> { place, place }:
@@ -82,8 +82,8 @@ Feature: Recursive Function Execution
 
       fun transitive_location_hierarchy_directed($x: place) -> { place }:
       match
-        (subordinate: $x, superior: $y) isa location-hierarchy;
-        (subordinate: $y, superior: $z) isa location-hierarchy;
+        location-hierarchy (subordinate: $x, superior: $y);
+        location-hierarchy (subordinate: $y, superior: $z);
       return {$z};
 
       fun big_location_hierarchy_directed($x: big-place) -> { big-place }:
@@ -102,8 +102,8 @@ Feature: Recursive Function Execution
       $y isa place, has name "Tanzania";
       $z isa big-place, has name "Africa";
 
-      (subordinate: $x, superior: $y) isa location-hierarchy;
-      (subordinate: $y, superior: $z) isa location-hierarchy;
+      location-hierarchy (subordinate: $x, superior: $y);
+      location-hierarchy (subordinate: $y, superior: $z);
       """
     Given transaction commits
 
@@ -138,9 +138,9 @@ Feature: Recursive Function Execution
       fun ancestor_pairs() -> { person, person } :
         match
          $x isa person; $y isa person;
-         { (parent: $x, child: $y) isa parentship; } or
+         { parentship (parent: $x, child: $y); } or
          {
-            (parent: $x, child: $z) isa parentship;
+            parentship (parent: $x, child: $z);
             let $z, $y1 in ancestor_pairs();
             $y is $y1;
           };
@@ -149,9 +149,9 @@ Feature: Recursive Function Execution
       fun ancestors_directed($x: person) -> { person } :
         match
          $y isa person;
-         { (parent: $x, child: $y) isa parentship; } or
+         { parentship (parent: $x, child: $y); } or
          {
-            (parent: $x, child: $z) isa parentship;
+            parentship (parent: $x, child: $z);
             let $y1 in ancestors_directed($z);
             $y is $y1;
           };
@@ -174,12 +174,12 @@ Feature: Recursive Function Execution
       $c isa person, has name 'c';
       $ca isa person, has name 'ca';
 
-      (parent: $a, child: $aa) isa parentship;
-      (parent: $a, child: $ab) isa parentship;
-      (parent: $aa, child: $aaa) isa parentship;
-      (parent: $aa, child: $aab) isa parentship;
-      (parent: $aaa, child: $aaaa) isa parentship;
-      (parent: $c, child: $ca) isa parentship;
+      parentship (parent: $a, child: $aa);
+      parentship (parent: $a, child: $ab);
+      parentship (parent: $aa, child: $aaa);
+      parentship (parent: $aa, child: $aab);
+      parentship (parent: $aaa, child: $aaaa);
+      parentship (parent: $c, child: $ca);
       """
     Given transaction commits
 
@@ -259,11 +259,11 @@ Feature: Recursive Function Execution
       match
         $x isa person; $y isa person;
         {
-         (friend: $x, friend: $y) isa friendship;
+         friendship (friend: $x, friend: $y);
          not { $x is $y; }; # TODO: 3.0 does not de-duplicate links yet
           } or
         {
-          (parent: $x1, child: $z) isa parentship;
+          parentship (parent: $x1, child: $z);
           let $z, $y1 in ancestor_friendship_pairs();
           $y is $y1; $x is $x1;
         };
@@ -273,11 +273,11 @@ Feature: Recursive Function Execution
       match
         $x isa person; $y isa person;
         {
-         (friend: $x, friend: $y) isa friendship;
+         friendship (friend: $x, friend: $y);
          $x has name $xn; $y has name $yn; $xn != $yn; # TODO: 3.0 does not de-duplicate symmetric links yet
           } or
         {
-          (parent: $x, child: $z) isa parentship;
+          parentship (parent: $x, child: $z);
           let $z in ancestor_friendship_directed($y);
         };
         return { $x };
@@ -295,10 +295,10 @@ Feature: Recursive Function Execution
       $d isa person, has name "d";
       $g isa person, has name "g";
 
-      (parent: $a, child: $b) isa parentship;
-      (parent: $b, child: $c) isa parentship;
-      (friend: $a, friend: $g) isa friendship;
-      (friend: $c, friend: $d) isa friendship;
+      parentship (parent: $a, child: $b);
+      parentship (parent: $b, child: $c);
+      friendship (friend: $a, friend: $g);
+      friendship (friend: $c, friend: $d);
       """
     Given transaction commits
 
@@ -374,8 +374,8 @@ Feature: Recursive Function Execution
       {
         $x isa Human; $y is $x;
       } or {
-        (parent: $x1, child: $u) isa parentship;
-        (parent: $y1, child: $v) isa parentship;
+        parentship (parent: $x1, child: $u);
+        parentship (parent: $y1, child: $v);
         let $u, $v in same_gen_pairs();
         $x is $x1; $y is $y1;
       };
@@ -388,8 +388,8 @@ Feature: Recursive Function Execution
         # $x is $y; # is unimplemented when $x is input. So we workaround with names
         $x has name $name; $y has name $name;
       } or {
-        (parent: $x, child: $u) isa parentship;
-        (parent: $y1, child: $v) isa parentship;
+        parentship (parent: $x, child: $u);
+        parentship (parent: $y1, child: $v);
         let $u in same_gen_directed($v);
         $y is $y1;
       };
@@ -411,16 +411,16 @@ Feature: Recursive Function Execution
       $g isa entity2, has name "g";
       $h isa entity2, has name "h";
 
-      (parent: $a, child: $b) isa parentship;
-      (parent: $a, child: $c) isa parentship;
-      (parent: $b, child: $d) isa parentship;
-      (parent: $c, child: $d) isa parentship;
-      (parent: $e, child: $d) isa parentship;
-      (parent: $f, child: $e) isa parentship;
+      parentship (parent: $a, child: $b);
+      parentship (parent: $a, child: $c);
+      parentship (parent: $b, child: $d);
+      parentship (parent: $c, child: $d);
+      parentship (parent: $e, child: $d);
+      parentship (parent: $f, child: $e);
 
       #Extra data
-      (parent: $g, child: $f) isa parentship;
-      (parent: $h, child: $g) isa parentship;
+      parentship (parent: $g, child: $f);
+      parentship (parent: $h, child: $g);
       """
     Given transaction commits
 
@@ -483,9 +483,9 @@ Feature: Recursive Function Execution
       fun tc_pairs() -> { entity2, entity2 } :
       match
         $x isa entity2; $y isa entity2;
-        { (roleA: $x, roleB: $y) isa P; } or
+        { P (roleA: $x, roleB: $y); } or
         {
-          (roleA: $x, roleB: $z) isa P;
+          P (roleA: $x, roleB: $z);
           let $z, $y1 in tc_pairs();
           $y is $y1;
         };
@@ -503,8 +503,8 @@ Feature: Recursive Function Execution
       $a1 isa entity2, has index "a1";
       $a2 isa q, has index "a2";
 
-      (roleA: $a1, roleB: $a) isa P;
-      (roleA: $a2, roleB: $a1) isa P;
+      P (roleA: $a1, roleB: $a);
+      P (roleA: $a2, roleB: $a1);
       """
     Given transaction commits
 
@@ -560,9 +560,9 @@ Feature: Recursive Function Execution
       fun reachable_pairs() -> {traversable, traversable}:
       match
         $x isa traversable; $y isa traversable;
-        { (start: $x, end: $y) isa link; } or
+        { link (start: $x, end: $y); } or
         {
-          (start: $x, end: $z) isa link;
+          link (start: $x, end: $z);
           let $z, $y1 in reachable_pairs();
           $y1 is $y;
         };
@@ -571,7 +571,7 @@ Feature: Recursive Function Execution
       fun indirect_link_pairs() -> { traversable, traversable }:
         match
           let $x, $y in reachable_pairs();
-          not {(start: $x, end: $y) isa link;};
+          not { link (start: $x, end: $y);};
         return { $x, $y };
 
       fun unreachable_pairs() -> {traversable, traversable}:
@@ -588,9 +588,9 @@ Feature: Recursive Function Execution
       fun reachable_from($x: traversable) -> {traversable}:
       match
         $x isa traversable; $y isa traversable;
-        { (start: $x, end: $y) isa link; } or
+        { link (start: $x, end: $y); } or
         {
-          (start: $x, end: $z) isa link;
+          link (start: $x, end: $z);
           let $y1 in reachable_from($z);
           $y1 is $y;
         };
@@ -599,7 +599,7 @@ Feature: Recursive Function Execution
       fun indirect_link_from($x: traversable) -> { traversable }:
         match
           let $y in reachable_from($x);
-          not {(start: $x, end: $y) isa link;};
+          not {link (start: $x, end: $y); };
         return { $y };
 
       fun unreachable_from($x: traversable) -> {traversable}:
@@ -624,10 +624,10 @@ Feature: Recursive Function Execution
       $cc isa node, has index "cc";
       $dd isa node, has index "dd";
 
-      (start: $aa, end: $bb) isa link;
-      (start: $bb, end: $cc) isa link;
-      (start: $cc, end: $cc) isa link;
-      (start: $cc, end: $dd) isa link;
+      link (start: $aa, end: $bb);
+      link (start: $bb, end: $cc);
+      link (start: $cc, end: $cc);
+      link (start: $cc, end: $dd);
       """
     Given transaction commits
 
@@ -697,9 +697,9 @@ Feature: Recursive Function Execution
       fun reachable_pairs() -> { vertex, vertex }:
       match
         $x isa vertex; $y isa vertex;
-        { ($x, $y) isa link; } or
+        { link ($x, $y); } or
         {
-          ($x, $z) isa link;
+          link ($x, $z);
           let $z, $y1 in reachable_pairs();
           $y is $y1;
         };
@@ -709,9 +709,9 @@ Feature: Recursive Function Execution
       fun reachable_from($x: vertex) -> { vertex }:
       match
         $x isa vertex; $y isa vertex;
-        { ($x, $y) isa link; } or
+        { link ($x, $y); } or
         {
-          ($x, $z) isa link;
+          link ($x, $z);
           let $y1 in reachable_from($z);
           $y is $y1;
         };
@@ -731,10 +731,10 @@ Feature: Recursive Function Execution
       $c isa vertex, has index "c";
       $d isa vertex, has index "d";
 
-      (coordinate: $a, coordinate: $b) isa link;
-      (coordinate: $b, coordinate: $c) isa link;
-      (coordinate: $c, coordinate: $c) isa link;
-      (coordinate: $c, coordinate: $d) isa link;
+      link (coordinate: $a, coordinate: $b);
+      link (coordinate: $b, coordinate: $c);
+      link (coordinate: $c, coordinate: $c);
+      link (coordinate: $c, coordinate: $d);
       """
     Given transaction commits
 
@@ -801,19 +801,19 @@ Feature: Recursive Function Execution
         $x isa person; $y isa person;
         { let $x1, $y1 in sibling_pairs(); $x1 is $x; $y1 is $y; } or
         {
-          (parent: $x, child: $u) isa parentship;
+          parentship (parent: $x, child: $u);
           let $u, $v in same_gen_pairs();
-          (parent: $y, child: $v) isa parentship;
+          parentship (parent: $y, child: $v);
         };
       return { $x, $y };
 
       fun sibling_pairs() -> { person, person }:
       match
         $x isa person; $y isa person;
-        { (A: $x, B: $y) isa Sibling; } or
+        { Sibling (A: $x, B: $y); } or
         {
-          (parent: $z, child: $x) isa parentship;
-          (parent: $z, child: $y) isa parentship;
+          parentship (parent: $z, child: $x);
+          parentship (parent: $z, child: $y);
         };
       return {$x, $y};
 
@@ -821,21 +821,21 @@ Feature: Recursive Function Execution
       fun same_gen_directed($x: person) -> { person }:
       match
         $x isa person; $y isa person;
-        { $y1 in sibling_directed($x); $y is $y1; } or
+        { let $y1 in sibling_directed($x); $y is $y1; } or
         {
-          (parent: $x, child: $u) isa parentship;
+          parentship (parent: $x, child: $u);
           let $v in same_gen_directed($u);
-          (parent: $y, child: $v) isa parentship;
+          parentship (parent: $y, child: $v);
         };
       return { $y };
 
       fun sibling_directed($x: person) -> { person }:
       match
         $x isa person; $y isa person;
-        { (A: $x, B: $y) isa Sibling; } or
+        { Sibling (A: $x, B: $y); } or
         {
-          (parent: $z, child: $x) isa parentship;
-          (parent: $z, child: $y) isa parentship;
+          parentship (parent: $z, child: $x);
+          parentship (parent: $z, child: $y);
         };
       return { $y };
       """
@@ -851,9 +851,9 @@ Feature: Recursive Function Execution
       $john isa person, has name "john";
       $peter isa person, has name "peter";
 
-      (parent: $john, child: $ann) isa parentship;
-      (parent: $john, child: $peter) isa parentship;
-      (parent: $john, child: $bill) isa parentship;
+      parentship (parent: $john, child: $ann);
+      parentship (parent: $john, child: $peter);
+      parentship (parent: $john, child: $bill);
       """
     Given transaction commits
 
@@ -923,11 +923,11 @@ Feature: Recursive Function Execution
       fun rev_sg_pairs() -> { person, person }:
       match
       $x isa person; $y isa person;
-      { (start: $x, end: $y) isa flat; } or
+      { flat (start: $x, end: $y); } or
       {
-        (start: $x, end: $x1) isa up;
+        up (start: $x, end: $x1);
         let $y1, $x1 in rev_sg_pairs();
-        (start: $y1, end: $y) isa down;
+        down (start: $y1, end: $y);
       };
       return {$x, $y};
 
@@ -935,11 +935,11 @@ Feature: Recursive Function Execution
       fun rev_sg_directed_from_bound($x: person) -> { person }:
       match
       $x isa person; $y isa person;
-      { (start: $x, end: $y) isa flat; } or
+      { flat (start: $x, end: $y); } or
       {
-        (start: $x, end: $x1) isa up;
+        up (start: $x, end: $x1);
         let $y1 in rev_sg_directed_to_bound($x1);
-        (start: $y1, end: $y) isa down;
+        down (start: $y1, end: $y);
       };
       return {$y};
 
@@ -947,11 +947,11 @@ Feature: Recursive Function Execution
       fun rev_sg_directed_to_bound($y: person) -> { person }:
       match
       $x isa person; $y isa person;
-      { (start: $x, end: $y) isa flat; } or
+      { flat (start: $x, end: $y); } or
       {
-        (start: $x, end: $x1) isa up;
+        up (start: $x, end: $x1);
         let $x1 in rev_sg_directed_from_bound($y1);
-        (start: $y1, end: $y) isa down;
+        down (start: $y1, end: $y);
       };
       return {$x};
       """
@@ -979,25 +979,25 @@ Feature: Recursive Function Execution
       $o isa person, has name "o";
       $p isa person, has name "p";
 
-      (start: $a, end: $e) isa up;
-      (start: $a, end: $f) isa up;
-      (start: $f, end: $m) isa up;
-      (start: $g, end: $n) isa up;
-      (start: $h, end: $n) isa up;
-      (start: $i, end: $o) isa up;
-      (start: $j, end: $o) isa up;
+      up (start: $a, end: $e);
+      up (start: $a, end: $f);
+      up (start: $f, end: $m);
+      up (start: $g, end: $n);
+      up (start: $h, end: $n);
+      up (start: $i, end: $o);
+      up (start: $j, end: $o);
 
-      (start: $g, end: $f) isa flat;
-      (start: $m, end: $n) isa flat;
-      (start: $m, end: $o) isa flat;
-      (start: $p, end: $m) isa flat;
+      flat (start: $g, end: $f);
+      flat (start: $m, end: $n);
+      flat (start: $m, end: $o);
+      flat (start: $p, end: $m);
 
-      (start: $l, end: $f) isa down;
-      (start: $m, end: $f) isa down;
-      (start: $g, end: $b) isa down;
-      (start: $h, end: $c) isa down;
-      (start: $i, end: $d) isa down;
-      (start: $p, end: $k) isa down;
+      down (start: $l, end: $f);
+      down (start: $m, end: $f);
+      down (start: $g, end: $b);
+      down (start: $h, end: $c);
+      down (start: $i, end: $d);
+      down (start: $p, end: $k);
       """
     Given transaction commits
 
@@ -1125,9 +1125,9 @@ Feature: Recursive Function Execution
       fun q1_pairs() -> { entity2, entity2 }:
         match
          $x isa entity2; $y isa entity2;
-         { (start: $x, end: $y) isa R1; } or
+         { R1 (start: $x, end: $y); } or
          {
-            (start: $x, end: $z) isa R1;
+            R1 (start: $x, end: $z);
             let $z, $y1 in q1_pairs();
             $y is $y1;
          };
@@ -1136,9 +1136,9 @@ Feature: Recursive Function Execution
       fun q2_pairs() -> { entity2, entity2 }:
       match
         $x isa entity2; $y isa entity2;
-        { (start: $x, end: $y) isa R2; }
+        { R2 (start: $x, end: $y); }
         or {
-            (start: $x, end: $z) isa R2;
+            R2 (start: $x, end: $z);
             let $z, $y1 in q2_pairs();
             $y is $y1;
         };
@@ -1154,9 +1154,9 @@ Feature: Recursive Function Execution
       fun q1_directed($x: entity2) -> { entity2 }:
         match
          $x isa entity2; $y isa entity2;
-         { (start: $x, end: $y) isa R1; } or
+         { R1 (start: $x, end: $y); } or
          {
-            (start: $x, end: $z) isa R1;
+            R1 (start: $x, end: $z);
             let $y1 in q1_directed($z);
             $y is $y1;
          };
@@ -1165,9 +1165,9 @@ Feature: Recursive Function Execution
       fun q2_directed($x: entity2) -> { entity2 }:
       match
         $x isa entity2; $y isa entity2;
-        { (start: $x, end: $y) isa R2; }
+        { R2 (start: $x, end: $y); }
         or {
-            (start: $x, end: $z) isa R2;
+            R2 (start: $x, end: $z);
             let $y1 in q2_directed($z);
             $y is $y1;
         };
@@ -1230,45 +1230,45 @@ Feature: Recursive Function Execution
 
 
       # (start: $a{i}, end: $a{i+1} isa R1; for 0 <= i < m
-      (start: $a0, end: $a1) isa R1;
-      (start: $a1, end: $a2) isa R1;
-      (start: $a2, end: $a3) isa R1;
-      (start: $a3, end: $a4) isa R1;
-      (start: $a4, end: $a5) isa R1;
+      R1 (start: $a0, end: $a1);
+      R1 (start: $a1, end: $a2);
+      R1 (start: $a2, end: $a3);
+      R1 (start: $a3, end: $a4);
+      R1 (start: $a4, end: $a5);
 
 
       # (start: $a0, end: $b1{j}) isa R2; for 1 <= j <= n
       # (start: $b{m-1}{j}, end: $a{m}) isa R2; for 1 <= j <= n
       # (start: $b{i}{j}, end: $b{i+1}{j}) isa R2; for 1 <= j <= n; for 1 <= i < m - 1
-      (start: $a0, end: $b11) isa R2;
-      (start: $b41, end: $a5) isa R2;
-      (start: $b11, end: $b21) isa R2;
-      (start: $b21, end: $b31) isa R2;
-      (start: $b31, end: $b41) isa R2;
+      R2 (start: $a0, end: $b11);
+      R2 (start: $b41, end: $a5);
+      R2 (start: $b11, end: $b21);
+      R2 (start: $b21, end: $b31);
+      R2 (start: $b31, end: $b41);
 
-      (start: $a0, end: $b12) isa R2;
-      (start: $b42, end: $a5) isa R2;
-      (start: $b12, end: $b22) isa R2;
-      (start: $b22, end: $b32) isa R2;
-      (start: $b32, end: $b42) isa R2;
+      R2 (start: $a0, end: $b12);
+      R2 (start: $b42, end: $a5);
+      R2 (start: $b12, end: $b22);
+      R2 (start: $b22, end: $b32);
+      R2 (start: $b32, end: $b42);
 
-      (start: $a0, end: $b13) isa R2;
-      (start: $b43, end: $a5) isa R2;
-      (start: $b13, end: $b23) isa R2;
-      (start: $b23, end: $b33) isa R2;
-      (start: $b33, end: $b43) isa R2;
+      R2 (start: $a0, end: $b13);
+      R2 (start: $b43, end: $a5);
+      R2 (start: $b13, end: $b23);
+      R2 (start: $b23, end: $b33);
+      R2 (start: $b33, end: $b43);
 
-      (start: $a0, end: $b14) isa R2;
-      (start: $b44, end: $a5) isa R2;
-      (start: $b14, end: $b24) isa R2;
-      (start: $b24, end: $b34) isa R2;
-      (start: $b34, end: $b44) isa R2;
+      R2 (start: $a0, end: $b14);
+      R2 (start: $b44, end: $a5);
+      R2 (start: $b14, end: $b24);
+      R2 (start: $b24, end: $b34);
+      R2 (start: $b34, end: $b44);
 
-      (start: $a0, end: $b15) isa R2;
-      (start: $b45, end: $a5) isa R2;
-      (start: $b15, end: $b25) isa R2;
-      (start: $b25, end: $b35) isa R2;
-      (start: $b35, end: $b45) isa R2;
+      R2 (start: $a0, end: $b15);
+      R2 (start: $b45, end: $a5);
+      R2 (start: $b15, end: $b25);
+      R2 (start: $b25, end: $b35);
+      R2 (start: $b35, end: $b45);
       """
     Given transaction commits
 
@@ -1328,9 +1328,9 @@ Feature: Recursive Function Execution
       match
         let $x in identity($x1);
         let $y in identity($y1);
-        { (start: $x1, end: $y1) isa Q; } or
+        { Q (start: $x1, end: $y1); } or
         {
-          (start: $x1, end: $z1) isa Q;
+          Q (start: $x1, end: $z1);
           let $z1, $y1 in p_pairs();
         };
       return { $x, $y };
@@ -1338,9 +1338,9 @@ Feature: Recursive Function Execution
       fun p_directed($x: entity2) -> {entity2}:
       match
         let $y in identity($y1);
-        { (start: $x, end: $y1) isa Q; } or
+        { Q (start: $x, end: $y1); } or
         {
-          (start: $x, end: $z) isa Q;
+          Q (start: $x, end: $z);
           let $y1 in p_directed($z);
         };
       return { $y };
@@ -1425,78 +1425,78 @@ Feature: Recursive Function Execution
 
 
       # (start: $a0, end: $b1_{j}) isa Q; for 1 <= j <= n
-      (start: $a0, end: $b1_1) isa Q;
-      (start: $a0, end: $b1_2) isa Q;
-      (start: $a0, end: $b1_3) isa Q;
-      (start: $a0, end: $b1_4) isa Q;
-      (start: $a0, end: $b1_5) isa Q;
-      (start: $a0, end: $b1_6) isa Q;
-      (start: $a0, end: $b1_7) isa Q;
-      (start: $a0, end: $b1_8) isa Q;
-      (start: $a0, end: $b1_9) isa Q;
-      (start: $a0, end: $b1_10) isa Q;
+      Q (start: $a0, end: $b1_1);
+      Q (start: $a0, end: $b1_2);
+      Q (start: $a0, end: $b1_3);
+      Q (start: $a0, end: $b1_4);
+      Q (start: $a0, end: $b1_5);
+      Q (start: $a0, end: $b1_6);
+      Q (start: $a0, end: $b1_7);
+      Q (start: $a0, end: $b1_8);
+      Q (start: $a0, end: $b1_9);
+      Q (start: $a0, end: $b1_10);
 
 
       # (start: $b{i}_{j}, end: $b{i+1}_{j}) isa Q; for 1 <= j <= n; for 1 <= i <= m
-      (start: $b1_1, end: $b2_1) isa Q;
-      (start: $b2_1, end: $b3_1) isa Q;
-      (start: $b3_1, end: $b4_1) isa Q;
-      (start: $b4_1, end: $b5_1) isa Q;
-      (start: $b5_1, end: $b6_1) isa Q;
+      Q (start: $b1_1, end: $b2_1);
+      Q (start: $b2_1, end: $b3_1);
+      Q (start: $b3_1, end: $b4_1);
+      Q (start: $b4_1, end: $b5_1);
+      Q (start: $b5_1, end: $b6_1);
 
-      (start: $b1_2, end: $b2_2) isa Q;
-      (start: $b2_2, end: $b3_2) isa Q;
-      (start: $b3_2, end: $b4_2) isa Q;
-      (start: $b4_2, end: $b5_2) isa Q;
-      (start: $b5_2, end: $b6_2) isa Q;
+      Q (start: $b1_2, end: $b2_2);
+      Q (start: $b2_2, end: $b3_2);
+      Q (start: $b3_2, end: $b4_2);
+      Q (start: $b4_2, end: $b5_2);
+      Q (start: $b5_2, end: $b6_2);
 
-      (start: $b1_3, end: $b2_3) isa Q;
-      (start: $b2_3, end: $b3_3) isa Q;
-      (start: $b3_3, end: $b4_3) isa Q;
-      (start: $b4_3, end: $b5_3) isa Q;
-      (start: $b5_3, end: $b6_3) isa Q;
+      Q (start: $b1_3, end: $b2_3);
+      Q (start: $b2_3, end: $b3_3);
+      Q (start: $b3_3, end: $b4_3);
+      Q (start: $b4_3, end: $b5_3);
+      Q (start: $b5_3, end: $b6_3);
 
-      (start: $b1_4, end: $b2_4) isa Q;
-      (start: $b2_4, end: $b3_4) isa Q;
-      (start: $b3_4, end: $b4_4) isa Q;
-      (start: $b4_4, end: $b5_4) isa Q;
-      (start: $b5_4, end: $b6_4) isa Q;
+      Q (start: $b1_4, end: $b2_4);
+      Q (start: $b2_4, end: $b3_4);
+      Q (start: $b3_4, end: $b4_4);
+      Q (start: $b4_4, end: $b5_4);
+      Q (start: $b5_4, end: $b6_4);
 
-      (start: $b1_5, end: $b2_5) isa Q;
-      (start: $b2_5, end: $b3_5) isa Q;
-      (start: $b3_5, end: $b4_5) isa Q;
-      (start: $b4_5, end: $b5_5) isa Q;
-      (start: $b5_5, end: $b6_5) isa Q;
+      Q (start: $b1_5, end: $b2_5);
+      Q (start: $b2_5, end: $b3_5);
+      Q (start: $b3_5, end: $b4_5);
+      Q (start: $b4_5, end: $b5_5);
+      Q (start: $b5_5, end: $b6_5);
 
-      (start: $b1_6, end: $b2_6) isa Q;
-      (start: $b2_6, end: $b3_6) isa Q;
-      (start: $b3_6, end: $b4_6) isa Q;
-      (start: $b4_6, end: $b5_6) isa Q;
-      (start: $b5_6, end: $b6_6) isa Q;
+      Q (start: $b1_6, end: $b2_6);
+      Q (start: $b2_6, end: $b3_6);
+      Q (start: $b3_6, end: $b4_6);
+      Q (start: $b4_6, end: $b5_6);
+      Q (start: $b5_6, end: $b6_6);
 
-      (start: $b1_7, end: $b2_7) isa Q;
-      (start: $b2_7, end: $b3_7) isa Q;
-      (start: $b3_7, end: $b4_7) isa Q;
-      (start: $b4_7, end: $b5_7) isa Q;
-      (start: $b5_7, end: $b6_7) isa Q;
+      Q (start: $b1_7, end: $b2_7);
+      Q (start: $b2_7, end: $b3_7);
+      Q (start: $b3_7, end: $b4_7);
+      Q (start: $b4_7, end: $b5_7);
+      Q (start: $b5_7, end: $b6_7);
 
-      (start: $b1_8, end: $b2_8) isa Q;
-      (start: $b2_8, end: $b3_8) isa Q;
-      (start: $b3_8, end: $b4_8) isa Q;
-      (start: $b4_8, end: $b5_8) isa Q;
-      (start: $b5_8, end: $b6_8) isa Q;
+      Q (start: $b1_8, end: $b2_8);
+      Q (start: $b2_8, end: $b3_8);
+      Q (start: $b3_8, end: $b4_8);
+      Q (start: $b4_8, end: $b5_8);
+      Q (start: $b5_8, end: $b6_8);
 
-      (start: $b1_9, end: $b2_9) isa Q;
-      (start: $b2_9, end: $b3_9) isa Q;
-      (start: $b3_9, end: $b4_9) isa Q;
-      (start: $b4_9, end: $b5_9) isa Q;
-      (start: $b5_9, end: $b6_9) isa Q;
+      Q (start: $b1_9, end: $b2_9);
+      Q (start: $b2_9, end: $b3_9);
+      Q (start: $b3_9, end: $b4_9);
+      Q (start: $b4_9, end: $b5_9);
+      Q (start: $b5_9, end: $b6_9);
 
-      (start: $b1_10, end: $b2_10) isa Q;
-      (start: $b2_10, end: $b3_10) isa Q;
-      (start: $b3_10, end: $b4_10) isa Q;
-      (start: $b4_10, end: $b5_10) isa Q;
-      (start: $b5_10, end: $b6_10) isa Q;
+      Q (start: $b1_10, end: $b2_10);
+      Q (start: $b2_10, end: $b3_10);
+      Q (start: $b3_10, end: $b4_10);
+      Q (start: $b4_10, end: $b5_10);
+      Q (start: $b5_10, end: $b6_10);
       """
     Given transaction commits
 
@@ -1549,9 +1549,9 @@ Feature: Recursive Function Execution
       fun p_pairs() -> { entity2, entity2 }:
       match
       $x isa entity2; $y isa entity2;
-      { (start: $x, end: $y) isa Q; } or
+      { Q (start: $x, end: $y); } or
       {
-        (start: $x, end: $z) isa Q;
+        Q (start: $x, end: $z);
         let $z, $y1 in p_pairs();
         $y is $y1;
       };
@@ -1566,9 +1566,9 @@ Feature: Recursive Function Execution
       fun p_directed($x: entity2) -> {entity2 }:
       match
       $x isa entity2; $y isa entity2;
-      { (start: $x, end: $y) isa Q; } or
+      { Q (start: $x, end: $y); } or
       {
-        (start: $x, end: $z) isa Q;
+        Q (start: $x, end: $z);
         let $y1 in p_directed($z);
         $y is $y1;
       };
@@ -1619,58 +1619,58 @@ Feature: Recursive Function Execution
       $a5_4 isa a-entity, has index "a5_4";
       $a5_5 isa a-entity, has index "a5_5";
 
-      (start: $a, end: $a1_1) isa Q;
+      Q (start: $a, end: $a1_1);
 
       # (start: $a{i}_{j}, end: $a{i+1}_{j}) isa Q; for 1 <= i < n; for 1 <= j <= m
-      (start: $a1_1, end: $a2_1) isa Q;
-      (start: $a1_2, end: $a2_2) isa Q;
-      (start: $a1_3, end: $a2_3) isa Q;
-      (start: $a1_4, end: $a2_4) isa Q;
-      (start: $a1_5, end: $a2_5) isa Q;
+      Q (start: $a1_1, end: $a2_1);
+      Q (start: $a1_2, end: $a2_2);
+      Q (start: $a1_3, end: $a2_3);
+      Q (start: $a1_4, end: $a2_4);
+      Q (start: $a1_5, end: $a2_5);
 
-      (start: $a2_1, end: $a3_1) isa Q;
-      (start: $a2_2, end: $a3_2) isa Q;
-      (start: $a2_3, end: $a3_3) isa Q;
-      (start: $a2_4, end: $a3_4) isa Q;
-      (start: $a2_5, end: $a3_5) isa Q;
+      Q (start: $a2_1, end: $a3_1);
+      Q (start: $a2_2, end: $a3_2);
+      Q (start: $a2_3, end: $a3_3);
+      Q (start: $a2_4, end: $a3_4);
+      Q (start: $a2_5, end: $a3_5);
 
-      (start: $a3_1, end: $a4_1) isa Q;
-      (start: $a3_2, end: $a4_2) isa Q;
-      (start: $a3_3, end: $a4_3) isa Q;
-      (start: $a3_4, end: $a4_4) isa Q;
-      (start: $a3_5, end: $a4_5) isa Q;
+      Q (start: $a3_1, end: $a4_1);
+      Q (start: $a3_2, end: $a4_2);
+      Q (start: $a3_3, end: $a4_3);
+      Q (start: $a3_4, end: $a4_4);
+      Q (start: $a3_5, end: $a4_5);
 
-      (start: $a4_1, end: $a5_1) isa Q;
-      (start: $a4_2, end: $a5_2) isa Q;
-      (start: $a4_3, end: $a5_3) isa Q;
-      (start: $a4_4, end: $a5_4) isa Q;
-      (start: $a4_5, end: $a5_5) isa Q;
+      Q (start: $a4_1, end: $a5_1);
+      Q (start: $a4_2, end: $a5_2);
+      Q (start: $a4_3, end: $a5_3);
+      Q (start: $a4_4, end: $a5_4);
+      Q (start: $a4_5, end: $a5_5);
 
       # (start: $a{i}_{j}, end: $a{i}_{j+1}) isa Q; for 1 <= i <= n; for 1 <= j < m
-      (start: $a1_1, end: $a1_2) isa Q;
-      (start: $a1_2, end: $a1_3) isa Q;
-      (start: $a1_3, end: $a1_4) isa Q;
-      (start: $a1_4, end: $a1_5) isa Q;
+      Q (start: $a1_1, end: $a1_2);
+      Q (start: $a1_2, end: $a1_3);
+      Q (start: $a1_3, end: $a1_4);
+      Q (start: $a1_4, end: $a1_5);
 
-      (start: $a2_1, end: $a2_2) isa Q;
-      (start: $a2_2, end: $a2_3) isa Q;
-      (start: $a2_3, end: $a2_4) isa Q;
-      (start: $a2_4, end: $a2_5) isa Q;
+      Q (start: $a2_1, end: $a2_2);
+      Q (start: $a2_2, end: $a2_3);
+      Q (start: $a2_3, end: $a2_4);
+      Q (start: $a2_4, end: $a2_5);
 
-      (start: $a3_1, end: $a3_2) isa Q;
-      (start: $a3_2, end: $a3_3) isa Q;
-      (start: $a3_3, end: $a3_4) isa Q;
-      (start: $a3_4, end: $a3_5) isa Q;
+      Q (start: $a3_1, end: $a3_2);
+      Q (start: $a3_2, end: $a3_3);
+      Q (start: $a3_3, end: $a3_4);
+      Q (start: $a3_4, end: $a3_5);
 
-      (start: $a4_1, end: $a4_2) isa Q;
-      (start: $a4_2, end: $a4_3) isa Q;
-      (start: $a4_3, end: $a4_4) isa Q;
-      (start: $a4_4, end: $a4_5) isa Q;
+      Q (start: $a4_1, end: $a4_2);
+      Q (start: $a4_2, end: $a4_3);
+      Q (start: $a4_3, end: $a4_4);
+      Q (start: $a4_4, end: $a4_5);
 
-      (start: $a5_1, end: $a5_2) isa Q;
-      (start: $a5_2, end: $a5_3) isa Q;
-      (start: $a5_3, end: $a5_4) isa Q;
-      (start: $a5_4, end: $a5_5) isa Q;
+      Q (start: $a5_1, end: $a5_2);
+      Q (start: $a5_2, end: $a5_3);
+      Q (start: $a5_3, end: $a5_4);
+      Q (start: $a5_4, end: $a5_5);
       """
     Given transaction commits
 

--- a/query/functions/signature.feature
+++ b/query/functions/signature.feature
@@ -141,14 +141,14 @@ Feature: Validate Function Signatures Against Definition & Calls
     Then typeql read query; fails
     """
     match
-      $name = "Socks";
-      $cat in cats_of_name($name);
+      let $name = "Socks";
+      let $cat in cats_of_name($name);
     """
     Then typeql read query; fails
     """
     match
       $name isa breed;
-      $cat in cats_of_name($name);
+      let $cat in cats_of_name($name);
     """
 
 
@@ -162,7 +162,7 @@ Feature: Validate Function Signatures Against Definition & Calls
     match
       $name_attr isa name;
       $cat isa cat, has $name_attr;
-      $name = $name_attr;
+      let $name = $name_attr;
     return { $name };
     """
     Given transaction commits
@@ -170,7 +170,7 @@ Feature: Validate Function Signatures Against Definition & Calls
     Then typeql read query; fails
     """
     match
-      $name in name_string_of_cat($cat);
+      let $name in name_string_of_cat($cat);
       $name isa name;
       $other-cat has $name;
     """
@@ -193,7 +193,7 @@ Feature: Validate Function Signatures Against Definition & Calls
     """
     match
       $name isa breed;
-      $cat in cats_of_name($name);
+      let $cat in cats_of_name($name);
     """
 
 
@@ -213,7 +213,7 @@ Feature: Validate Function Signatures Against Definition & Calls
     Then typeql read query; fails
     """
     match
-      $name in name_attribute_of_cat($cat);
+      let $name in name_attribute_of_cat($cat);
       $name isa breed;
     """
 

--- a/query/functions/signature.feature
+++ b/query/functions/signature.feature
@@ -19,7 +19,7 @@ Feature: Validate Function Signatures Against Definition & Calls
     entity person, owns name, owns nationality;
     entity cat, owns name, owns breed;
     attribute name, value string;
-    attribute nationality, value long;
+    attribute nationality, value integer;
     attribute breed, value string;
     """
     Given transaction commits

--- a/query/functions/structure.feature
+++ b/query/functions/structure.feature
@@ -21,8 +21,8 @@ Feature: Function Body Structure
         owns age @card(0..),
         owns ref @key;
       attribute name value string;
-      attribute age @independent, value long;
-      attribute ref value long;
+      attribute age @independent, value integer;
+      attribute ref value integer;
       """
     Given transaction commits
 
@@ -117,7 +117,7 @@ Feature: Function Body Structure
     Given typeql schema query
       """
       define
-      fun sum_all_ages() -> { long }:
+      fun sum_all_ages() -> { integer }:
       match
         $p isa person, has age $age;
       reduce $sum_ages = sum($age);
@@ -132,7 +132,7 @@ Feature: Function Body Structure
     """
     Then uniquely identify answer concepts
       | sum_ages      |
-      | value:long:42 |
+      | value:integer:42 |
 
 
   Scenario: A function may not have write stages in the body

--- a/query/functions/structure.feature
+++ b/query/functions/structure.feature
@@ -54,7 +54,7 @@ Feature: Function Body Structure
     Given connection open read transaction for database: typedb
     Given get answers of typeql read query
     """
-    match $p in alice_or_bob();
+    match let $p in alice_or_bob();
     """
     Then uniquely identify answer concepts
      | p         |
@@ -78,7 +78,7 @@ Feature: Function Body Structure
     Given connection open read transaction for database: typedb
     Given get answers of typeql read query
     """
-    match $p in not_alice_or_bob();
+    match let $p in not_alice_or_bob();
     """
     Then uniquely identify answer concepts
       | p         |
@@ -104,7 +104,7 @@ Feature: Function Body Structure
     Given connection open read transaction for database: typedb
     Given get answers of typeql read query
     """
-    match $age in second_and_third_largest_ages();
+    match let $age in second_and_third_largest_ages();
     """
     Then order of answer concepts is
       | age         |
@@ -128,7 +128,7 @@ Feature: Function Body Structure
     Given connection open read transaction for database: typedb
     Given get answers of typeql read query
     """
-    match $sum_ages in sum_all_ages();
+    match let $sum_ages in sum_all_ages();
     """
     Then uniquely identify answer concepts
       | sum_ages      |

--- a/query/functions/usage.feature
+++ b/query/functions/usage.feature
@@ -29,7 +29,7 @@ Feature: Function Usage
     define
     fun five() -> long :
     match
-      $five = 5;
+      let $five = 5;
     return first $five;
     """
     Given transaction commits
@@ -37,7 +37,7 @@ Feature: Function Usage
     When get answers of typeql read query
     """
     match
-      $six = five() + 1;
+      let $six = five() + 1;
     """
     Then uniquely identify answer concepts
       | six          |
@@ -52,12 +52,12 @@ Feature: Function Usage
     define
     fun five() -> long :
     match
-      $five = 5;
+      let $five = 5;
     return first $five;
 
     fun six() -> long :
     match
-      $six = 6;
+      let $six = 6;
     return first $six;
     """
     Given transaction commits
@@ -95,7 +95,7 @@ Feature: Function Usage
     define
     fun five() -> long :
     match
-      $five = 5;
+      let $five = 5;
     return first $five;
     """
     Given transaction commits
@@ -103,7 +103,7 @@ Feature: Function Usage
     When get answers of typeql read query
     """
     match
-      $ten = five() + five();
+      let $ten = five() + five();
     """
     Then uniquely identify answer concepts
       | ten           |
@@ -118,7 +118,7 @@ Feature: Function Usage
     define
     fun five() -> long :
     match
-      $five = 5;
+      let $five = 5;
     return first $five;
     """
     Given transaction commits
@@ -126,7 +126,7 @@ Feature: Function Usage
     When typeql read query; fails
     """
     match
-      $five = five();
-      $five = five();
+      let $five = five();
+      let $five = five();
     """
 

--- a/query/functions/usage.feature
+++ b/query/functions/usage.feature
@@ -27,7 +27,7 @@ Feature: Function Usage
     Given typeql schema query
     """
     define
-    fun five() -> long :
+    fun five() -> integer :
     match
       let $five = 5;
     return first $five;
@@ -41,7 +41,7 @@ Feature: Function Usage
     """
     Then uniquely identify answer concepts
       | six          |
-      | value:long:6 |
+      | value:integer:6 |
     Given transaction closes
 
 
@@ -50,12 +50,12 @@ Feature: Function Usage
     Given typeql schema query
     """
     define
-    fun five() -> long :
+    fun five() -> integer :
     match
       let $five = 5;
     return first $five;
 
-    fun six() -> long :
+    fun six() -> integer :
     match
       let $six = 6;
     return first $six;
@@ -93,7 +93,7 @@ Feature: Function Usage
     Given typeql schema query
     """
     define
-    fun five() -> long :
+    fun five() -> integer :
     match
       let $five = 5;
     return first $five;
@@ -107,7 +107,7 @@ Feature: Function Usage
     """
     Then uniquely identify answer concepts
       | ten           |
-      | value:long:10 |
+      | value:integer:10 |
     Given transaction closes
 
 
@@ -116,7 +116,7 @@ Feature: Function Usage
     Given typeql schema query
     """
     define
-    fun five() -> long :
+    fun five() -> integer :
     match
       let $five = 5;
     return first $five;

--- a/query/language/define.feature
+++ b/query/language/define.feature
@@ -944,7 +944,7 @@ Feature: TypeQL Define Query
     Then answer size is: 1
     Examples:
       | value-type  | label              |
-      | long        | number-of-cows     |
+      | integer        | number-of-cows     |
       | string      | favourite-food     |
       | boolean     | can-fly            |
       | double      | density            |
@@ -966,7 +966,7 @@ Feature: TypeQL Define Query
     When typeql schema query
       """
       define
-      number-of value long;
+      number-of value integer;
       number-of @abstract;
       number-of-cows @abstract;
       number-of-cows sub number-of;
@@ -1080,21 +1080,21 @@ Feature: TypeQL Define Query
     When connection open schema transaction for database: typedb
     Then typeql schema query; fails
       """
-      define attribute code-name sub name, value long;
+      define attribute code-name sub name, value integer;
       """
     When transaction closes
 
     When connection open schema transaction for database: typedb
     When typeql schema query
       """
-      define attribute code-name sub name; attribute code-name-2 value long;
+      define attribute code-name sub name; attribute code-name-2 value integer;
       """
     When transaction commits
 
     When connection open schema transaction for database: typedb
     Then typeql schema query; fails
       """
-      define attribute code-name value long;
+      define attribute code-name value integer;
       """
     When transaction closes
 
@@ -1125,7 +1125,7 @@ Feature: TypeQL Define Query
     Examples:
       | value_type | label             |
       | boolean    | is-sleeping       |
-      | long       | number-of-fingers |
+      | integer       | number-of-fingers |
       | double     | height            |
       | string     | first-word        |
       | datetime   | graduation-date   |
@@ -1134,7 +1134,7 @@ Feature: TypeQL Define Query
   Scenario: defining an attribute type value when a different value is already defined errors
     Then typeql schema query; fails with a message containing: "different 'name value string' is already defined"
       """
-      define name value long;
+      define name value integer;
       """
 
   ###########
@@ -1453,7 +1453,7 @@ Feature: TypeQL Define Query
     Examples:
       | annotation                                            | value-type          |
       | regex("A")                                            | , value bool        |
-      | regex("A")                                            | , value long        |
+      | regex("A")                                            | , value integer        |
       | regex("A")                                            | , value double      |
       | regex("A")                                            | , value decimal     |
       | regex("A")                                            | , value date        |
@@ -1464,8 +1464,8 @@ Feature: TypeQL Define Query
 
       | range("A".."B")                                       |                     |
       | range(1..2)                                           |                     |
-      | range("A".."B")                                       | , value long        |
-      | range("P1Y2M3DT4H5M6.788S".."P1Y2M3DT4H5M6.789S")     | , value long        |
+      | range("A".."B")                                       | , value integer        |
+      | range("P1Y2M3DT4H5M6.788S".."P1Y2M3DT4H5M6.789S")     | , value integer        |
       | range("A".."B")                                       | , value datetime    |
       | range(1..2)                                           | , value datetime    |
       | range(1..2)                                           | , value string      |
@@ -1479,13 +1479,13 @@ Feature: TypeQL Define Query
       | values("A")                                           |                     |
       | values(false)                                         |                     |
       | values(0)                                             |                     |
-      | values("A", 2)                                        | , value long        |
-      | values("A", "B")                                      | , value long        |
-      | values(0.1)                                           | , value long        |
-      | values("string")                                      | , value long        |
-      | values(true)                                          | , value long        |
-      | values(2024-06-04)                                    | , value long        |
-      | values(2024-06-04T00:00:00+0010)                      | , value long        |
+      | values("A", 2)                                        | , value integer        |
+      | values("A", "B")                                      | , value integer        |
+      | values(0.1)                                           | , value integer        |
+      | values("string")                                      | , value integer        |
+      | values(true)                                          | , value integer        |
+      | values(2024-06-04)                                    | , value integer        |
+      | values(2024-06-04T00:00:00+0010)                      | , value integer        |
       | values("string")                                      | , value double      |
       | values(true)                                          | , value double      |
       | values(2024-06-04)                                    | , value double      |
@@ -1540,7 +1540,7 @@ Feature: TypeQL Define Query
       """
     Examples:
       | arg0                     | arg1                     | value-type  |
-      | 1                        | 2                        | long        |
+      | 1                        | 2                        | integer        |
       | 112.2                    | 134.3                    | double      |
       | 124.4                    | 124.0                    | decimal     |
       | false                    | true                     | boolean     |
@@ -1671,7 +1671,7 @@ Feature: TypeQL Define Query
     Examples:
       | annotation                                            | value-type  |
       | regex("A")                                            | bool        |
-      | regex("A")                                            | long        |
+      | regex("A")                                            | integer        |
       | regex("A")                                            | double      |
       | regex("A")                                            | decimal     |
       | regex("A")                                            | date        |
@@ -1679,8 +1679,8 @@ Feature: TypeQL Define Query
       | regex("A")                                            | datetime-tz |
       | regex("A")                                            | duration    |
 
-      | range("A".."B")                                       | long        |
-      | range("P1Y2M3DT4H5M6.788S".."P1Y2M3DT4H5M6.789S")     | long        |
+      | range("A".."B")                                       | integer        |
+      | range("P1Y2M3DT4H5M6.788S".."P1Y2M3DT4H5M6.789S")     | integer        |
       | range("A".."B")                                       | datetime    |
       | range(1..2)                                           | datetime    |
       | range(1..2)                                           | string      |
@@ -1690,13 +1690,13 @@ Feature: TypeQL Define Query
       | range(2024-06-04T16:35:02.10..2024-06-04T16:35:03.11) | date        |
       | range("P1Y2M3DT4H5M6.788S".."P1Y2M3DT4H5M6.789S")     | date        |
 
-      | values("A", 2)                                        | long        |
-      | values("A", "B")                                      | long        |
-      | values(0.1)                                           | long        |
-      | values("string")                                      | long        |
-      | values(true)                                          | long        |
-      | values(2024-06-04)                                    | long        |
-      | values(2024-06-04T00:00:00+0010)                      | long        |
+      | values("A", 2)                                        | integer        |
+      | values("A", "B")                                      | integer        |
+      | values(0.1)                                           | integer        |
+      | values("string")                                      | integer        |
+      | values(true)                                          | integer        |
+      | values(2024-06-04)                                    | integer        |
+      | values(2024-06-04T00:00:00+0010)                      | integer        |
       | values("string")                                      | double      |
       | values(true)                                          | double      |
       | values(2024-06-04)                                    | double      |
@@ -1761,7 +1761,7 @@ Feature: TypeQL Define Query
       """
     Examples:
       | arg0                     | arg1                     | value-type  |
-      | 1                        | 2                        | long        |
+      | 1                        | 2                        | integer        |
       | 112.2                    | 134.3                    | double      |
       | 124.4                    | 124.0                    | decimal     |
       | false                    | true                     | boolean     |
@@ -2276,7 +2276,7 @@ Feature: TypeQL Define Query
   Scenario: an abstract attribute type can be defined
     When typeql schema query
       """
-      define attribute number-of-limbs @abstract, value long;
+      define attribute number-of-limbs @abstract, value integer;
       """
     Then transaction commits
 
@@ -2295,7 +2295,7 @@ Feature: TypeQL Define Query
     When typeql schema query
       """
       define
-      attribute number-of-limbs @abstract, value long;
+      attribute number-of-limbs @abstract, value integer;
       attribute number-of-legs sub number-of-limbs;
       """
     Then transaction commits
@@ -2315,7 +2315,7 @@ Feature: TypeQL Define Query
     When typeql schema query
       """
       define
-      attribute number-of-limbs @abstract, value long;
+      attribute number-of-limbs @abstract, value integer;
       attribute number-of-artificial-limbs @abstract, sub number-of-limbs;
       """
     Then transaction commits
@@ -2612,7 +2612,7 @@ Feature: TypeQL Define Query
   Scenario: Defining an attribute type multiple times succeeds if and only if the value type remains unchanged
     Then typeql schema query; fails
       """
-      define attribute name value long;
+      define attribute name value integer;
       """
     Given transaction closes
     Given connection open schema transaction for database: typedb
@@ -2671,7 +2671,7 @@ Feature: TypeQL Define Query
   Scenario: a regex constraint can not be added to an existing attribute type whose value type isn't 'string'
     Given typeql schema query
       """
-      define attribute house-number value long;
+      define attribute house-number value integer;
       """
     Given transaction commits
 
@@ -2699,13 +2699,13 @@ Feature: TypeQL Define Query
   Scenario: the value type of an existing attribute type is not modifiable through define
     Then typeql schema query; fails
       """
-      define name value long;
+      define name value integer;
       """
     Given transaction closes
     Given connection open schema transaction for database: typedb
     Then typeql schema query; fails
       """
-      define attribute name value long;
+      define attribute name value integer;
       """
 
   Scenario: an attribute ownership can be converted to a key ownership
@@ -2952,7 +2952,7 @@ Feature: TypeQL Define Query
   Scenario: a concrete attribute type can be converted to an abstract attribute type
     When typeql schema query
       """
-      define attribute age value long;
+      define attribute age value integer;
       """
     Then transaction commits
     Given connection open schema transaction for database: typedb
@@ -3217,7 +3217,7 @@ Feature: TypeQL Define Query
     """
        define
        entity person owns mobile;
-       attribute mobile value long;
+       attribute mobile value integer;
        entity child sub person;
       """
     Given transaction commits
@@ -3240,7 +3240,7 @@ Feature: TypeQL Define Query
       """
       define
       entity child sub person;
-      attribute phone-number value long;
+      attribute phone-number value integer;
       entity person owns phone-number @key;
       """
     Given transaction commits

--- a/query/language/define.feature
+++ b/query/language/define.feature
@@ -2514,8 +2514,8 @@ Feature: TypeQL Define Query
       insert
       $x isa product, has name "Cheese", has barcode "10001";
       $y isa product, has name "Ham", has barcode "10011";
-      $a "Milk" isa name;
-      $b "11111" isa barcode;
+      $a isa name "Milk";
+      $b isa barcode "11111";
       """
     Given transaction commits
 

--- a/query/language/delete.feature
+++ b/query/language/delete.feature
@@ -32,7 +32,7 @@ Feature: TypeQL Delete Query
         owns ref @key;
       attribute name, value string;
       attribute email, value string;
-      attribute ref, value long;
+      attribute ref, value integer;
       """
     Given transaction commits
 
@@ -893,7 +893,7 @@ Feature: TypeQL Delete Query
     Given typeql schema query
       """
       define
-      attribute age, value long;
+      attribute age, value integer;
       person owns age;
       """
     Given transaction commits
@@ -1023,7 +1023,7 @@ Feature: TypeQL Delete Query
     Given typeql schema query
       """
       define
-      attribute duration, value long;
+      attribute duration, value integer;
       friendship owns duration;
       """
     Given transaction commits
@@ -1069,7 +1069,7 @@ Feature: TypeQL Delete Query
     Given typeql schema query
       """
       define
-      attribute duration, value long;
+      attribute duration, value integer;
       friendship owns duration;
       """
     Given transaction commits

--- a/query/language/expression.feature
+++ b/query/language/expression.feature
@@ -22,9 +22,9 @@ Feature: TypeQL Get Query with Expressions
         owns height,
         owns weight;
       name sub attribute, value string;
-      age sub attribute, value long;
-      height sub attribute, value long;
-      weight sub attribute, value long;
+      age sub attribute, value integer;
+      height sub attribute, value integer;
+      weight sub attribute, value integer;
 
       limit-double sub attribute, value double;
       """
@@ -171,7 +171,7 @@ Feature: TypeQL Get Query with Expressions
       """
     Then uniquely identify answer concepts
       | x            | const           | plus-negative  | minus-negative  |
-      | attr:age:16  | value:long:-10  | value:long:6   | value:long:26   |
+      | attr:age:16  | value:integer:-10  | value:integer:6   | value:integer:26   |
 
 
   Scenario: Test operator definitions
@@ -202,7 +202,7 @@ Feature: TypeQL Get Query with Expressions
       """
     Then uniquely identify answer concepts
       | a             | b            | c             | d                  |
-      | value:long: 9 | value:long:3 | value:long:18 | value:double: 2.0  |
+      | value:integer: 9 | value:integer:3 | value:integer:18 | value:double: 2.0  |
 
     When get answers of typeql read query
     """
@@ -247,7 +247,7 @@ Feature: TypeQL Get Query with Expressions
       """
     Then uniquely identify answer concepts
       | a             | b             |
-      | value:long: 1 | value:long: 2 |
+      | value:integer: 1 | value:integer: 2 |
 
     When get answers of typeql read query
     """
@@ -259,7 +259,7 @@ Feature: TypeQL Get Query with Expressions
       """
     Then uniquely identify answer concepts
       | a             | b                 |
-      | value:long: 1 | value:double: 0.5 |
+      | value:integer: 1 | value:double: 0.5 |
 
     When get answers of typeql read query
     """
@@ -271,7 +271,7 @@ Feature: TypeQL Get Query with Expressions
       """
     Then uniquely identify answer concepts
       | a             | b              |
-      | value:long: 2 | value:long: -5 |
+      | value:integer: 2 | value:integer: -5 |
 
 
 

--- a/query/language/fetch.feature
+++ b/query/language/fetch.feature
@@ -226,7 +226,7 @@ Feature: TypeQL Fetch Query
       """
       match
       $a isa name;
-      $v = $a;
+      let $v = $a;
       fetch {
         "value": $v,
         "attribute": $a
@@ -790,7 +790,7 @@ Feature: TypeQL Fetch Query
       """
       match
         $_ isa collection, has $a;
-        $v = $a;
+        let $v = $a;
       fetch {
         "v": $v
       };
@@ -1235,7 +1235,7 @@ Feature: TypeQL Fetch Query
         "first": $t,
         "second": [
           match
-            $v = $n;
+            let $v = $n;
           fetch {
             "first": $n,
             "second": $v
@@ -1295,8 +1295,8 @@ Feature: TypeQL Fetch Query
         "subquery": [
           match
             $p has person-name $pn;
-            $nv = $n;
-            $pnv = $pn;
+            let $nv = $n;
+            let $pnv = $pn;
             not { $nv == $pnv; };
           sort $nv;
           select $pnv;
@@ -1327,7 +1327,7 @@ Feature: TypeQL Fetch Query
       fetch {
         "subquery": [
           match
-            $v = $n;
+            let $v = $n;
         ]
       };
       """
@@ -1373,8 +1373,8 @@ Feature: TypeQL Fetch Query
         "subquery": [
           match
             $p has person-name $pn;
-            $nv = $n;
-            $pnv = $pn;
+            let $nv = $n;
+            let $pnv = $pn;
             not { $nv == $pnv; };
           sort $nv;
           select $pnv;
@@ -1390,8 +1390,8 @@ Feature: TypeQL Fetch Query
         "subquery": [
           match
             $p has person-name $pn;
-            $nv = $n;
-            $pnv = $pn;
+            let $nv = $n;
+            let $pnv = $pn;
             not { $nv == $pnv; };
           insert
             $p has person-name "Paul";
@@ -1406,8 +1406,8 @@ Feature: TypeQL Fetch Query
         "subquery": [
           match
             $p has person-name $pn;
-            $nv = $n;
-            $pnv = $pn;
+            let $nv = $n;
+            let $pnv = $pn;
             not { $nv == $pnv; };
           insert
             $p has person-name "Paul";
@@ -1425,8 +1425,8 @@ Feature: TypeQL Fetch Query
         "subquery": [
           match
             $p has person-name $pn;
-            $nv = $n;
-            $pnv = $pn;
+            let $nv = $n;
+            let $pnv = $pn;
             not { $nv == $pnv; };
           define
             person-name @card(0..99);
@@ -1442,8 +1442,8 @@ Feature: TypeQL Fetch Query
         "subquery": [
           match
             $p has person-name $pn;
-            $nv = $n;
-            $pnv = $pn;
+            let $nv = $n;
+            let $pnv = $pn;
             not { $nv == $pnv; };
           define
             person-name @card(0..99);
@@ -1541,7 +1541,7 @@ Feature: TypeQL Fetch Query
 
         match
           $p isa person;
-          $z in get_names($p);
+          let $z in get_names($p);
       """
     Given answer size is: 3
     Given uniquely identify answer concepts
@@ -1560,7 +1560,7 @@ Feature: TypeQL Fetch Query
 
         match
           $p isa person;
-          $z in get_age($p);
+          let $z in get_age($p);
       """
     Given answer size is: 1
     Given uniquely identify answer concepts
@@ -1670,13 +1670,13 @@ Feature: TypeQL Fetch Query
         fun get_names($p_arg: person) -> { string }:
         match
           $p_arg has person-name $name;
-          $value = $name;
+          let $value = $name;
         sort $value;
         return { $value };
 
         match
           $p isa person;
-          $z in get_names($p);
+          let $z in get_names($p);
       """
     Given answer size is: 3
     Given uniquely identify answer concepts
@@ -1691,12 +1691,12 @@ Feature: TypeQL Fetch Query
         fun get_age($p_arg: person) -> { long }:
         match
           $p_arg has age $age;
-          $value = $age;
+          let $value = $age;
         return { $value };
 
         match
           $p isa person;
-          $z in get_age($p);
+          let $z in get_age($p);
       """
     Given answer size is: 1
     Given uniquely identify answer concepts
@@ -1709,7 +1709,7 @@ Feature: TypeQL Fetch Query
         fun get_name($p_arg: person) -> string:
         match
           $p_arg has person-name $name;
-          $value = $name;
+          let $value = $name;
         sort $value;
         return first $value;
 
@@ -1739,7 +1739,7 @@ Feature: TypeQL Fetch Query
         fun get_name($p_arg: person) -> string:
         match
           $p_arg has person-name $name;
-          $value = $name;
+          let $value = $name;
         sort $value;
         return last $value;
 
@@ -1747,7 +1747,7 @@ Feature: TypeQL Fetch Query
         fun get_age($p_arg: person) -> long:
         match
           $p_arg has age $age;
-          $value = $age;
+          let $value = $age;
         return first $value;
 
         match
@@ -1779,7 +1779,7 @@ Feature: TypeQL Fetch Query
         fun get_age($p_arg: person) -> long:
         match
           $p_arg has age $age;
-          $value = $age;
+          let $value = $age;
         return first $value;
 
         match
@@ -1929,7 +1929,7 @@ Feature: TypeQL Fetch Query
         fetch {
           "name value": match
             $p has person-name $name;
-            $v = $name;
+            let $v = $name;
             sort $v;
             return first $v;
         };
@@ -1956,13 +1956,13 @@ Feature: TypeQL Fetch Query
           "name value": (
             match
               $p has person-name $name;
-              $v = $name;
+              let $v = $name;
               sort $v;
               return last $v;
           ),
           "age value": match
             $p has age $age;
-            $v = $age;
+            let $v = $age;
             return first $v;
         };
       """
@@ -1989,7 +1989,7 @@ Feature: TypeQL Fetch Query
         fetch {
           "age value": match
             $p has age $age;
-            $v = $age;
+            let $v = $age;
             return first $v;
         };
       """
@@ -2058,7 +2058,7 @@ Feature: TypeQL Fetch Query
 
         match
           $p isa person;
-          $x, $y, $z in get_info($p);
+          let $x, $y, $z in get_info($p);
       """
     Given answer size is: 2
     Given uniquely identify answer concepts
@@ -2268,7 +2268,7 @@ Feature: TypeQL Fetch Query
 #        fun get_karma($p_arg: person) -> double:
 #        match
 #            $p_arg has karma $k;
-#            $v = $k;
+#            let $v = $k;
 #        return first $v;
 #
 #        match
@@ -2306,7 +2306,7 @@ Feature: TypeQL Fetch Query
 
         match
           $p isa person;
-          $z in get_names($p);
+          let $z in get_names($p);
       """
     Given answer size is: 3
     Given uniquely identify answer concepts
@@ -2325,7 +2325,7 @@ Feature: TypeQL Fetch Query
 
         match
           $p isa person;
-          $z in get_ages($p);
+          let $z in get_ages($p);
       """
     Given answer size is: 1
     Given uniquely identify answer concepts
@@ -2396,12 +2396,12 @@ Feature: TypeQL Fetch Query
         fun get_names($p_arg: person) -> { string }:
         match
           $p_arg has person-name $name;
-          $v = $name;
+          let $v = $name;
         return { $v };
 
         match
           $p isa person;
-          $z in get_names($p);
+          let $z in get_names($p);
       """
     Given answer size is: 3
     Given uniquely identify answer concepts
@@ -2416,12 +2416,12 @@ Feature: TypeQL Fetch Query
         fun get_ages($p_arg: person) -> { long }:
         match
           $p_arg has age $age;
-          $v = $age;
+          let $v = $age;
         return { $v };
 
         match
           $p isa person;
-          $z in get_ages($p);
+          let $z in get_ages($p);
       """
     Given answer size is: 1
     Given uniquely identify answer concepts
@@ -2434,7 +2434,7 @@ Feature: TypeQL Fetch Query
         fun get_names($p_arg: person) -> { string }:
         match
           $p_arg has person-name $name;
-          $v = $name;
+          let $v = $name;
         return { $v };
 
         match
@@ -2463,7 +2463,7 @@ Feature: TypeQL Fetch Query
         fun get_ages($p_arg: person) -> { long }:
         match
           $p_arg has age $age;
-          $v = $age;
+          let $v = $age;
         return { $v };
 
         match
@@ -2648,7 +2648,7 @@ Feature: TypeQL Fetch Query
           "names": [
             match
               $p has person-name $name;
-              $v = $name;
+              let $v = $name;
               return { $v };
           ]
         };
@@ -2675,13 +2675,13 @@ Feature: TypeQL Fetch Query
           "names": [
             match
               $p has person-name $name;
-              $v = $name;
+              let $v = $name;
               return { $v };
           ],
           "ages": [
             match
               $p has age $age;
-              $v = $age;
+              let $v = $age;
               return { $v };
           ]
         };
@@ -2710,7 +2710,7 @@ Feature: TypeQL Fetch Query
           "ages": [
             match
               $p has age $age;
-              $v = $age;
+              let $v = $age;
               return { $v };
           ]
         };
@@ -2856,8 +2856,8 @@ Feature: TypeQL Fetch Query
     When get answers of typeql write query
       """
       match
-        $n = "John";
-        $pn = "Johnny";
+        let $n = "John";
+        let $pn = "Johnny";
       insert
         $p isa person, has person-name == $n, has person-name == $pn, has ref 66;
       fetch {
@@ -2878,8 +2878,8 @@ Feature: TypeQL Fetch Query
     When get answers of typeql write query
       """
       insert
-        $n "John" isa person-name;
-        $pn "Jon" isa person-name;
+        $n isa person-name "John";
+        $pn isa person-name "Jon";
         $p isa person, has $n, has $pn, has ref 77;
       fetch {
         "name": $n,

--- a/query/language/fetch.feature
+++ b/query/language/fetch.feature
@@ -45,9 +45,9 @@ Feature: TypeQL Fetch Query
       attribute person-name sub name;
       attribute company-name sub name;
       attribute description, value string;
-      attribute age value long;
+      attribute age value integer;
       attribute karma value double;
-      attribute ref value long;
+      attribute ref value integer;
       attribute start-date value datetime;
       attribute end-date value datetime;
       attribute achievement @abstract;
@@ -811,7 +811,7 @@ Feature: TypeQL Fetch Query
     Examples:
       | value-type  | value                                       | expected                                      | not-expected                                 |
       | boolean     | true                                        | true                                          | false                                        |
-      | long        | 12345090                                    | 12345090                                      | 0                                            |
+      | integer        | 12345090                                    | 12345090                                      | 0                                            |
       | double      | 0.0000000001                                | 0.0000000001                                  | 0.000000001                                  |
       | double      | 2.01234567                                  | 2.01234567                                    | 2.01234568                                   |
       | decimal     | 1234567890.0001234567890                    | "1234567890.000123456789"                     | "1234567890.0001234567890"                   |
@@ -1688,7 +1688,7 @@ Feature: TypeQL Fetch Query
     Given get answers of typeql read query
       """
         with
-        fun get_age($p_arg: person) -> { long }:
+        fun get_age($p_arg: person) -> { integer }:
         match
           $p_arg has age $age;
           let $value = $age;
@@ -1701,7 +1701,7 @@ Feature: TypeQL Fetch Query
     Given answer size is: 1
     Given uniquely identify answer concepts
       | z             |
-      | value:long:10 |
+      | value:integer:10 |
 
     When get answers of typeql read query
       """
@@ -1744,7 +1744,7 @@ Feature: TypeQL Fetch Query
         return last $value;
 
         with
-        fun get_age($p_arg: person) -> long:
+        fun get_age($p_arg: person) -> integer:
         match
           $p_arg has age $age;
           let $value = $age;
@@ -1776,7 +1776,7 @@ Feature: TypeQL Fetch Query
     When get answers of typeql read query
       """
         with
-        fun get_age($p_arg: person) -> long:
+        fun get_age($p_arg: person) -> integer:
         match
           $p_arg has age $age;
           let $value = $age;
@@ -2051,7 +2051,7 @@ Feature: TypeQL Fetch Query
   Scenario: fetch can have a subquery returning a list of aggregations
     Given get answers of typeql read query
       """
-        with fun get_info($p_arg: person) -> long, long, long:
+        with fun get_info($p_arg: person) -> integer, integer, integer:
           match
             $p_arg has person-name $name, has age $age;
             return count($name), sum($age), count($age);
@@ -2063,8 +2063,8 @@ Feature: TypeQL Fetch Query
     Given answer size is: 2
     Given uniquely identify answer concepts
       | x            | y             | z            |
-      | value:long:2 | value:long:20 | value:long:2 |
-      | value:long:0 | value:long:0  | value:long:0 |
+      | value:integer:2 | value:integer:20 | value:integer:2 |
+      | value:integer:0 | value:integer:0  | value:integer:0 |
     When get answers of typeql read query
       """
         match
@@ -2413,7 +2413,7 @@ Feature: TypeQL Fetch Query
     Given get answers of typeql read query
       """
         with
-        fun get_ages($p_arg: person) -> { long }:
+        fun get_ages($p_arg: person) -> { integer }:
         match
           $p_arg has age $age;
           let $v = $age;
@@ -2426,7 +2426,7 @@ Feature: TypeQL Fetch Query
     Given answer size is: 1
     Given uniquely identify answer concepts
       | z             |
-      | value:long:10 |
+      | value:integer:10 |
 
     When get answers of typeql read query
       """
@@ -2460,7 +2460,7 @@ Feature: TypeQL Fetch Query
     When get answers of typeql read query
       """
         with
-        fun get_ages($p_arg: person) -> { long }:
+        fun get_ages($p_arg: person) -> { integer }:
         match
           $p_arg has age $age;
           let $v = $age;

--- a/query/language/insert.feature
+++ b/query/language/insert.feature
@@ -38,10 +38,10 @@ Feature: TypeQL Insert Query
         value string;
 
       attribute age
-        value long;
+        value integer;
 
       attribute ref
-        value long;
+        value integer;
 
       attribute email
         value string;
@@ -411,7 +411,7 @@ Feature: TypeQL Insert Query
     Examples:
       | attr              | type     | val1       | val2       |
       | subject-taken     | string   | "Maths"    | "Physics"  |
-      | lucky-number      | long     | 10         | 3          |
+      | lucky-number      | integer     | 10         | 3          |
       | recite-pi-attempt | double   | 3.146      | 3.14158    |
       | is-alive          | boolean  | true       | false      |
       | work-start-date   | datetime | 2018-01-01 | 2020-01-01 |
@@ -527,7 +527,7 @@ Parker";
         owns ref @key;
       person plays residence:resident;
       attribute address value string, plays residence:place;
-      attribute tenure-days value long;
+      attribute tenure-days value integer;
       """
     Given transaction commits
 
@@ -1011,7 +1011,7 @@ Parker";
     Examples:
       | attr           | type     | value      |
       | title          | string   | "Prologue" |
-      | page-number    | long     | 233        |
+      | page-number    | integer     | 233        |
       | price          | double   | 15.99      |
       | purchased      | boolean  | true       |
       | published-date | datetime | 2020-01-01 |
@@ -1051,7 +1051,7 @@ Parker";
     Examples:
       | attr           | type     | value      |
       | title          | string   | "Prologue" |
-      | page-number    | long     | 233        |
+      | page-number    | integer     | 233        |
       | price          | double   | 15.99      |
       | purchased      | boolean  | true       |
       | published-date | datetime | 2020-01-01 |
@@ -1252,8 +1252,8 @@ Parker";
 
     Examples:
       | type     | attr       | insert           | match            |
-      | long     | shoe-size  | 92               | 92               |
-      | long     | shoe-size  | 92               | 92.00            |
+      | integer     | shoe-size  | 92               | 92               |
+      | integer     | shoe-size  | 92               | 92.00            |
       | double   | length     | 52               | 52               |
       | double   | length     | 52               | 52.00            |
       | double   | length     | 52.0             | 52               |
@@ -1286,11 +1286,11 @@ Parker";
       | string   | colour     | 92.8         |
       | string   | colour     | false        |
       | string   | colour     | 2019-12-26   |
-      | long     | shoe-size  | 28.5         |
-      | long     | shoe-size  | "28"         |
-      | long     | shoe-size  | true         |
-      | long     | shoe-size  | 2019-12-26   |
-      | long     | shoe-size  | 28.0         |
+      | integer     | shoe-size  | 28.5         |
+      | integer     | shoe-size  | "28"         |
+      | integer     | shoe-size  | true         |
+      | integer     | shoe-size  | 2019-12-26   |
+      | integer     | shoe-size  | 28.0         |
       | double   | length     | "28.0"       |
       | double   | length     | false        |
       | double   | length     | 2019-12-26   |
@@ -1391,7 +1391,7 @@ Parker";
     Given typeql schema query
       """
       define
-      attribute ref value long;
+      attribute ref value integer;
       entity base owns ref @key;
       entity derived sub base;
       """
@@ -1426,7 +1426,7 @@ Parker";
     Given typeql schema query
       """
       define
-      attribute ref value long;
+      attribute ref value integer;
       entity base owns ref @key;
       entity derived-a sub base;
       entity derived-b sub base;
@@ -1688,7 +1688,7 @@ Parker";
     Given typeql schema query
       """
       define
-      attribute height value long;
+      attribute height value integer;
       person owns height;
       """
     Given transaction commits
@@ -2485,7 +2485,7 @@ Parker";
     Then transaction commits
 
     When connection open read transaction for database: typedb
-    # After deleting all the links to 'c', our rules no longer infer that 'd' is reachable from 'a'. But in fact we
+    # After deleting all the links to 'c', our rules no integerer infer that 'd' is reachable from 'a'. But in fact we
     # materialised this reachable link when we did our match-insert, because it played a role in our road-proposal,
     # which itself plays a role in the road-construction that we explicitly inserted:
     When get answers of typeql read query
@@ -2645,7 +2645,7 @@ Parker";
     Given typeql schema query
       """
       define
-      attribute capacity value long;
+      attribute capacity value integer;
       """
     Given transaction commits
 

--- a/query/language/match.feature
+++ b/query/language/match.feature
@@ -928,7 +928,7 @@ Feature: TypeQL Match Clause
   Scenario: when matching by a relation type whose label doesn't exist, an error is thrown
     Then typeql read query; fails
       """
-      match ($x, $y) isa $type; $type label jakas-relacja;
+      match $r isa $type ($x, $y); $type label jakas-relacja;
       """
     Then transaction is open: true
 
@@ -1074,7 +1074,7 @@ Feature: TypeQL Match Clause
     Given connection open write transaction for database: typedb
     Given typeql write query
       """
-      insert $x isa some-entity, has ref 0; (player: $x, player: $x) isa symmetric, has ref 1;
+      insert $x isa some-entity, has ref 0; symmetric (player: $x, player: $x), has ref 1;
       """
     Given transaction commits
 
@@ -1100,7 +1100,7 @@ Feature: TypeQL Match Clause
     Given connection open write transaction for database: typedb
     Given typeql write query
       """
-      insert $x isa some-entity, has ref 0; (player: $x, player: $x) isa symmetric, has ref 1;
+      insert $x isa some-entity, has ref 0; symmetric (player: $x, player: $x), has ref 1;
       """
     Given transaction commits
 
@@ -1151,14 +1151,14 @@ Feature: TypeQL Match Clause
     Given typeql write query
       """
       insert
-      $rlinks (compared:$r), isa comparator;
+      $rlinks isa comparator (compared:$r);
       """
     Given transaction commits
 
     Given connection open read transaction for database: typedb
     When get answers of typeql read query
       """
-      match $rlinks (compared:$r), isa comparator;
+      match $rlinks isa comparator (compared:$r);
       """
     Then answer size is: 1
 
@@ -1179,7 +1179,7 @@ Feature: TypeQL Match Clause
     Given typeql write query
       """
       insert
-      $rlinks (compared: $v, compared:$r), isa comparator;
+      $rlinks isa comparator (compared: $v, compared:$r);
       $v isa variable;
       """
     Given transaction commits
@@ -1187,7 +1187,7 @@ Feature: TypeQL Match Clause
     Given connection open read transaction for database: typedb
     When get answers of typeql read query
       """
-      match $rlinks (compared: $v, compared:$r), isa comparator;
+      match $rlinks isa comparator (compared: $v, compared:$r);
       """
     Then answer size is: 1
 
@@ -1238,10 +1238,10 @@ Feature: TypeQL Match Clause
       $x2b isa person, has name "Patricia", has ref 2;
       $x2c isa person, has name "Lily", has ref 3;
 
-      (sender: $x1, recipient: $x2a) isa gift-delivery;
-      (sender: $x1, recipient: $x2b) isa gift-delivery;
-      (sender: $x1, recipient: $x2c) isa gift-delivery;
-      (sender: $x2a, recipient: $x2b) isa gift-delivery;
+      gift-delivery (sender: $x1, recipient: $x2a);
+      gift-delivery (sender: $x1, recipient: $x2b);
+      gift-delivery (sender: $x1, recipient: $x2c);
+      gift-delivery (sender: $x2a, recipient: $x2b);
       """
     Given transaction commits
 
@@ -1249,8 +1249,8 @@ Feature: TypeQL Match Clause
     When get answers of typeql read query
       """
       match
-        (sender: $a, recipient: $b) isa gift-delivery;
-        (sender: $b, recipient: $c) isa gift-delivery;
+        gift-delivery (sender: $a, recipient: $b);
+        gift-delivery (sender: $b, recipient: $c);
       """
     Then uniquely identify answer concepts
       | a         | b         | c         |
@@ -1258,9 +1258,9 @@ Feature: TypeQL Match Clause
     When get answers of typeql read query
       """
       match
-        (sender: $a, recipient: $b) isa gift-delivery;
-        (sender: $b, recipient: $c) isa gift-delivery;
-        (sender: $c, recipient: $d) isa gift-delivery;
+        gift-delivery (sender: $a, recipient: $b);
+        gift-delivery (sender: $b, recipient: $c);
+        gift-delivery (sender: $c, recipient: $d);
       """
     Then answer size is: 0
 
@@ -1326,7 +1326,7 @@ Feature: TypeQL Match Clause
   Scenario: an error is thrown when matching an entity type as if it were a relation type
     Then typeql read query; fails
       """
-      match ($x) isa person;
+      match person ($x);
       """
     Then transaction is open: true
 
@@ -1334,7 +1334,7 @@ Feature: TypeQL Match Clause
   Scenario: an error is thrown when matching a non-existent type label as if it were a relation type
     Then typeql read query; fails
       """
-      match ($x) isa bottle-of-rum;
+      match bottle-of-rum ($x);
       """
     Then transaction is open: true
 
@@ -1350,7 +1350,7 @@ Feature: TypeQL Match Clause
   Scenario: when matching a role in a relation type that doesn't have that role, an error is thrown
     Then typeql read query; fails
       """
-      match (friend: $x) isa employment;
+      match employment (friend: $x);
       """
     Then transaction is open: true
 
@@ -1360,7 +1360,7 @@ Feature: TypeQL Match Clause
       """
       match
       $x isa company;
-      ($x) isa friendship;
+      friendship ($x);
       """
     Then transaction is open: true
 
@@ -1467,7 +1467,7 @@ Feature: TypeQL Match Clause
     Given typeql write query
       """
       insert
-      (owned: $c1, owner: $company) isa ownership, has is-insured true;
+      ownership (owned: $c1, owner: $company), has is-insured true;
       $c1 isa car, has ref 0; $company isa company, has ref 1;
       """
     Given transaction commits
@@ -1475,7 +1475,7 @@ Feature: TypeQL Match Clause
     Given typeql write query
       """
       insert
-      (owned: $c2, owner: $person) isa ownership, has is-insured true;
+      ownership (owned: $c2, owner: $person), has is-insured true;
       $c2 isa car, has ref 2; $person isa person, has ref 3;
       """
     Given transaction commits
@@ -1775,14 +1775,14 @@ Feature: TypeQL Match Clause
     Given connection open write transaction for database: typedb
     Given typeql write query
        """
-       insert $n <value> isa <attr>;
+       insert $n isa <attr> <value>;
        """
     Given transaction commits
 
     Given connection open read transaction for database: typedb
     When get answers of typeql read query
        """
-       match $a <value> isa <attr>;
+       match $a isa <attr> <value>;
        """
     Then uniquely identify answer concepts
       | a                   |
@@ -1816,7 +1816,7 @@ Feature: TypeQL Match Clause
     Given connection open read transaction for database: typedb
     When get answers of typeql read query
       """
-      match $a <value> isa <attr>;
+      match $a isa <attr> <value>;
       """
     Then answer size is: 0
 
@@ -2228,8 +2228,8 @@ Feature: TypeQL Match Clause
     Given typeql write query
       """
       insert
-      $x 1 isa house-number;
-      $y 2.0 isa length;
+      $x isa house-number 1;
+      $y isa length 2.0;
       """
     Given transaction commits
 
@@ -2353,10 +2353,10 @@ Feature: TypeQL Match Clause
     Given typeql write query
       """
       insert
-      $a 24 isa age;
-      $b 19 isa age;
-      $c 20.9 isa length;
-      $d 19.9 isa length;
+      $a isa age 24;
+      $b isa age 19;
+      $c isa length 20.9;
+      $d isa length 19.9;
       """
     Given transaction commits
 

--- a/query/language/match.feature
+++ b/query/language/match.feature
@@ -35,8 +35,8 @@ Feature: TypeQL Match Clause
         relates employer @card(0..),
         owns ref @key;
       attribute name value string;
-      attribute age @independent, value long;
-      attribute ref value long;
+      attribute age @independent, value integer;
+      attribute ref value integer;
       attribute email value string;
       """
     Given transaction commits
@@ -1690,7 +1690,7 @@ Feature: TypeQL Match Clause
       """
       define
       attribute root @abstract;
-      attribute age, value long;
+      attribute age, value integer;
       attribute name, value string;
       attribute is-new, value boolean;
       attribute success, value double;
@@ -1706,7 +1706,7 @@ Feature: TypeQL Match Clause
     When get answers of typeql read query
       """
       match
-      $lo value long;
+      $lo value integer;
       $st value string;
       $bo value boolean;
       $do value double;
@@ -1791,7 +1791,7 @@ Feature: TypeQL Match Clause
     Examples:
       | attr              | type        | value                              |
       | is-alive          | boolean     | true                               |
-      | age               | long        | 21                                 |
+      | age               | integer        | 21                                 |
       | score             | double      | 123.456                            |
       | balance           | decimal     | 123.456                            |
       | name              | string      | "alice"                            |
@@ -1823,7 +1823,7 @@ Feature: TypeQL Match Clause
     Examples:
       | attr        | type        | value                    |
       | colour      | string      | "Green"                  |
-      | calories    | long        | 1761                     |
+      | calories    | integer        | 1761                     |
       | grams       | double      | 9.6                      |
       | gluten-free | boolean     | false                    |
       | use-by-date | datetime    | 2020-06-16               |
@@ -1977,7 +1977,7 @@ Feature: TypeQL Match Clause
     Given typeql schema query
       """
       define
-      attribute shoe-size value long;
+      attribute shoe-size value integer;
       person owns shoe-size;
       """
     Given transaction commits
@@ -2037,7 +2037,7 @@ Feature: TypeQL Match Clause
     Given typeql schema query
       """
       define
-      attribute lucky-number value long;
+      attribute lucky-number value integer;
       person owns lucky-number @card(0..);
       """
     Given transaction commits
@@ -2215,11 +2215,11 @@ Feature: TypeQL Match Clause
       | key:ref:1 |
 
 
-  Scenario: value comparisons can be performed between a 'double' and a 'long'
+  Scenario: value comparisons can be performed between a 'double' and a 'integer'
     Given typeql schema query
       """
       define
-      attribute house-number @independent, value long;
+      attribute house-number @independent, value integer;
       attribute length @independent, value double;
       """
     Given transaction commits
@@ -2291,7 +2291,7 @@ Feature: TypeQL Match Clause
     Given typeql schema query
       """
       define
-      attribute lucky-number value long;
+      attribute lucky-number value integer;
       person owns lucky-number @card(0..);
       """
     Given transaction commits
@@ -2341,7 +2341,7 @@ Feature: TypeQL Match Clause
       | key:ref:2 |
 
 
-  Scenario: when the answers of a value comparison include both a 'double' and a 'long', both answers are returned
+  Scenario: when the answers of a value comparison include both a 'double' and a 'integer', both answers are returned
     Given typeql schema query
       """
       define
@@ -2667,7 +2667,7 @@ Feature: TypeQL Match Clause
   #     """
   #   Then transaction is open: false
 
-  Scenario: the first variable in a negation can be unbound, as long as it is connected to a bound variable
+  Scenario: the first variable in a negation can be unbound, as integer as it is connected to a bound variable
     Then get answers of typeql read query
       """
       match

--- a/query/language/modifiers.feature
+++ b/query/language/modifiers.feature
@@ -33,8 +33,8 @@ Feature: TypeQL Query Modifiers
         relates employer,
         owns ref @key;
       attribute name @independent, value string;
-      attribute age, value long;
-      attribute ref, value long;
+      attribute age, value integer;
+      attribute ref, value integer;
       attribute email, value string;
       """
     Given transaction commits
@@ -81,7 +81,7 @@ Feature: TypeQL Query Modifiers
     Examples:
       | attr          | type     | val4       | val2             | val3             | val1       |
       | colour        | string   | "blue"     | "green"          | "red"            | "yellow"   |
-      | score         | long     | -38        | -4               | 18               | 152        |
+      | score         | integer     | -38        | -4               | 18               | 152        |
       | correlation   | double   | -29.7      | -0.9             | 0.01             | 100.0      |
 #      | date-of-birth | datetime | 1970-01-01 | 1999-12-31T23:00 | 1999-12-31T23:01 | 2020-02-29 |
 
@@ -172,10 +172,10 @@ Feature: TypeQL Query Modifiers
       """
     Then order of answer concepts is
       | x         | to20         |
-      | key:ref:1 | value:long:6 |
-      | key:ref:3 | value:long:4 |
-      | key:ref:0 | value:long:2 |
-      | key:ref:2 | value:long:0 |
+      | key:ref:1 | value:integer:6 |
+      | key:ref:3 | value:integer:4 |
+      | key:ref:0 | value:integer:2 |
+      | key:ref:2 | value:integer:0 |
 
 
   Scenario: multiple sort variables may be used to sort ascending
@@ -558,7 +558,7 @@ Feature: TypeQL Query Modifiers
     Examples:
       | attr          | type     | pivot      | lesser       | greater          |
       | colour        | string   | "green"    | "blue"       | "red"            |
-      | score         | long     | -4         | -38          | 18               |
+      | score         | integer     | -4         | -38          | 18               |
       | correlation   | double   | -0.9       | -1.2         | 0.01             |
       | date-of-birth | datetime | 1970-02-01 |  1970-01-01  | 1999-12-31T23:01 |
 
@@ -721,10 +721,10 @@ Feature: TypeQL Query Modifiers
       # NOTE: fourthValuePivot is expected to be the middle of the sort order (pivot)
       | firstAttr   | firstType | firstValue1 | firstValue2 | secondAttr | secondType | secondValue | thirdAttr | thirdType | thirdValue | fourthAttr | fourthType | fourthValuePivot |
       | colour      | string    | "green"     | "blue"      | name       | string     | "alice"     | shape     | string    | "square"   | street     | string     | "carnaby"        |
-      | score       | long      | 4           | -38         | quantity   | long       | -50         | area      | long      | 100        | length     | long       | 0                |
+      | score       | integer      | 4           | -38         | quantity   | integer       | -50         | area      | integer      | 100        | length     | integer       | 0                |
       | correlation | double    | 4.1         | -38.999     | quantity   | double     | -101.4      | area      | double    | 110.0555   | length     | double     | 0.5              |
-      # mixed double-long data
-      | score       | long      | 4           | -38         | quantity   | double     | -55.123     | area      | long      | 100        | length     | double     | 0.5              |
+      # mixed double-integer data
+      | score       | integer      | 4           | -38         | quantity   | double     | -55.123     | area      | integer      | 100        | length     | double     | 0.5              |
       | dob         | datetime  | 2970-01-01   | 1970-02-01 | start-date | datetime   | 1970-01-01  | end-date  | datetime  | 3100-11-20 | last-date  | datetime   | 2000-08-03       |
 
 
@@ -760,7 +760,7 @@ Feature: TypeQL Query Modifiers
             ],
             "email": [ { "type": { "label": "email", "root": "attribute", "value_type": "string" }, "value": "frederick@gmail.com" } ]
           },
-          "ref": { "type" : { "label": "ref", "root": "attribute", "value_type": "long" }, "value": 2 }
+          "ref": { "type" : { "label": "ref", "root": "attribute", "value_type": "integer" }, "value": 2 }
         },
         {
           "person": {
@@ -768,7 +768,7 @@ Feature: TypeQL Query Modifiers
             "name": [ { "type": { "label": "name", "root": "attribute", "value_type": "string" }, "value": "Jemima" } ],
             "email": [ ]
           },
-          "ref": { "type" : { "label": "ref", "root": "attribute", "value_type": "long" }, "value" : 1 }
+          "ref": { "type" : { "label": "ref", "root": "attribute", "value_type": "integer" }, "value" : 1 }
         }
       ]
       """
@@ -932,7 +932,7 @@ Feature: TypeQL Query Modifiers
       """
     Then uniquely identify answer concepts
       | z         | x              | b                |
-      | key:ref:0 | attr:name:Lisa | value:long:2001  |
+      | key:ref:0 | attr:name:Lisa | value:integer:2001  |
 
 
   # Guards against regression of #6967

--- a/query/language/pipelines.feature
+++ b/query/language/pipelines.feature
@@ -28,8 +28,8 @@ Feature: TypeQL pipelines
         relates employee,
         relates employer;
       attribute name @independent, value string;
-      attribute age @independent, value long;
-      attribute ref value long;
+      attribute age @independent, value integer;
+      attribute ref value integer;
       """
     Given transaction commits
 
@@ -216,6 +216,6 @@ Feature: TypeQL pipelines
     """
     Then uniquely identify answer concepts
       | name             | sum_age        |
-      | attr:name:Alice  | value:long:23  |
-      | attr:name:Bob    | value:long:47  |
+      | attr:name:Alice  | value:integer:23  |
+      | attr:name:Bob    | value:integer:47  |
 

--- a/query/language/redefine.feature
+++ b/query/language/redefine.feature
@@ -32,7 +32,7 @@ Feature: TypeQL Redefine Query
       attribute phone-nr value string;
       attribute empty-data @abstract;
       attribute abstract-decimal-data @abstract, value decimal;
-      attribute long-data sub empty-data, value long @values(1, 2, 3, 4, 5, 6, 7, 8, 9);
+      attribute integer-data sub empty-data, value integer @values(1, 2, 3, 4, 5, 6, 7, 8, 9);
       attribute empty-sub-data @abstract, sub empty-data;
       """
     Given transaction commits
@@ -763,13 +763,13 @@ Feature: TypeQL Redefine Query
 
     Examples:
       | value-type-1 | value-type-2 | label              |
-      | date         | long         | number-of-cows     |
+      | date         | integer         | number-of-cows     |
       | decimal      | string       | favourite-food     |
       | duration     | boolean      | can-fly            |
       | datetime-tz  | double       | density            |
       | double       | decimal      | savings            |
       | datetime     | date         | flight-date        |
-      | long         | datetime     | flight-time        |
+      | integer         | datetime     | flight-time        |
       | boolean      | datetime-tz  | flight-time-tz     |
       | string       | duration     | procedure-duration |
 
@@ -781,7 +781,7 @@ Feature: TypeQL Redefine Query
       """
     When typeql schema query
       """
-      redefine attribute long-data sub data;
+      redefine attribute integer-data sub data;
       """
     Then transaction commits
 
@@ -793,7 +793,7 @@ Feature: TypeQL Redefine Query
     Then uniquely identify answer concepts
       | x               |
       | label:data      |
-      | label:long-data |
+      | label:integer-data |
 
 
   Scenario: a redefined attribute subtype inherits the value type of its parent
@@ -817,7 +817,7 @@ Feature: TypeQL Redefine Query
   Scenario: redefining an attribute subtype throws if it is given a different value type to what its parent has
     Then typeql schema query; fails
       """
-      redefine attribute long-data sub abstract-decimal-data;
+      redefine attribute integer-data sub abstract-decimal-data;
       """
 
 
@@ -828,7 +828,7 @@ Feature: TypeQL Redefine Query
       """
     Then typeql schema query
       """
-      redefine attribute id value long;
+      redefine attribute id value integer;
       """
     Then transaction commits
 
@@ -840,7 +840,7 @@ Feature: TypeQL Redefine Query
       """
     Then typeql schema query
       """
-      redefine id value long;
+      redefine id value integer;
       """
     Then transaction commits
 
@@ -855,7 +855,7 @@ Feature: TypeQL Redefine Query
   Scenario: the value type of an existing attribute type is modifiable through redefine
     Then typeql schema query
       """
-      redefine phone-nr value long;
+      redefine phone-nr value integer;
       """
     Then transaction commits
     Given connection open schema transaction for database: typedb

--- a/query/language/reduce.feature
+++ b/query/language/reduce.feature
@@ -34,8 +34,8 @@ Feature: TypeQL Reduce Queries
         relates employer @card(0..),
         owns ref @key;
       attribute name value string;
-      attribute age value long;
-      attribute ref value long;
+      attribute age value integer;
+      attribute ref value integer;
       attribute email value string;
       """
     Given transaction commits
@@ -74,7 +74,7 @@ Feature: TypeQL Reduce Queries
         $f isa friendship;
       reduce $count = count($x);
       """
-    Then result is a single row with variable 'count': value:long:9
+    Then result is a single row with variable 'count': value:integer:9
     When get answers of typeql read query
       """
       match
@@ -91,7 +91,7 @@ Feature: TypeQL Reduce Queries
         $f isa friendship, links (friend: $x);
       reduce $count = count($x);
       """
-    Then result is a single row with variable 'count': value:long:6
+    Then result is a single row with variable 'count': value:integer:6
     When get answers of typeql read query
       """
       match
@@ -100,7 +100,7 @@ Feature: TypeQL Reduce Queries
         $f isa friendship, links (friend: $x);
       reduce $count = count;
       """
-    Then result is a single row with variable 'count': value:long:6
+    Then result is a single row with variable 'count': value:integer:6
 
 
   Scenario: the 'count' of an empty answer set is zero
@@ -110,7 +110,7 @@ Feature: TypeQL Reduce Queries
       match $x isa person, has name "Voldemort";
       reduce $count = count($x);
       """
-    Then result is a single row with variable 'count': value:long:0
+    Then result is a single row with variable 'count': value:integer:0
 
 
   Scenario Outline: the <reduction> of an answer set of '<type>' values can be retrieved
@@ -143,7 +143,7 @@ Feature: TypeQL Reduce Queries
 
     Examples:
       | attr   | type   | val1 | val2 | val3 | reduction | val_type | red_val |
-      | age    | long   | 6    | 30   | 14   | sum       | long     | 50      |
+      | age    | integer   | 6    | 30   | 14   | sum       | integer     | 50      |
       | weight | double | 61.8 | 86.5 | 24.8 | sum       | double   | 173.1   |
 
 
@@ -177,10 +177,10 @@ Feature: TypeQL Reduce Queries
 
     Examples:
       | attr   | type   | val1 | val2 | val3 | reduction | val_type | red_val |
-      | age    | long   | 6    | 30   | 14   | max       | long     | 30      |
-      | age    | long   | 6    | 30   | 14   | min       | long     | 6       |
-      | age    | long   | 6    | 30   | 14   | mean      | double   | 16.6667 |
-      | age    | long   | 6    | 30   | 14   | median    | double   | 14      |
+      | age    | integer   | 6    | 30   | 14   | max       | integer     | 30      |
+      | age    | integer   | 6    | 30   | 14   | min       | integer     | 6       |
+      | age    | integer   | 6    | 30   | 14   | mean      | double   | 16.6667 |
+      | age    | integer   | 6    | 30   | 14   | median    | double   | 14      |
       | weight | double | 61.8 | 86.5 | 24.8 | max       | double   | 86.5    |
       | weight | double | 61.8 | 86.5 | 24.8 | min       | double   | 24.8    |
       | weight | double | 61.8 | 86.5 | 24.8 | mean      | double   | 57.7    |
@@ -234,14 +234,14 @@ Feature: TypeQL Reduce Queries
       match $x isa person, has name $y, has age $z;
       reduce $sum = sum($z);
       """
-    Then result is a single row with variable 'sum': value:long:65
+    Then result is a single row with variable 'sum': value:integer:65
     Then get answers of typeql read query
       """
       match $x isa person, has name $y, has age $z;
       select $y, $z;
       reduce $sum = sum($z);
       """
-    Then result is a single row with variable 'sum': value:long:65
+    Then result is a single row with variable 'sum': value:integer:65
 
 
   Scenario Outline: duplicate attribute values are included in a '<reduction>'
@@ -487,10 +487,10 @@ Feature: TypeQL Reduce Queries
       """
     Then uniquely identify answer concepts
       | x         | count        |
-      | key:ref:0 | value:long:3 |
-      | key:ref:1 | value:long:3 |
-      | key:ref:2 | value:long:3 |
-      | key:ref:3 | value:long:3 |
+      | key:ref:0 | value:integer:3 |
+      | key:ref:1 | value:integer:3 |
+      | key:ref:2 | value:integer:3 |
+      | key:ref:3 | value:integer:3 |
 
     When get answers of typeql read query
       """
@@ -499,10 +499,10 @@ Feature: TypeQL Reduce Queries
       """
     Then uniquely identify answer concepts
       | x         | count        |
-      | key:ref:0 | value:long:3 |
-      | key:ref:1 | value:long:3 |
-      | key:ref:2 | value:long:3 |
-      | key:ref:3 | value:long:3 |
+      | key:ref:0 | value:integer:3 |
+      | key:ref:1 | value:integer:3 |
+      | key:ref:2 | value:integer:3 |
+      | key:ref:3 | value:integer:3 |
 
 
   Scenario: the size of answer groups is still computed correctly when restricting variables with 'select'
@@ -552,8 +552,8 @@ Feature: TypeQL Reduce Queries
       """
     Then uniquely identify answer concepts
       | $x        | cy           | cz           |
-      | key:ref:0 | value:long:4 | value:long:4 |
-      | key:ref:1 | value:long:2 | value:long:2 |
+      | key:ref:0 | value:integer:4 | value:integer:4 |
+      | key:ref:1 | value:integer:2 | value:integer:2 |
 
 
   Scenario: the maximum value for a particular variable within each answer group can be retrieved using a group 'max'
@@ -583,8 +583,8 @@ Feature: TypeQL Reduce Queries
       """
     Then uniquely identify answer concepts
       | x         | max           |
-      | key:ref:0 | value:long:57 |
-      | key:ref:1 | value:long:45 |
+      | key:ref:0 | value:integer:57 |
+      | key:ref:1 | value:integer:45 |
 
 
   Scenario: Grouped reductions can be performed on value variables
@@ -610,8 +610,8 @@ Feature: TypeQL Reduce Queries
       """
     Then uniquely identify answer concepts
       | n                  | sum           |
-      | value:string:Alice | value:long:10 |
-      | value:string:Bob   | value:long:5  |
+      | value:string:Alice | value:integer:10 |
+      | value:string:Bob   | value:integer:5  |
 
 
   Scenario: Grouped standard deviation of one value returns an empty group value

--- a/query/language/rule-validation.feature
+++ b/query/language/rule-validation.feature
@@ -322,7 +322,7 @@ Feature: TypeQL Rule Validation
     Given typeql schema query; throws exception
       """
       define
-      age sub attribute, value long;
+      age sub attribute, value integer;
       rule boudicca-is-1960-years-old: when {
         $person isa person, has name "Boudicca";
       } then {
@@ -343,7 +343,7 @@ Feature: TypeQL Rule Validation
       """
 
 
-  Scenario: a rule can materialise a long attribute for a double attribute type
+  Scenario: a rule can materialise a integer attribute for a double attribute type
     Then typeql schema query
       """
       define
@@ -358,12 +358,12 @@ Feature: TypeQL Rule Validation
       """
 
 
-  Scenario: when a rule creates double attribute for a long attribute type, an error is thrown
+  Scenario: when a rule creates double attribute for a integer attribute type, an error is thrown
     Then typeql schema query; throws exception
       """
       define
       person owns weight;
-      grade sub attribute, value long;
+      grade sub attribute, value integer;
 
       rule may-has-grade-5: when {
         $p has name "May";
@@ -420,7 +420,7 @@ Feature: TypeQL Rule Validation
     Then typeql schema query; throws exception
       """
       define
-      number-of-devices sub attribute, value long, abstract;
+      number-of-devices sub attribute, value integer, abstract;
       person owns number-of-devices;
       rule karl-is-allergic-to-technology: when {
         $karl isa person, has name "Karl";
@@ -686,7 +686,7 @@ Feature: TypeQL Rule Validation
     Then transaction commits
 
 
-  Scenario: rules with cyclic inferences are allowed as long as there is no negation
+  Scenario: rules with cyclic inferences are allowed as integer as there is no negation
     When typeql schema query
       """
       define
@@ -749,7 +749,7 @@ Feature: TypeQL Rule Validation
 
       person owns age;
 
-      age sub attribute, value long;
+      age sub attribute, value integer;
 
       man sub person;
       boy sub person;

--- a/query/language/undefine.feature
+++ b/query/language/undefine.feature
@@ -757,7 +757,7 @@ Feature: TypeQL Undefine Query
     Examples:
       | value_type | attr       |
       | string     | colour     |
-      | long       | age        |
+      | integer       | age        |
       | double     | height     |
       | boolean    | is-awake   |
       | datetime   | birth-date |
@@ -863,7 +863,7 @@ Feature: TypeQL Undefine Query
   Scenario: undefining the value type of an attribute type is possible
     Then typeql schema query; fails with a message containing: "defined 'value' is 'string'"
       """
-      undefine value long from name;
+      undefine value integer from name;
       """
 
     Then typeql schema query; fails with a message containing: "should be abstract"

--- a/query/language/undefine.feature
+++ b/query/language/undefine.feature
@@ -848,7 +848,7 @@ Feature: TypeQL Undefine Query
     When connection open write transaction for database: typedb
     When typeql write query
       """
-      insert $x "not-email-regex" isa email;
+      insert $x isa email "not-email-regex";
       """
     Then transaction commits
 
@@ -895,7 +895,7 @@ Feature: TypeQL Undefine Query
     Given connection open write transaction for database: typedb
     Given typeql write query
       """
-      insert $x "Colette" isa name;
+      insert $x isa name "Colette";
       """
     Given transaction commits
 

--- a/query/language/update.feature
+++ b/query/language/update.feature
@@ -30,7 +30,7 @@ Feature: TypeQL Update Query
         relates parent,
         relates child;
       name sub attribute, value string;
-      ref sub attribute, value long;
+      ref sub attribute, value integer;
       """
     Given transaction commits
 


### PR DESCRIPTION
## Usage and product changes
Update BDDs for TypeQL syntax changes - namely introducing 'let' before assignments, and moving values / role-players after the label in isa (i.e. `$m ($x, $y) isa marriage;` -> `$m isa marriage ($x, $y);`)

## Implementation

