### PR TITLE
Fix most of the query/language/insert tests

### DIFF
--- a/concept/migration/function.feature
+++ b/concept/migration/function.feature
@@ -3,7 +3,7 @@
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 #noinspection CucumberUndefinedStep
-Feature: Schema validation
+Feature: Function
 
   Background:
     Given typedb starts


### PR DESCRIPTION
## Usage and product changes
We fix most of the `query/language/insert.feature` tests by updating TypeQL statements to 3.0 and removing outdated scenarios (e.g. attributes owning attributes). After these fixes, the result of running these tests is `121 scenarios (98 passed, 23 failed)`.

## Implementation

