### PR TITLE
Adjust tests to allow abstract relation types having zero role types

### DIFF
--- a/query/language/define.feature
+++ b/query/language/define.feature
@@ -851,12 +851,21 @@ Feature: TypeQL Define Query
 #      | label:flight-attendant-employment |
 
 
-  Scenario: a relation type cannot be defined with no roleplayers even if it is marked as @abstract
+  Scenario: a relation type can be defined with no role players if it is @abstract
     When typeql schema query
       """
       define relation connection @abstract;
       """
-    Then transaction commits; fails
+    Then transaction commits
+
+    When connection open read transaction for database: typedb
+    When get answers of typeql read query
+      """
+      match relation $x label connection;
+      """
+    Then uniquely identify answer concepts
+      | x                |
+      | label:connection |
 
 
   Scenario: an abstract relation type can be defined with both abstract and concrete role types

--- a/query/language/match.feature
+++ b/query/language/match.feature
@@ -784,8 +784,8 @@ Feature: TypeQL Match Clause
         select $lt, $rt;
        """
     Then uniquely identify answer concepts
-      | lt        | rt            |
-      | label:l0  | label:l0:r0   |
+      | lt       | rt          |
+      | label:l0 | label:l0:r0 |
 
     When get answers of typeql read query
        """
@@ -799,8 +799,8 @@ Feature: TypeQL Match Clause
         select $lt, $rt;
        """
     Then uniquely identify answer concepts
-      | lt        | rt            |
-      | label:l0  | label:l0:r0   |
+      | lt       | rt          |
+      | label:l0 | label:l0:r0 |
 
 
   Scenario: Match queries with unsatisfiable schema constraints pass type-inference but return no answers
@@ -1064,6 +1064,38 @@ Feature: TypeQL Match Clause
   #############
   # RELATIONS #
   #############
+
+  Scenario: relation types without role types can be matched
+    Given typeql schema query
+      """
+      define relation loneliness;
+      """
+    When get answers of typeql read query
+      """
+      match $r label loneliness;
+      """
+    Then uniquely identify answer concepts
+      | r                |
+      | label:loneliness |
+    When get answers of typeql read query
+      """
+      match relation $r;
+      """
+    Then uniquely identify answer concepts
+      | r                |
+      | label:friendship |
+      | label:employment |
+      | label:loneliness |
+    When get answers of typeql read query
+      """
+      match not {$_ isa $r;}; relation $r;
+      """
+    Then uniquely identify answer concepts
+      | r                |
+      | label:friendship |
+      | label:employment |
+      | label:loneliness |
+
 
   Scenario: a relation is matchable from role players without specifying relation type
     Given transaction commits
@@ -3177,8 +3209,8 @@ Feature: TypeQL Match Clause
     Then answer size is: 2
 
 
-   Scenario: variable role types with relations playing roles
-     Given typeql schema query
+  Scenario: variable role types with relations playing roles
+    Given typeql schema query
        """
        define
          relation parent relates nested, owns id;
@@ -3186,10 +3218,10 @@ Feature: TypeQL Match Clause
          entity player owns id, plays nested:player;
          attribute id value string;
        """
-     Given transaction commits
+    Given transaction commits
 
-     Given connection open write transaction for database: typedb
-     Given typeql write query
+    Given connection open write transaction for database: typedb
+    Given typeql write query
        """
        insert
          $i1 isa id "i1";
@@ -3201,11 +3233,11 @@ Feature: TypeQL Match Clause
          $par1 isa parent, links (nested: $n1), has id $i1;
          $par2 isa parent, links (nested: $n2), has id $i2;
        """
-     Given transaction commits
-     Given connection open read transaction for database: typedb
+    Given transaction commits
+    Given connection open read transaction for database: typedb
 
      # Force traversal of role edges in each direction: See typedb/typedb#6925
-     When get answers of typeql read query
+    When get answers of typeql read query
        """
        match
          let $boundId1 = "i1";
@@ -3216,9 +3248,9 @@ Feature: TypeQL Match Clause
          not { $role-nested sub! $r1; };
          not { $role-player sub! $r2; };
        """
-     Then answer size is: 1
+    Then answer size is: 1
 
-     When get answers of typeql read query
+    When get answers of typeql read query
        """
        match
          let $boundId1 = "i1";
@@ -3231,7 +3263,7 @@ Feature: TypeQL Match Clause
          not { $role-nested sub! $r1; };
          not { $role-player sub! $r2; };
        """
-     Then answer size is: 1
+    Then answer size is: 1
 
 
   #######################

--- a/query/language/undefine.feature
+++ b/query/language/undefine.feature
@@ -2305,7 +2305,7 @@ Feature: TypeQL Undefine Query
     Then answer size is: 0
 
 
-  Scenario: can undefine the same type's capabilities piece by piece in one query
+  Scenario: can undefine the same type's capabilities piece by piece in one query, with exceptions
     Given typeql schema query
       """
       define
@@ -2318,10 +2318,139 @@ Feature: TypeQL Undefine Query
     Then typeql schema query
       """
       undefine
+      fathership;
+      """
+    When get answers of typeql read query
+      """
+      match parentship relates $r;
+      """
+    Then uniquely identify answer concepts
+      | r                       |
+      | label:parentship:parent |
+      | label:parentship:child  |
+    When transaction closes
+
+    When connection open schema transaction for database: typedb
+    Then typeql schema query
+      """
+      undefine
+      relates father from fathership;
+      fathership;
+      """
+    When get answers of typeql read query
+      """
+      match parentship relates $r;
+      """
+    Then uniquely identify answer concepts
+      | r                       |
+      | label:parentship:parent |
+      | label:parentship:child  |
+    When transaction closes
+
+    When connection open schema transaction for database: typedb
+    Then typeql schema query
+      """
+      undefine
+      @abstract from fathership;
+      fathership;
+      """
+    When get answers of typeql read query
+      """
+      match parentship relates $r;
+      """
+    Then uniquely identify answer concepts
+      | r                       |
+      | label:parentship:parent |
+      | label:parentship:child  |
+    When transaction closes
+
+    When connection open schema transaction for database: typedb
+    When typeql schema query
+      """
+      undefine
+      relates father from fathership;
+      """
+    When get answers of typeql read query
+      """
+      match fathership relates $r;
+      """
+    Then answer size is: 2
+    When typeql schema query
+      """
+      undefine
+      sub parentship from fathership;
+      """
+    When get answers of typeql read query
+      """
+      match fathership relates $r;
+      """
+    Then answer size is: 0
+    Then typeql schema query; fails with a message containing: "not have any role types related"
+      """
+      undefine
+      @abstract from fathership;
+      """
+    When transaction closes
+
+    When connection open schema transaction for database: typedb
+    When typeql schema query
+      """
+      undefine
+      relates father from fathership;
+      """
+    When get answers of typeql read query
+      """
+      match fathership relates $r;
+      """
+    Then answer size is: 2
+    When typeql schema query
+      """
+      undefine
+      @abstract from fathership;
+      """
+    When get answers of typeql read query
+      """
+      match fathership relates $r;
+      """
+    Then answer size is: 2
+    Then typeql schema query; fails with a message containing: "not have any role types related"
+      """
+      undefine
+      sub parentship from fathership;
+      """
+    When transaction closes
+
+    When connection open schema transaction for database: typedb
+    Then typeql schema query; fails with a message containing: "not have any role types related"
+      """
+      undefine
+      relates father from fathership;
+      @abstract from fathership;
+      sub parentship from fathership;
+      fathership;
+      """
+    When transaction closes
+
+    When connection open schema transaction for database: typedb
+    Then typeql schema query; fails with a message containing: "not have any role types related"
+      """
+      undefine
+      as parent from fathership relates father;
+      relates father from fathership;
+      @abstract from fathership;
+      sub parentship from fathership;
+      fathership;
+      """
+    When transaction closes
+
+    When connection open schema transaction for database: typedb
+    Then typeql schema query
+      """
+      undefine
       as parent from fathership relates father;
       @card from fathership relates father;
       relates father from fathership;
-      @abstract from fathership;
+      # @abstract from fathership; # fathership does not have roles at this point. we may want to allow it or error...
       sub parentship from fathership;
       fathership;
       """


### PR DESCRIPTION
## Usage and product changes
Adjust tests to allow abstract relation types have zero role types. Update some of the tests to expect validation errors at operation time instead of commits.
Additionally, add more cases for role type modification to catch bugs related to incorrect specialized role types' deletions.

## Implementation

