### PR TITLE
Add tests for relates specialization definitions, redefinitions, and undefinitions

### DIFF
--- a/concept/type/relationtype.feature
+++ b/concept/type/relationtype.feature
@@ -213,8 +213,8 @@ Feature: Concept Relation Type and Role Type
     Then relation(fathership) get role(father) get supertype: parentship:parent
     Then relation(parentship) get role(parent) get supertype does not exist
     Then relation(parentship) get role(child) get supertype does not exist
-    Then relation(parentship) get relates(parentship:parent) is specialising: false
-    Then relation(fathership) get relates(parentship:parent) is specialising: true
+    Then relation(parentship) get relates(parentship:parent) is implicit: false
+    Then relation(fathership) get relates(parentship:parent) is implicit: true
     Then relation(fathership) get supertypes contain:
       | parentship |
     Then relation(fathership) get role(father) get supertypes contain:
@@ -408,8 +408,8 @@ Feature: Concept Relation Type and Role Type
       | parentship:parent |
     Then relation(fathership) get declared relates do not contain:
       | parentship:child |
-    Then relation(parentship) get relates(parentship:parent) is specialising: false
-    Then relation(fathership) get relates(parentship:parent) is specialising: true
+    Then relation(parentship) get relates(parentship:parent) is implicit: false
+    Then relation(fathership) get relates(parentship:parent) is implicit: true
     Then relation(parentship) get role(parent) get declared annotations do not contain: @abstract
     Then relation(parentship) get role(parent) get constraints do not contain: @abstract
     Then relation(parentship) get constraints for related role(parentship:parent) do not contain: @abstract
@@ -458,9 +458,9 @@ Feature: Concept Relation Type and Role Type
       | fathership:father |
       | parentship:child  |
       | parentship:parent |
-    Then relation(fathership) get relates(fathership:father) is specialising: false
-    Then relation(fathership) get relates(parentship:child) is specialising: false
-    Then relation(fathership) get relates(parentship:parent) is specialising: true
+    Then relation(fathership) get relates(fathership:father) is implicit: false
+    Then relation(fathership) get relates(parentship:child) is implicit: false
+    Then relation(fathership) get relates(parentship:parent) is implicit: true
     Then relation(fathership) get declared relates contain:
       | fathership:father |
       | parentship:parent |
@@ -472,9 +472,9 @@ Feature: Concept Relation Type and Role Type
       | parentship:parent |
       | parentship:child  |
       | parentship:parent |
-    Then relation(fathership) get relates(fathership:father) is specialising: false
-    Then relation(fathership) get relates(parentship:child) is specialising: false
-    Then relation(fathership) get relates(parentship:parent) is specialising: false
+    Then relation(fathership) get relates(fathership:father) is implicit: false
+    Then relation(fathership) get relates(parentship:child) is implicit: false
+    Then relation(fathership) get relates(parentship:parent) is implicit: false
     Then relation(fathership) get declared relates contain:
       | fathership:father |
     Then relation(fathership) get declared relates do not contain:
@@ -487,9 +487,9 @@ Feature: Concept Relation Type and Role Type
       | parentship:parent |
       | parentship:child  |
       | parentship:parent |
-    Then relation(fathership) get relates(fathership:father) is specialising: false
-    Then relation(fathership) get relates(parentship:child) is specialising: false
-    Then relation(fathership) get relates(parentship:parent) is specialising: false
+    Then relation(fathership) get relates(fathership:father) is implicit: false
+    Then relation(fathership) get relates(parentship:child) is implicit: false
+    Then relation(fathership) get relates(parentship:parent) is implicit: false
     Then relation(fathership) get declared relates contain:
       | fathership:father |
     Then relation(fathership) get declared relates do not contain:
@@ -507,7 +507,7 @@ Feature: Concept Relation Type and Role Type
     Then relation(fathership) get role(father) get supertype: parentship:parent
     Then relation(fathership) get relates contain:
       | parentship:parent |
-    Then relation(fathership) get relates(parentship:parent) is specialising: true
+    Then relation(fathership) get relates(parentship:parent) is implicit: true
     When transaction commits
     When connection open schema transaction for database: typedb
     When create relation type: mothership
@@ -516,16 +516,16 @@ Feature: Concept Relation Type and Role Type
     When relation(mothership) get role(mother) set specialise: parent
     Then relation(mothership) get relates contain:
       | parentship:parent |
-    Then relation(mothership) get relates(parentship:parent) is specialising: true
+    Then relation(mothership) get relates(parentship:parent) is implicit: true
     When transaction commits
     When connection open read transaction for database: typedb
     Then relation(fathership) get relates contain:
       | parentship:parent |
-    Then relation(fathership) get relates(parentship:parent) is specialising: true
+    Then relation(fathership) get relates(parentship:parent) is implicit: true
     Then relation(mothership) get relates contain:
       | parentship:parent |
-    Then relation(mothership) get relates(parentship:parent) is specialising: true
-    Then relation(parentship) get relates(parentship:parent) is specialising: false
+    Then relation(mothership) get relates(parentship:parent) is implicit: true
+    Then relation(parentship) get relates(parentship:parent) is implicit: false
 
   Scenario: Relation types cannot redeclare inherited related role types
     When create relation type: parentship
@@ -549,7 +549,7 @@ Feature: Concept Relation Type and Role Type
       | parentship:parent |
     Then relation(fathership) get relates do not contain:
       | fathership:parent |
-    Then relation(fathership) get relates(parentship:parent) is specialising: true
+    Then relation(fathership) get relates(parentship:parent) is implicit: true
     When transaction commits
     When connection open schema transaction for database: typedb
     When create relation type: biological-fathership
@@ -581,8 +581,8 @@ Feature: Concept Relation Type and Role Type
       | parentship:child  |
       | fathership:spouse |
       | parentship:parent |
-    Then relation(biological-fathership) get relates(parentship:parent) is specialising: true
-    Then relation(biological-fathership) get relates(fathership:father) is specialising: false
+    Then relation(biological-fathership) get relates(parentship:parent) is implicit: true
+    Then relation(biological-fathership) get relates(fathership:father) is implicit: false
     When transaction commits
     When connection open read transaction for database: typedb
     Then relation(biological-fathership) get relates do not contain:
@@ -596,8 +596,8 @@ Feature: Concept Relation Type and Role Type
       | parentship:child  |
       | fathership:spouse |
       | parentship:parent |
-    Then relation(biological-fathership) get relates(parentship:parent) is specialising: true
-    Then relation(biological-fathership) get relates(fathership:father) is specialising: false
+    Then relation(biological-fathership) get relates(parentship:parent) is implicit: true
+    Then relation(biological-fathership) get relates(fathership:father) is implicit: false
 
   Scenario: Relation types cannot redeclare inherited role without changes
     When create relation type: parentship
@@ -679,14 +679,14 @@ Feature: Concept Relation Type and Role Type
       | split-parentship:father |
       | split-parentship:mother |
       | parentship:parent       |
-    Then relation(split-parentship) get relates(parentship:parent) is specialising: true
+    Then relation(split-parentship) get relates(parentship:parent) is implicit: true
     When transaction commits
     When connection open read transaction for database: typedb
     Then relation(split-parentship) get relates contain:
       | split-parentship:father |
       | split-parentship:mother |
       | parentship:parent       |
-    Then relation(split-parentship) get relates(parentship:parent) is specialising: true
+    Then relation(split-parentship) get relates(parentship:parent) is implicit: true
 
   Scenario: Relation types cannot unset supertype while having relates specialise
     When create relation type: parentship
@@ -734,20 +734,20 @@ Feature: Concept Relation Type and Role Type
     When relation(fathership) get role(father) set specialise: parent
     When create relation type: subfathership
     When relation(subfathership) set supertype: fathership
-    Then relation(fathership) get relates(parentship:parent) is specialising: true
-    Then relation(subfathership) get relates(parentship:parent) is specialising: true
+    Then relation(fathership) get relates(parentship:parent) is implicit: true
+    Then relation(subfathership) get relates(parentship:parent) is implicit: true
     When relation(subfathership) create role: subfather
     Then relation(subfathership) get role(subfather) set specialise: parent; fails
     When relation(fathership) get role(father) unset specialise
-    Then relation(fathership) get relates(parentship:parent) is specialising: false
-    Then relation(subfathership) get relates(parentship:parent) is specialising: false
+    Then relation(fathership) get relates(parentship:parent) is implicit: false
+    Then relation(subfathership) get relates(parentship:parent) is implicit: false
     Then relation(subfathership) get role(subfather) set specialise: parent
-    Then relation(fathership) get relates(parentship:parent) is specialising: false
-    Then relation(subfathership) get relates(parentship:parent) is specialising: true
+    Then relation(fathership) get relates(parentship:parent) is implicit: false
+    Then relation(subfathership) get relates(parentship:parent) is implicit: true
     When transaction commits
     When connection open schema transaction for database: typedb
-    Then relation(fathership) get relates(parentship:parent) is specialising: false
-    Then relation(subfathership) get relates(parentship:parent) is specialising: true
+    Then relation(fathership) get relates(parentship:parent) is implicit: false
+    Then relation(subfathership) get relates(parentship:parent) is implicit: true
     Then relation(fathership) get role(father) get supertype does not exist
     Then relation(subfathership) get role(subfather) get supertype: parentship:parent
 
@@ -764,29 +764,29 @@ Feature: Concept Relation Type and Role Type
     When connection open schema transaction for database: typedb
     Then relation(family) get role(father) get supertype: parentship:parent
     Then relation(family) get role(mother) get supertype: parentship:parent
-    Then relation(family) get relates(parentship:parent) is specialising: true
+    Then relation(family) get relates(parentship:parent) is implicit: true
     Then relation(family) get constraints for related role(parentship:parent) contain: @abstract
     When relation(family) get role(mother) unset specialise
     Then relation(family) get role(father) get supertype: parentship:parent
     Then relation(family) get role(mother) get supertype does not exist
-    Then relation(family) get relates(parentship:parent) is specialising: true
+    Then relation(family) get relates(parentship:parent) is implicit: true
     Then relation(family) get constraints for related role(parentship:parent) contain: @abstract
     When transaction commits
     When connection open schema transaction for database: typedb
     Then relation(family) get role(father) get supertype: parentship:parent
     Then relation(family) get role(mother) get supertype does not exist
-    Then relation(family) get relates(parentship:parent) is specialising: true
+    Then relation(family) get relates(parentship:parent) is implicit: true
     Then relation(family) get constraints for related role(parentship:parent) contain: @abstract
     When relation(family) get role(father) unset specialise
     Then relation(family) get role(father) get supertype does not exist
     Then relation(family) get role(mother) get supertype does not exist
-    Then relation(family) get relates(parentship:parent) is specialising: false
+    Then relation(family) get relates(parentship:parent) is implicit: false
     Then relation(family) get constraints for related role(parentship:parent) do not contain: @abstract
     When transaction commits
     When connection open read transaction for database: typedb
     Then relation(family) get role(father) get supertype does not exist
     Then relation(family) get role(mother) get supertype does not exist
-    Then relation(family) get relates(parentship:parent) is specialising: false
+    Then relation(family) get relates(parentship:parent) is implicit: false
     Then relation(family) get constraints for related role(parentship:parent) do not contain: @abstract
 
 ########################
@@ -1447,9 +1447,9 @@ Feature: Concept Relation Type and Role Type
     When relation(rel1) create role: role1
     # role00 is specialised by a role of rel1's subtype, but it can also be specialised by rel1 itself
     Then relation(rel1) get role(role1) set specialise: role00
-    Then relation(rel00) get relates(rel00:role00) is specialising: false
-    Then relation(rel1) get relates(rel00:role00) is specialising: true
-    Then relation(rel2) get relates(rel00:role00) is specialising: true
+    Then relation(rel00) get relates(rel00:role00) is implicit: false
+    Then relation(rel1) get relates(rel00:role00) is implicit: true
+    Then relation(rel2) get relates(rel00:role00) is implicit: true
     When transaction closes
     When connection open schema transaction for database: typedb
     When create relation type: rel3
@@ -1895,7 +1895,7 @@ Feature: Concept Relation Type and Role Type
     When relation(fathership) get role(father) set ordering: ordered
     When relation(fathership) get role(father) set specialise: parent
     Then relation(fathership) get role(father) get supertype: parentship:parent
-    Then relation(fathership) get relates(parentship:parent) is specialising: true
+    Then relation(fathership) get relates(parentship:parent) is implicit: true
     Then relation(fathership) get constraints for related role(parentship:parent) contain: @abstract
     When transaction commits
     When connection open schema transaction for database: typedb
@@ -1904,13 +1904,13 @@ Feature: Concept Relation Type and Role Type
     When relation(mothership) create role: mother
     When relation(mothership) get role(mother) set ordering: ordered
     When relation(mothership) get role(mother) set specialise: parent
-    Then relation(mothership) get relates(parentship:parent) is specialising: true
+    Then relation(mothership) get relates(parentship:parent) is implicit: true
     Then relation(mothership) get constraints for related role(parentship:parent) contain: @abstract
     When transaction commits
     When connection open read transaction for database: typedb
-    Then relation(fathership) get relates(parentship:parent) is specialising: true
+    Then relation(fathership) get relates(parentship:parent) is implicit: true
     Then relation(fathership) get constraints for related role(parentship:parent) contain: @abstract
-    Then relation(mothership) get relates(parentship:parent) is specialising: true
+    Then relation(mothership) get relates(parentship:parent) is implicit: true
     Then relation(mothership) get constraints for related role(parentship:parent) contain: @abstract
 
   Scenario: Relation types cannot redeclare inherited ordered role types
@@ -3096,11 +3096,11 @@ Feature: Concept Relation Type and Role Type
       | parentship:custom-role             |
       | parentship:second-custom-role      |
       | fathership:specialised-custom-role |
-    Then relation(fathership) get relates(custom-role) is specialising: false
-    Then relation(fathership) get relates(second-custom-role) is specialising: true
-    Then relation(fathership) get relates(specialised-custom-role) is specialising: false
-    Then relation(parentship) get relates(custom-role) is specialising: false
-    Then relation(parentship) get relates(second-custom-role) is specialising: false
+    Then relation(fathership) get relates(custom-role) is implicit: false
+    Then relation(fathership) get relates(second-custom-role) is implicit: true
+    Then relation(fathership) get relates(specialised-custom-role) is implicit: false
+    Then relation(parentship) get relates(custom-role) is implicit: false
+    Then relation(parentship) get relates(second-custom-role) is implicit: false
     Then relation(parentship) get role(custom-role) get constraints contain: @card(<args>)
     Then relation(fathership) get role(specialised-custom-role) get constraints do not contain: @card(<args>)
     Then relation(fathership) get role(specialised-custom-role) get declared annotations do not contain: @card(<args>)

--- a/query/language/define.feature
+++ b/query/language/define.feature
@@ -975,7 +975,7 @@ Feature: TypeQL Define Query
     Given transaction commits
 
     Given connection open schema transaction for database: typedb
-    Then typeql schema query; fails with a message containing: "'family-relation:member' should be inherited without specialization"
+    Then typeql schema query; fails with a message containing: "'family-relation:member' must be inherited without specialization"
       """
       define
       relation fathership relates father as member;

--- a/query/language/define.feature
+++ b/query/language/define.feature
@@ -922,6 +922,116 @@ Feature: TypeQL Define Query
       | label:loan      |
       | label:ownership |
 
+  Scenario: defining multiple relates specialising a single relates is allowed for a single relation type
+    When typeql schema query
+      """
+      define
+      relation family-relation relates member @abstract;
+      relation parentship sub family-relation, relates parent as member, relates child as member;
+      """
+    Then transaction commits
+
+    When connection open read transaction for database: typedb
+    When get answers of typeql read query
+      """
+      match $_ relates $x as member;
+      """
+    Then uniquely identify answer concepts
+      | x                            |
+      | label:family-relation:member |
+      | label:parentship:parent      |
+      | label:parentship:child       |
+    When transaction closes
+
+    When connection open schema transaction for database: typedb
+    When typeql schema query
+      """
+      define
+      relation adopting-parentship sub parentship, relates advisor;
+      relation adopting-fathership sub adopting-parentship, relates adopting-father as parent, relates biological-father as parent;
+      """
+    Then transaction commits
+
+    When connection open read transaction for database: typedb
+    When get answers of typeql read query
+      """
+      match $_ relates $x as parent;
+      """
+    Then uniquely identify answer concepts
+      | x                                           |
+      | label:parentship:parent                     |
+      | label:adopting-fathership:adopting-father   |
+      | label:adopting-fathership:biological-father |
+
+
+  Scenario: defining multiple relates specialising a single relates is not allowed for different relation types
+    Given typeql schema query
+      """
+      define
+      relation family-relation relates member @abstract, relates pet @abstract;
+      relation parentship sub family-relation, relates parent as member;
+      relation fathership sub parentship, relates fathers-dog as pet;
+      """
+    Given transaction commits
+
+    Given connection open schema transaction for database: typedb
+    Then typeql schema query; fails with a message containing: "'family-relation:member' should be inherited without specialization"
+      """
+      define
+      relation fathership relates father as member;
+      """
+
+
+  Scenario: definition of a relates of an inherited role type is not allowed even after specialization
+    Given typeql schema query
+      """
+      define
+      relation parentship relates parent;
+      relation fathership sub parentship, relates father;
+      """
+    Given transaction commits
+
+    When connection open schema transaction for database: typedb
+    Then typeql schema query; fails with a message containing: "'parentship:parent' should be unique in relation type hierarchy"
+      """
+      define
+      fathership relates parent;
+      """
+    When transaction closes
+
+    When connection open schema transaction for database: typedb
+    Then typeql schema query; fails with a message containing: "'parentship:parent' should be unique in relation type hierarchy"
+      """
+      define
+      fathership relates father as parent, relates parent;
+      """
+    When transaction closes
+
+    When connection open schema transaction for database: typedb
+    When typeql schema query
+      """
+      define
+      fathership relates father as parent;
+      """
+    Then typeql schema query; fails with a message containing: "'parentship:parent' should be unique in relation type hierarchy"
+      """
+      define
+      fathership relates parent @abstract;
+      """
+    When transaction closes
+
+    When connection open schema transaction for database: typedb
+    When typeql schema query
+      """
+      define
+      fathership relates father as parent;
+      """
+    Then typeql schema query; fails with a message containing: "'parentship:parent' should be unique in relation type hierarchy"
+      """
+      define
+      fathership relates parent;
+      """
+
   ###################
   # ATTRIBUTE TYPES #
   ###################
@@ -944,7 +1054,7 @@ Feature: TypeQL Define Query
     Then answer size is: 1
     Examples:
       | value-type  | label              |
-      | integer        | number-of-cows     |
+      | integer     | number-of-cows     |
       | string      | favourite-food     |
       | boolean     | can-fly            |
       | double      | density            |
@@ -1125,7 +1235,7 @@ Feature: TypeQL Define Query
     Examples:
       | value_type | label             |
       | boolean    | is-sleeping       |
-      | integer       | number-of-fingers |
+      | integer    | number-of-fingers |
       | double     | height            |
       | string     | first-word        |
       | datetime   | graduation-date   |
@@ -1453,7 +1563,7 @@ Feature: TypeQL Define Query
     Examples:
       | annotation                                            | value-type          |
       | regex("A")                                            | , value bool        |
-      | regex("A")                                            | , value integer        |
+      | regex("A")                                            | , value integer     |
       | regex("A")                                            | , value double      |
       | regex("A")                                            | , value decimal     |
       | regex("A")                                            | , value date        |
@@ -1464,8 +1574,8 @@ Feature: TypeQL Define Query
 
       | range("A".."B")                                       |                     |
       | range(1..2)                                           |                     |
-      | range("A".."B")                                       | , value integer        |
-      | range("P1Y2M3DT4H5M6.788S".."P1Y2M3DT4H5M6.789S")     | , value integer        |
+      | range("A".."B")                                       | , value integer     |
+      | range("P1Y2M3DT4H5M6.788S".."P1Y2M3DT4H5M6.789S")     | , value integer     |
       | range("A".."B")                                       | , value datetime    |
       | range(1..2)                                           | , value datetime    |
       | range(1..2)                                           | , value string      |
@@ -1479,13 +1589,13 @@ Feature: TypeQL Define Query
       | values("A")                                           |                     |
       | values(false)                                         |                     |
       | values(0)                                             |                     |
-      | values("A", 2)                                        | , value integer        |
-      | values("A", "B")                                      | , value integer        |
-      | values(0.1)                                           | , value integer        |
-      | values("string")                                      | , value integer        |
-      | values(true)                                          | , value integer        |
-      | values(2024-06-04)                                    | , value integer        |
-      | values(2024-06-04T00:00:00+0010)                      | , value integer        |
+      | values("A", 2)                                        | , value integer     |
+      | values("A", "B")                                      | , value integer     |
+      | values(0.1)                                           | , value integer     |
+      | values("string")                                      | , value integer     |
+      | values(true)                                          | , value integer     |
+      | values(2024-06-04)                                    | , value integer     |
+      | values(2024-06-04T00:00:00+0010)                      | , value integer     |
       | values("string")                                      | , value double      |
       | values(true)                                          | , value double      |
       | values(2024-06-04)                                    | , value double      |
@@ -1540,7 +1650,7 @@ Feature: TypeQL Define Query
       """
     Examples:
       | arg0                     | arg1                     | value-type  |
-      | 1                        | 2                        | integer        |
+      | 1                        | 2                        | integer     |
       | 112.2                    | 134.3                    | double      |
       | 124.4                    | 124.0                    | decimal     |
       | false                    | true                     | boolean     |
@@ -1671,7 +1781,7 @@ Feature: TypeQL Define Query
     Examples:
       | annotation                                            | value-type  |
       | regex("A")                                            | bool        |
-      | regex("A")                                            | integer        |
+      | regex("A")                                            | integer     |
       | regex("A")                                            | double      |
       | regex("A")                                            | decimal     |
       | regex("A")                                            | date        |
@@ -1679,8 +1789,8 @@ Feature: TypeQL Define Query
       | regex("A")                                            | datetime-tz |
       | regex("A")                                            | duration    |
 
-      | range("A".."B")                                       | integer        |
-      | range("P1Y2M3DT4H5M6.788S".."P1Y2M3DT4H5M6.789S")     | integer        |
+      | range("A".."B")                                       | integer     |
+      | range("P1Y2M3DT4H5M6.788S".."P1Y2M3DT4H5M6.789S")     | integer     |
       | range("A".."B")                                       | datetime    |
       | range(1..2)                                           | datetime    |
       | range(1..2)                                           | string      |
@@ -1690,13 +1800,13 @@ Feature: TypeQL Define Query
       | range(2024-06-04T16:35:02.10..2024-06-04T16:35:03.11) | date        |
       | range("P1Y2M3DT4H5M6.788S".."P1Y2M3DT4H5M6.789S")     | date        |
 
-      | values("A", 2)                                        | integer        |
-      | values("A", "B")                                      | integer        |
-      | values(0.1)                                           | integer        |
-      | values("string")                                      | integer        |
-      | values(true)                                          | integer        |
-      | values(2024-06-04)                                    | integer        |
-      | values(2024-06-04T00:00:00+0010)                      | integer        |
+      | values("A", 2)                                        | integer     |
+      | values("A", "B")                                      | integer     |
+      | values(0.1)                                           | integer     |
+      | values("string")                                      | integer     |
+      | values(true)                                          | integer     |
+      | values(2024-06-04)                                    | integer     |
+      | values(2024-06-04T00:00:00+0010)                      | integer     |
       | values("string")                                      | double      |
       | values(true)                                          | double      |
       | values(2024-06-04)                                    | double      |
@@ -1761,7 +1871,7 @@ Feature: TypeQL Define Query
       """
     Examples:
       | arg0                     | arg1                     | value-type  |
-      | 1                        | 2                        | integer        |
+      | 1                        | 2                        | integer     |
       | 112.2                    | 134.3                    | double      |
       | 124.4                    | 124.0                    | decimal     |
       | false                    | true                     | boolean     |

--- a/query/language/redefine.feature
+++ b/query/language/redefine.feature
@@ -572,7 +572,7 @@ Feature: TypeQL Redefine Query
     Then transaction commits
 
     When connection open schema transaction for database: typedb
-    Then typeql schema query; fails with a message containing: "'empty-relation:empty-role' should be inherited without specialization"
+    Then typeql schema query; fails with a message containing: "'empty-relation:empty-role' must be inherited without specialization"
       """
       redefine internship relates intern as empty-role;
       """

--- a/query/language/redefine.feature
+++ b/query/language/redefine.feature
@@ -543,7 +543,7 @@ Feature: TypeQL Redefine Query
       """
 
 
-  Scenario: redefining specialisation to an inherited not specialising relates is allowed
+  Scenario: redefining specialisation to an inherited explicit relates is allowed
     Then typeql schema query
       """
       define relation internship sub part-time-employment, relates intern as empty-role;

--- a/query/language/redefine.feature
+++ b/query/language/redefine.feature
@@ -525,21 +525,56 @@ Feature: TypeQL Redefine Query
       """
     Then transaction commits
 
-    # TODO: Uncomment when querying for specialise works. Now it returns every `$_ relates $x`.
-#    When connection open read transaction for database: typedb
-#    When get answers of typeql read query
-#      """
-#      match $_ relates $x as empty-abstract-role;
-#      """
-#    Then uniquely identify answer concepts
-#      | x                                         |
-#      | label:part-time-employment:part-time-role |
-#    When transaction closes
+    When connection open read transaction for database: typedb
+    When get answers of typeql read query
+      """
+      match $_ relates $x as empty-abstract-role;
+      """
+    Then uniquely identify answer concepts
+      | x                                         |
+      | label:empty-relation:empty-abstract-role  |
+      | label:part-time-employment:part-time-role |
+    When transaction closes
 
     When connection open schema transaction for database: typedb
     Then typeql schema query; fails with a message containing: "already defined"
       """
       redefine part-time-employment relates part-time-role as empty-abstract-role;
+      """
+
+
+  Scenario: redefining specialisation to an inherited not specialising relates is allowed
+    Then typeql schema query
+      """
+      define relation internship sub part-time-employment, relates intern as empty-role;
+      """
+    Then transaction commits
+
+    When connection open read transaction for database: typedb
+    When get answers of typeql read query
+      """
+      match $_ relates $x as empty-role;
+      """
+    Then uniquely identify answer concepts
+      | x                               |
+      | label:empty-relation:empty-role |
+      | label:internship:intern         |
+    When transaction closes
+
+
+  Scenario: redefining specialisation to a specialising relates of the supertype is not allowed
+    Given typeql schema query
+      """
+      define
+      part-time-employment relates part-time-role as empty-role;
+      relation internship sub part-time-employment, relates intern as part-time-role;
+      """
+    Then transaction commits
+
+    When connection open schema transaction for database: typedb
+    Then typeql schema query; fails with a message containing: "'empty-relation:empty-role' should be inherited without specialization"
+      """
+      redefine internship relates intern as empty-role;
       """
 
 
@@ -763,13 +798,13 @@ Feature: TypeQL Redefine Query
 
     Examples:
       | value-type-1 | value-type-2 | label              |
-      | date         | integer         | number-of-cows     |
+      | date         | integer      | number-of-cows     |
       | decimal      | string       | favourite-food     |
       | duration     | boolean      | can-fly            |
       | datetime-tz  | double       | density            |
       | double       | decimal      | savings            |
       | datetime     | date         | flight-date        |
-      | integer         | datetime     | flight-time        |
+      | integer      | datetime     | flight-time        |
       | boolean      | datetime-tz  | flight-time-tz     |
       | string       | duration     | procedure-duration |
 
@@ -791,8 +826,8 @@ Feature: TypeQL Redefine Query
       match $x sub data;
       """
     Then uniquely identify answer concepts
-      | x               |
-      | label:data      |
+      | x                  |
+      | label:data         |
       | label:integer-data |
 
 

--- a/query/language/undefine.feature
+++ b/query/language/undefine.feature
@@ -668,7 +668,7 @@ Feature: TypeQL Undefine Query
     When transaction closes
 
     When connection open schema transaction for database: typedb
-    Then typeql schema query; fails with a message containing: "there is no defined 'part-time-employment relates employee'"
+    Then typeql schema query; fails with a message containing: "there is no defined 'internship relates employee'"
       """
       undefine relates employee from internship;
       """
@@ -780,7 +780,7 @@ Feature: TypeQL Undefine Query
     Examples:
       | value_type | attr       |
       | string     | colour     |
-      | integer       | age        |
+      | integer    | age        |
       | double     | height     |
       | boolean    | is-awake   |
       | datetime   | birth-date |
@@ -1165,7 +1165,7 @@ Feature: TypeQL Undefine Query
     Then transaction commits
 
     When connection open schema transaction for database: typedb
-    Then typeql schema query; fails with a message containing: "'part-time-employment' does not relate the role 'employment:employee'"
+    Then typeql schema query; fails with a message containing: "there is no defined 'part-time-employment relates employee'"
       """
       undefine relates employee from part-time-employment;
       """
@@ -1179,9 +1179,30 @@ Feature: TypeQL Undefine Query
     Then transaction commits
 
     When connection open schema transaction for database: typedb
-    Then typeql schema query; fails with a message containing: "'user' does not play the role 'employment:employee'"
+    Then typeql schema query; fails with a message containing: "The relation type 'part-time-employment' does not relate role 'employee'"
       """
       undefine @card from part-time-employment relates employee;
+      """
+    When transaction closes
+
+    When connection open schema transaction for database: typedb
+    Then typeql schema query; parsing fails
+      """
+      undefine @card from part-time-employment relates employment:employee;
+      """
+
+
+  Scenario: undefining abstract annotation from a specialized relates is not allowed
+    When typeql schema query
+      """
+      define relation part-time-employment sub employment, relates part-time-employee as employee;
+      """
+    Then transaction commits
+
+    When connection open schema transaction for database: typedb
+    Then typeql schema query; fails with a message containing: "The relation type 'part-time-employment' does not relate role 'employee'"
+      """
+      undefine @abstract from part-time-employment relates employee;
       """
 
   ############################
@@ -1275,7 +1296,7 @@ Feature: TypeQL Undefine Query
     Then transaction commits
 
     When connection open schema transaction for database: typedb
-    Then typeql schema query; fails with a message containing: "'user' does not play the role 'employment:employee'"
+    Then typeql schema query; fails with a message containing: "Cannot unset 'plays employment:employee' constraint for 'user' inherited from 'person'"
       """
       undefine plays employment:employee from user;
       """
@@ -1422,7 +1443,7 @@ Feature: TypeQL Undefine Query
     Then transaction commits
 
     When connection open schema transaction for database: typedb
-    Then typeql schema query; fails with a message containing: "'user' does not own attribute type 'email'"
+    Then typeql schema query; fails with a message containing: "Cannot unset 'owns email' constraint for 'user' inherited from 'person'"
       """
       undefine owns email from user;
       """

--- a/query/language/undefine.feature
+++ b/query/language/undefine.feature
@@ -651,7 +651,7 @@ Feature: TypeQL Undefine Query
       """
 
 
-  Scenario: undefining specialising relates as if it was a real relates is not allowed
+  Scenario: undefining implicit relates as if it was an explicit relates is not allowed
     Given typeql schema query
       """
       define


### PR DESCRIPTION
## Usage and product changes
Add tests for relates specialization definitions, redefinitions, and undefinitions.
Previously, the tests relied on Concept API tests too much and didn't check multiple cases which ended up broken in https://github.com/typedb/typedb/issues/7322 because of the implementation details. Now, we add more explicit cases for validations. 

## Implementation

