### PR TITLE
Update BDD tests for TypeDB HTTP client

### DIFF
--- a/concept/type/attributetype.feature
+++ b/concept/type/attributetype.feature
@@ -66,17 +66,17 @@ Feature: Concept Attribute Type
     When struct(multi-name) create field: first-name, with value type: string
     When struct(multi-name) create field: second-name, with value type: string
     When create attribute type: full-name
-    When attribute(full-name) set value type: multi-name
+    When attribute(full-name) set value type: struct(multi-name)
     Then attribute(full-name) exists
     Then attribute(full-name) get supertype does not exist
-    Then attribute(full-name) get value type: multi-name
-    Then attribute(full-name) get value type declared: multi-name
+    Then attribute(full-name) get value type: struct(multi-name)
+    Then attribute(full-name) get value type declared: struct(multi-name)
     When transaction commits
     When connection open read transaction for database: typedb
     Then attribute(full-name) exists
     Then attribute(full-name) get supertype does not exist
-    Then attribute(full-name) get value type: multi-name
-    Then attribute(full-name) get value type declared: multi-name
+    Then attribute(full-name) get value type: struct(multi-name)
+    Then attribute(full-name) get value type declared: struct(multi-name)
 
   Scenario Outline: Attribute types cannot be recreated with <value-type> value type
     When create attribute type: name
@@ -88,17 +88,17 @@ Feature: Concept Attribute Type
     Then attribute(name) exists
     Then create attribute type: name; fails
     Examples:
-      | value-type    |
-      | integer       |
-      | string        |
-      | boolean       |
-      | double        |
-      | decimal       |
-      | date          |
-      | datetime      |
-      | datetime-tz   |
-      | duration      |
-      | custom-struct |
+      | value-type            |
+      | integer               |
+      | string                |
+      | boolean               |
+      | double                |
+      | decimal               |
+      | date                  |
+      | datetime              |
+      | datetime-tz           |
+      | duration              |
+      | struct(custom-struct) |
 
   Scenario: Attribute types cannot be created without value types
     When create attribute type: name
@@ -776,33 +776,33 @@ Feature: Concept Attribute Type
     Then attribute(first-name) get value type: <value-type-2>
     Then attribute(first-name) set supertype: name; fails
     Examples:
-      | value-type-1  | value-type-2    |
-      | integer       | string          |
-      | integer       | boolean         |
-      | integer       | double          |
-      | integer       | decimal         |
-      | integer       | date            |
-      | integer       | datetime        |
-      | integer       | datetime-tz     |
-      | integer       | duration        |
-      | integer       | custom-struct   |
-      | string        | integer         |
-      | boolean       | string          |
-      | double        | datetime-tz     |
-      | decimal       | datetime        |
-      | date          | decimal         |
-      | datetime      | date            |
-      | datetime-tz   | double          |
-      | duration      | boolean         |
-      | custom-struct | integer         |
-      | custom-struct | string          |
-      | custom-struct | boolean         |
-      | custom-struct | double          |
-      | custom-struct | decimal         |
-      | custom-struct | date            |
-      | custom-struct | datetime        |
-      | custom-struct | datetime-tz     |
-      | custom-struct | custom-struct-2 |
+      | value-type-1          | value-type-2            |
+      | integer               | string                  |
+      | integer               | boolean                 |
+      | integer               | double                  |
+      | integer               | decimal                 |
+      | integer               | date                    |
+      | integer               | datetime                |
+      | integer               | datetime-tz             |
+      | integer               | duration                |
+      | integer               | struct(custom-struct)   |
+      | string                | integer                 |
+      | boolean               | string                  |
+      | double                | datetime-tz             |
+      | decimal               | datetime                |
+      | date                  | decimal                 |
+      | datetime              | date                    |
+      | datetime-tz           | double                  |
+      | duration              | boolean                 |
+      | struct(custom-struct) | integer                 |
+      | struct(custom-struct) | string                  |
+      | struct(custom-struct) | boolean                 |
+      | struct(custom-struct) | double                  |
+      | struct(custom-struct) | decimal                 |
+      | struct(custom-struct) | date                    |
+      | struct(custom-struct) | datetime                |
+      | struct(custom-struct) | datetime-tz             |
+      | struct(custom-struct) | struct(custom-struct-2) |
 
   Scenario Outline: Attribute type subtyping an attribute type with value type <value-type-1> cannot set value type <value-type-2>
     When create attribute type: name
@@ -833,33 +833,33 @@ Feature: Concept Attribute Type
     Then attribute(name) get value type is none
     Then attribute(first-name) get value type: <value-type-2>
     Examples:
-      | value-type-1  | value-type-2    |
-      | integer       | string          |
-      | integer       | boolean         |
-      | integer       | double          |
-      | integer       | decimal         |
-      | integer       | date            |
-      | integer       | datetime        |
-      | integer       | datetime-tz     |
-      | integer       | duration        |
-      | integer       | custom-struct   |
-      | string        | boolean         |
-      | boolean       | string          |
-      | double        | datetime        |
-      | decimal       | datetime-tz     |
-      | date          | decimal         |
-      | datetime      | integer         |
-      | datetime-tz   | double          |
-      | duration      | date            |
-      | custom-struct | integer         |
-      | custom-struct | string          |
-      | custom-struct | boolean         |
-      | custom-struct | double          |
-      | custom-struct | decimal         |
-      | custom-struct | date            |
-      | custom-struct | datetime        |
-      | custom-struct | datetime-tz     |
-      | custom-struct | custom-struct-2 |
+      | value-type-1          | value-type-2            |
+      | integer               | string                  |
+      | integer               | boolean                 |
+      | integer               | double                  |
+      | integer               | decimal                 |
+      | integer               | date                    |
+      | integer               | datetime                |
+      | integer               | datetime-tz             |
+      | integer               | duration                |
+      | integer               | struct(custom-struct)   |
+      | string                | boolean                 |
+      | boolean               | string                  |
+      | double                | datetime                |
+      | decimal               | datetime-tz             |
+      | date                  | decimal                 |
+      | datetime              | integer                 |
+      | datetime-tz           | double                  |
+      | duration              | date                    |
+      | struct(custom-struct) | integer                 |
+      | struct(custom-struct) | string                  |
+      | struct(custom-struct) | boolean                 |
+      | struct(custom-struct) | double                  |
+      | struct(custom-struct) | decimal                 |
+      | struct(custom-struct) | date                    |
+      | struct(custom-struct) | datetime                |
+      | struct(custom-struct) | datetime-tz             |
+      | struct(custom-struct) | struct(custom-struct-2) |
 
   Scenario Outline: Supertype attribute type cannot set <value-type-2> conflicting with <value-type-1> set for one of subtypes
     When create attribute type: name
@@ -939,33 +939,33 @@ Feature: Concept Attribute Type
     Then attribute(second-name) get value type is none
     Then attribute(sub-first-name) get value type is none
     Examples:
-      | value-type-1  | value-type-2    |
-      | integer       | string          |
-      | integer       | boolean         |
-      | integer       | double          |
-      | integer       | decimal         |
-      | integer       | date            |
-      | integer       | datetime        |
-      | integer       | datetime-tz     |
-      | integer       | duration        |
-      | integer       | custom-struct   |
-      | string        | datetime-tz     |
-      | boolean       | date            |
-      | double        | datetime        |
-      | decimal       | double          |
-      | date          | string          |
-      | datetime      | integer         |
-      | datetime-tz   | decimal         |
-      | duration      | boolean         |
-      | custom-struct | integer         |
-      | custom-struct | string          |
-      | custom-struct | boolean         |
-      | custom-struct | double          |
-      | custom-struct | decimal         |
-      | custom-struct | date            |
-      | custom-struct | datetime        |
-      | custom-struct | datetime-tz     |
-      | custom-struct | custom-struct-2 |
+      | value-type-1          | value-type-2            |
+      | integer               | string                  |
+      | integer               | boolean                 |
+      | integer               | double                  |
+      | integer               | decimal                 |
+      | integer               | date                    |
+      | integer               | datetime                |
+      | integer               | datetime-tz             |
+      | integer               | duration                |
+      | integer               | struct(custom-struct)   |
+      | string                | datetime-tz             |
+      | boolean               | date                    |
+      | double                | datetime                |
+      | decimal               | double                  |
+      | date                  | string                  |
+      | datetime              | integer                 |
+      | datetime-tz           | decimal                 |
+      | duration              | boolean                 |
+      | struct(custom-struct) | integer                 |
+      | struct(custom-struct) | string                  |
+      | struct(custom-struct) | boolean                 |
+      | struct(custom-struct) | double                  |
+      | struct(custom-struct) | decimal                 |
+      | struct(custom-struct) | date                    |
+      | struct(custom-struct) | datetime                |
+      | struct(custom-struct) | datetime-tz             |
+      | struct(custom-struct) | struct(custom-struct-2) |
 
   Scenario Outline: Supertype attribute type can set <value-type> set for subtype, but subtype needs to explicitly unset it before commit
     When create attribute type: name
@@ -998,17 +998,17 @@ Feature: Concept Attribute Type
     Then attribute(name) get value type: <value-type>
     Then attribute(first-name) get value type: <value-type>
     Examples:
-      | value-type    |
-      | integer       |
-      | string        |
-      | boolean       |
-      | double        |
-      | decimal       |
-      | date          |
-      | datetime      |
-      | datetime-tz   |
-      | duration      |
-      | custom-struct |
+      | value-type            |
+      | integer               |
+      | string                |
+      | boolean               |
+      | double                |
+      | decimal               |
+      | date                  |
+      | datetime              |
+      | datetime-tz           |
+      | duration              |
+      | struct(custom-struct) |
 
   Scenario Outline: Attribute types can set <value-type> value type after subtyping attribute type without value type
     When create attribute type: name
@@ -1023,17 +1023,17 @@ Feature: Concept Attribute Type
     Then attribute(first-name) get value type: <value-type>
     Then attribute(name) get value type is none
     Examples:
-      | value-type    |
-      | integer       |
-      | string        |
-      | boolean       |
-      | double        |
-      | decimal       |
-      | date          |
-      | datetime      |
-      | datetime-tz   |
-      | duration      |
-      | custom-struct |
+      | value-type            |
+      | integer               |
+      | string                |
+      | boolean               |
+      | double                |
+      | decimal               |
+      | date                  |
+      | datetime              |
+      | datetime-tz           |
+      | duration              |
+      | struct(custom-struct) |
 
   Scenario Outline: Attribute types can set <value-type> value type before inheriting from an abstract attribute type without value type
     When create attribute type: name
@@ -1048,17 +1048,17 @@ Feature: Concept Attribute Type
     Then attribute(first-name) get value type: <value-type>
     Then attribute(name) get value type is none
     Examples:
-      | value-type    |
-      | integer       |
-      | string        |
-      | boolean       |
-      | double        |
-      | decimal       |
-      | date          |
-      | datetime      |
-      | datetime-tz   |
-      | duration      |
-      | custom-struct |
+      | value-type            |
+      | integer               |
+      | string                |
+      | boolean               |
+      | double                |
+      | decimal               |
+      | date                  |
+      | datetime              |
+      | datetime-tz           |
+      | duration              |
+      | struct(custom-struct) |
 
   Scenario Outline: Attribute types can inherit <value-type> value type from supertype
     When create attribute type: name
@@ -1074,17 +1074,17 @@ Feature: Concept Attribute Type
     Then attribute(first-name) get supertype: name
     Then attribute(first-name) get value type: <value-type>
     Examples:
-      | value-type    |
-      | integer       |
-      | string        |
-      | boolean       |
-      | double        |
-      | decimal       |
-      | date          |
-      | datetime      |
-      | datetime-tz   |
-      | duration      |
-      | custom-struct |
+      | value-type            |
+      | integer               |
+      | string                |
+      | boolean               |
+      | double                |
+      | decimal               |
+      | date                  |
+      | datetime              |
+      | datetime-tz           |
+      | duration              |
+      | struct(custom-struct) |
 
   Scenario Outline: Attribute type of <value-type> value type cannot inherit @abstract annotation, but can set it being a subtype
     When create attribute type: name
@@ -1112,17 +1112,17 @@ Feature: Concept Attribute Type
     Then attribute(first-name) get constraints contain: @abstract
     Then attribute(first-name) get declared annotations contain: @abstract
     Examples:
-      | value-type    |
-      | integer       |
-      | string        |
-      | boolean       |
-      | double        |
-      | decimal       |
-      | date          |
-      | datetime      |
-      | datetime-tz   |
-      | duration      |
-      | custom-struct |
+      | value-type            |
+      | integer               |
+      | string                |
+      | boolean               |
+      | double                |
+      | decimal               |
+      | date                  |
+      | datetime              |
+      | datetime-tz           |
+      | duration              |
+      | struct(custom-struct) |
 
   Scenario: Attribute types cannot unset @abstract annotation if it does not have value type
     When create attribute type: name
@@ -1344,16 +1344,16 @@ Feature: Concept Attribute Type
     Then attribute(email) get constraints is empty
     Then attribute(email) get declared annotations is empty
     Examples:
-      | value-type    | arg     |
-      | integer       | "value" |
-      | boolean       | "value" |
-      | double        | "value" |
-      | decimal       | "value" |
-      | date          | "value" |
-      | datetime      | "value" |
-      | datetime-tz   | "value" |
-      | duration      | "value" |
-      | custom-struct | "value" |
+      | value-type            | arg     |
+      | integer               | "value" |
+      | boolean               | "value" |
+      | double                | "value" |
+      | decimal               | "value" |
+      | date                  | "value" |
+      | datetime              | "value" |
+      | datetime-tz           | "value" |
+      | duration              | "value" |
+      | struct(custom-struct) | "value" |
 
   Scenario: Attribute type cannot set @regex annotation for none value type, cannot unset value type with @regex annotation
     When create attribute type: name
@@ -1545,7 +1545,7 @@ Feature: Concept Attribute Type
     Then attribute(custom-attribute) set value type: datetime; fails
     Then attribute(custom-attribute) set value type: datetime-tz; fails
     Then attribute(custom-attribute) set value type: duration; fails
-    Then attribute(custom-attribute) set value type: custom-struct; fails
+    Then attribute(custom-attribute) set value type: struct(custom-struct); fails
     When attribute(custom-attribute) set value type: string
     Then attribute(custom-attribute) get value type: string
     When attribute(custom-attribute) unset annotation: @regex
@@ -1566,7 +1566,7 @@ Feature: Concept Attribute Type
     Then attribute(custom-attribute) set value type: datetime; fails
     Then attribute(custom-attribute) set value type: datetime-tz; fails
     Then attribute(custom-attribute) set value type: duration; fails
-    Then attribute(custom-attribute) set value type: custom-struct; fails
+    Then attribute(custom-attribute) set value type: struct(custom-struct); fails
     Then attribute(custom-attribute) get value type: string
 
 ########################
@@ -1591,17 +1591,17 @@ Feature: Concept Attribute Type
     Then attribute(email) get constraints do not contain: @independent
     Then attribute(email) get declared annotations do not contain: @independent
     Examples:
-      | value-type    |
-      | integer       |
-      | string        |
-      | boolean       |
-      | double        |
-      | decimal       |
-      | date          |
-      | datetime      |
-      | datetime-tz   |
-      | duration      |
-      | custom-struct |
+      | value-type            |
+      | integer               |
+      | string                |
+      | boolean               |
+      | double                |
+      | decimal               |
+      | date                  |
+      | datetime              |
+      | datetime-tz           |
+      | duration              |
+      | struct(custom-struct) |
 
   Scenario: Attribute type can reset @independent annotation
     When create attribute type: name
@@ -2551,17 +2551,17 @@ Feature: Concept Attribute Type
     Then struct(passport) get field(name) get value type: <value-type>
     Then struct(passport) get field(name) is optional: false
     Examples:
-      | value-type    |
-      | integer       |
-      | string        |
-      | boolean       |
-      | double        |
-      | decimal       |
-      | date          |
-      | datetime      |
-      | datetime-tz   |
-      | duration      |
-      | custom-struct |
+      | value-type            |
+      | integer               |
+      | string                |
+      | boolean               |
+      | double                |
+      | decimal               |
+      | date                  |
+      | datetime              |
+      | datetime-tz           |
+      | duration              |
+      | struct(custom-struct) |
 
   Scenario Outline: Struct can be created with multiple fields, including another struct
     When create struct: passport
@@ -2585,17 +2585,17 @@ Feature: Concept Attribute Type
     Then struct(passport) get field(name) get value type: <value-type-2>
     Then struct(passport) get field(name) is optional: false
     Examples:
-      | value-type-1  | value-type-2  |
-      | integer       | string        |
-      | string        | boolean       |
-      | boolean       | double        |
-      | double        | decimal       |
-      | decimal       | date          |
-      | date          | datetime      |
-      | datetime      | datetime-tz   |
-      | datetime-tz   | duration      |
-      | duration      | custom-struct |
-      | custom-struct | integer       |
+      | value-type-1          | value-type-2          |
+      | integer               | string                |
+      | string                | boolean               |
+      | boolean               | double                |
+      | double                | decimal               |
+      | decimal               | date                  |
+      | date                  | datetime              |
+      | datetime              | datetime-tz           |
+      | datetime-tz           | duration              |
+      | duration              | struct(custom-struct) |
+      | struct(custom-struct) | integer               |
 
   Scenario Outline: Struct can be created with one optional field, including another struct
     When create struct: passport
@@ -2614,17 +2614,17 @@ Feature: Concept Attribute Type
     Then struct(passport) get field(name) get value type: <value-type>
     Then struct(passport) get field(name) is optional: true
     Examples:
-      | value-type    |
-      | integer       |
-      | string        |
-      | boolean       |
-      | double        |
-      | decimal       |
-      | date          |
-      | datetime      |
-      | datetime-tz   |
-      | duration      |
-      | custom-struct |
+      | value-type            |
+      | integer               |
+      | string                |
+      | boolean               |
+      | double                |
+      | decimal               |
+      | date                  |
+      | datetime              |
+      | datetime-tz           |
+      | duration              |
+      | struct(custom-struct) |
 
   Scenario Outline: Struct can be created with multiple optional fields, including another struct
     When create struct: passport
@@ -2662,17 +2662,17 @@ Feature: Concept Attribute Type
     Then struct(passport) get field(middle-name) get value type: <value-type-2>
     Then struct(passport) get field(middle-name) is optional: true
     Examples:
-      | value-type-1  | value-type-2  |
-      | integer       | string        |
-      | string        | boolean       |
-      | boolean       | double        |
-      | double        | decimal       |
-      | decimal       | date          |
-      | date          | datetime      |
-      | datetime      | datetime-tz   |
-      | datetime-tz   | duration      |
-      | duration      | custom-struct |
-      | custom-struct | integer       |
+      | value-type-1          | value-type-2          |
+      | integer               | string                |
+      | string                | boolean               |
+      | boolean               | double                |
+      | double                | decimal               |
+      | decimal               | date                  |
+      | date                  | datetime              |
+      | datetime              | datetime-tz           |
+      | datetime-tz           | duration              |
+      | duration              | struct(custom-struct) |
+      | struct(custom-struct) | integer               |
 
   Scenario: Struct without fields can be deleted
     When create struct: passport
@@ -2751,17 +2751,17 @@ Feature: Concept Attribute Type
     Then struct(passport) get fields contain:
       | not-name |
     Examples:
-      | value-type    |
-      | integer       |
-      | string        |
-      | boolean       |
-      | double        |
-      | decimal       |
-      | date          |
-      | datetime      |
-      | datetime-tz   |
-      | duration      |
-      | custom-struct |
+      | value-type            |
+      | integer               |
+      | string                |
+      | boolean               |
+      | double                |
+      | decimal               |
+      | date                  |
+      | datetime              |
+      | datetime-tz           |
+      | duration              |
+      | struct(custom-struct) |
 
   Scenario Outline: Struct cannot delete fields of type <value-type> if it doesn't exist
     When create struct: passport
@@ -2774,11 +2774,11 @@ Feature: Concept Attribute Type
     When struct(table) delete field: name
     Then struct(table) delete field: name; fails
     Examples:
-      | value-type    |
-      | integer       |
-      | string        |
-      | date          |
-      | custom-struct |
+      | value-type            |
+      | integer               |
+      | string                |
+      | date                  |
+      | struct(custom-struct) |
 
   Scenario: Struct cannot be redefined
     When create struct: passport

--- a/concept/type/owns-annotations.feature
+++ b/concept/type/owns-annotations.feature
@@ -1475,7 +1475,7 @@ Feature: Concept Owns Annotations
     Then entity(person) get owns is empty
     Examples:
       | value-type  |
-      | integer        |
+      | integer     |
       | decimal     |
       | string      |
       | boolean     |
@@ -1499,7 +1499,7 @@ Feature: Concept Owns Annotations
     Then entity(person) get owns(custom-attribute) is key: true
     Examples:
       | value-type  |
-      | integer        |
+      | integer     |
       | decimal     |
       | string      |
       | boolean     |
@@ -1520,9 +1520,9 @@ Feature: Concept Owns Annotations
     Then entity(person) get owns(custom-attribute) get constraints do not contain: @unique
     Then entity(person) get owns(custom-attribute) get constraints do not contain: @card(1..1)
     Examples:
-      | value-type    |
-      | double        |
-      | custom-struct |
+      | value-type            |
+      | double                |
+      | struct(custom-struct) |
 
   Scenario: Owns cannot set @key annotation for empty value type
     When create attribute type: id
@@ -1553,7 +1553,7 @@ Feature: Concept Owns Annotations
     When entity(person) get owns(custom-attribute) set annotation: @key
     Then attribute(custom-attribute) unset value type; fails
     Then attribute(custom-attribute) set value type: double; fails
-    Then attribute(custom-attribute) set value type: custom-struct; fails
+    Then attribute(custom-attribute) set value type: struct(custom-struct); fails
     When attribute(custom-attribute) set value type: string
     When entity(person) get owns(custom-attribute) unset annotation: @key
     When attribute(custom-attribute) unset value type
@@ -1579,7 +1579,7 @@ Feature: Concept Owns Annotations
     Then entity(person) get owns(custom-attribute) is key: true
     Examples:
       | value-type  |
-      | integer        |
+      | integer     |
       | decimal     |
       | string      |
       | boolean     |
@@ -1601,9 +1601,9 @@ Feature: Concept Owns Annotations
     Then entity(person) get owns(custom-attribute) get constraints do not contain: @unique
     Then entity(person) get owns(custom-attribute) get constraints do not contain: @card(1..1)
     Examples:
-      | value-type    |
-      | double        |
-      | custom-struct |
+      | value-type            |
+      | double                |
+      | struct(custom-struct) |
 
   Scenario Outline: Can set multiple specialises on the same type for a @key owns even if the cardinality is blocked
     When create attribute type: name
@@ -1854,7 +1854,7 @@ Feature: Concept Owns Annotations
 #    Examples:
 #      | value-type |
 #      | double     |
-#      | custom-struct |
+#      | struct(custom-struct) |
 #
 #  Scenario: Owns cannot set @subkey annotation for incorrect arguments
 #    When create attribute type: custom-attribute
@@ -1923,7 +1923,7 @@ Feature: Concept Owns Annotations
     Then entity(person) get owns is empty
     Examples:
       | value-type  |
-      | integer        |
+      | integer     |
       | decimal     |
       | string      |
       | boolean     |
@@ -1947,7 +1947,7 @@ Feature: Concept Owns Annotations
     Then entity(person) get owns(custom-attribute) get constraints contain: @unique
     Examples:
       | value-type  |
-      | integer        |
+      | integer     |
       | decimal     |
       | string      |
       | boolean     |
@@ -1966,9 +1966,9 @@ Feature: Concept Owns Annotations
     When connection open read transaction for database: typedb
     Then entity(person) get owns(custom-attribute) get constraints do not contain: @unique
     Examples:
-      | value-type    |
-      | double        |
-      | custom-struct |
+      | value-type            |
+      | double                |
+      | struct(custom-struct) |
 
   Scenario: Owns cannot set @unique annotation for empty value type
     When create attribute type: id
@@ -1994,7 +1994,7 @@ Feature: Concept Owns Annotations
     When entity(person) get owns(custom-attribute) set annotation: @unique
     Then attribute(custom-attribute) unset value type; fails
     Then attribute(custom-attribute) set value type: double; fails
-    Then attribute(custom-attribute) set value type: custom-struct; fails
+    Then attribute(custom-attribute) set value type: struct(custom-struct); fails
     When attribute(custom-attribute) set value type: string
     When entity(person) get owns(custom-attribute) unset annotation: @unique
     When attribute(custom-attribute) unset value type
@@ -2039,7 +2039,7 @@ Feature: Concept Owns Annotations
     Then entity(person) get owns is empty
     Examples:
       | value-type  |
-      | integer        |
+      | integer     |
       | decimal     |
       | string      |
       | boolean     |
@@ -2075,13 +2075,13 @@ Feature: Concept Owns Annotations
     Then entity(person) get owns is empty
     Examples:
       | value-type  | args                                                                                                                                                                                                                                                                                                                                                                                                 |
-      | integer        | 0                                                                                                                                                                                                                                                                                                                                                                                                    |
-      | integer        | 1                                                                                                                                                                                                                                                                                                                                                                                                    |
-      | integer        | -1                                                                                                                                                                                                                                                                                                                                                                                                   |
-      | integer        | 1, 2                                                                                                                                                                                                                                                                                                                                                                                                 |
-      | integer        | -9223372036854775808, 9223372036854775807                                                                                                                                                                                                                                                                                                                                                            |
-      | integer        | 2, 1, 3, 4, 5, 6, 7, 9, 10, 11, 55, -1, -654321, 123456                                                                                                                                                                                                                                                                                                                                              |
-      | integer        | 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 97, 98, 99 |
+      | integer     | 0                                                                                                                                                                                                                                                                                                                                                                                                    |
+      | integer     | 1                                                                                                                                                                                                                                                                                                                                                                                                    |
+      | integer     | -1                                                                                                                                                                                                                                                                                                                                                                                                   |
+      | integer     | 1, 2                                                                                                                                                                                                                                                                                                                                                                                                 |
+      | integer     | -9223372036854775808, 9223372036854775807                                                                                                                                                                                                                                                                                                                                                            |
+      | integer     | 2, 1, 3, 4, 5, 6, 7, 9, 10, 11, 55, -1, -654321, 123456                                                                                                                                                                                                                                                                                                                                              |
+      | integer     | 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 97, 98, 99 |
       | string      | ""                                                                                                                                                                                                                                                                                                                                                                                                   |
       | string      | "1"                                                                                                                                                                                                                                                                                                                                                                                                  |
       | string      | "福"                                                                                                                                                                                                                                                                                                                                                                                                  |
@@ -2137,7 +2137,7 @@ Feature: Concept Owns Annotations
     # TODO: Struct parsing is not supported in concept api tests now
 #  Scenario: Owns cannot set @values annotation for struct value type
 #    When create attribute type: custom-attribute
-#    When attribute(custom-attribute) set value type: custom-struct
+#    When attribute(custom-attribute) set value type: struct(custom-struct)
 #    When entity(person) set owns: custom-attribute
 #    When entity(person) get owns(custom-attribute) set annotation: @values(custom-struct); fails
 #    When entity(person) get owns(custom-attribute) set annotation: @values({"string"}); fails
@@ -2196,7 +2196,7 @@ Feature: Concept Owns Annotations
     Then entity(person) get owns(custom-attribute) get constraints contain: @values(<args>)
     Examples:
       | value-type  | args                             |
-      | integer        | 1, 2                             |
+      | integer     | 1, 2                             |
       | double      | 1.0, 2.0                         |
       | decimal     | 1.0, 2.0                         |
       | string      | "str", "str another"             |
@@ -2220,7 +2220,7 @@ Feature: Concept Owns Annotations
     Then entity(person) get owns(custom-attribute) get constraints do not contain: @values(<args>)
     Examples:
       | value-type  | args            | reset-args      |
-      | integer        | 1, 5            | 7, 9            |
+      | integer     | 1, 5            | 7, 9            |
       | double      | 1.1, 1.5        | -8.0, 88.3      |
       | decimal     | -8.0, 88.3      | 1.1, 1.5        |
       | string      | "s"             | "not s"         |
@@ -2344,7 +2344,7 @@ Feature: Concept Owns Annotations
     Then entity(player) get owns(second-custom-attribute) get constraints contain: @values(<args>)
     Examples:
       | value-type  | args                                                                         | args-specialise                            |
-      | integer        | 1, 10, 20, 30                                                                | 10, 30                                     |
+      | integer     | 1, 10, 20, 30                                                                | 10, 30                                     |
       | double      | 1.0, 2.0, 3.0, 4.5                                                           | 2.0                                        |
       | decimal     | 0.0, 1.0                                                                     | 0.0                                        |
       | string      | "john", "John", "Johnny", "johnny"                                           | "John", "Johnny"                           |
@@ -2434,7 +2434,7 @@ Feature: Concept Owns Annotations
     Then entity(player) get owns(second-custom-attribute) get constraints contain: @values(<args>)
     Examples:
       | value-type  | args                                                                         | args-specialise          |
-      | integer        | 1, 10, 20, 30                                                                | 10, 31                   |
+      | integer     | 1, 10, 20, 30                                                                | 10, 31                   |
       | double      | 1.0, 2.0, 3.0, 4.5                                                           | 2.001                    |
       | decimal     | 0.0, 1.0                                                                     | 0.01                     |
       | string      | "john", "John", "Johnny", "johnny"                                           | "Jonathan"               |
@@ -2663,11 +2663,11 @@ Feature: Concept Owns Annotations
     Then entity(person) get owns(custom-attribute) get constraint categories do not contain: @range
     Examples:
       | value-type  | arg0                              | arg1                                                  |
-      | integer        | 0                                 | 1                                                     |
-      | integer        | 1                                 | 2                                                     |
-      | integer        | 0                                 | 2                                                     |
-      | integer        | -1                                | 1                                                     |
-      | integer        | -9223372036854775808              | 9223372036854775807                                   |
+      | integer     | 0                                 | 1                                                     |
+      | integer     | 1                                 | 2                                                     |
+      | integer     | 0                                 | 2                                                     |
+      | integer     | -1                                | 1                                                     |
+      | integer     | -9223372036854775808              | 9223372036854775807                                   |
       | string      | "A"                               | "a"                                                   |
       | string      | "a"                               | "z"                                                   |
       | string      | "A"                               | "福"                                                   |
@@ -2700,7 +2700,7 @@ Feature: Concept Owns Annotations
     # TODO: Struct parsing is not supported now
 #  Scenario: Owns cannot set @range annotation for struct value type
 #    When create attribute type: custom-attribute
-#    When attribute(custom-attribute) set value type: custom-struct
+#    When attribute(custom-attribute) set value type: struct(custom-struct)
 #    When entity(person) set owns: custom-attribute
 #    When entity(person) get owns(custom-attribute) set annotation: @range(custom-struct..custom-struct); fails
 #    When entity(person) get owns(custom-attribute) set annotation: @range({"string"}..{"string+1"}); fails
@@ -2781,7 +2781,7 @@ Feature: Concept Owns Annotations
     Then entity(person) get owns(custom-attribute) get constraints contain: @range(<args>)
     Examples:
       | value-type  | args                             |
-      | integer        | 1..2                             |
+      | integer     | 1..2                             |
       | double      | 1.0..2.0                         |
       | decimal     | 1.0..2.0                         |
       | string      | "str".."str another"             |
@@ -2813,7 +2813,7 @@ Feature: Concept Owns Annotations
     Then entity(person) get owns(custom-attribute) get constraints do not contain: @range(<reset-args>)
     Examples:
       | value-type  | args                             | reset-args                       |
-      | integer        | 1..5                             | 7..9                             |
+      | integer     | 1..5                             | 7..9                             |
       | double      | 1.1..1.5                         | -8.0..88.3                       |
       | decimal     | -8.0..88.3                       | 1.1..1.5                         |
       | string      | "S".."s"                         | "not s".."xxxxxxxxx"             |
@@ -2832,7 +2832,7 @@ Feature: Concept Owns Annotations
     Then entity(person) get owns(custom-attribute) get constraint categories do not contain: @range
     Examples:
       | value-type  | arg0                     | args                     |
-      | integer        | 1                        | 1                        |
+      | integer     | 1                        | 1                        |
       | double      | 1.0                      | 1.0                      |
       | decimal     | 1.0                      | 1.0                      |
       | string      | "123"                    | "123"                    |
@@ -2955,7 +2955,7 @@ Feature: Concept Owns Annotations
     Then entity(player) get owns(second-custom-attribute) get constraints contain: @range(<args>)
     Examples:
       | value-type  | args                             | args-specialise                           |
-      | integer        | 1..10                            | 1..5                                      |
+      | integer     | 1..10                            | 1..5                                      |
       | double      | 1.0..10.0                        | 2.0..10.0                                 |
       | decimal     | 0.0..1.0                         | 0.0..0.999999                             |
       | string      | "A".."Z"                         | "J".."Z"                                  |
@@ -3043,7 +3043,7 @@ Feature: Concept Owns Annotations
     Then entity(player) get owns(second-custom-attribute) get constraints contain: @range(<args>)
     Examples:
       | value-type  | args                             | args-specialise                           |
-      | integer        | 1..10                            | -1..5                                     |
+      | integer     | 1..10                            | -1..5                                     |
       | double      | 1.0..10.0                        | 0.0..150.0                                |
       | decimal     | 0.0..1.0                         | -0.0001..0.999999                         |
       | string      | "A".."Z"                         | "A".."z"                                  |
@@ -3233,7 +3233,7 @@ Feature: Concept Owns Annotations
     Then entity(person) get owns(custom-attribute-2) get cardinality: @card(0..)
     Examples:
       | value-type  |
-      | integer        |
+      | integer     |
       | double      |
       | decimal     |
       | string      |
@@ -3276,15 +3276,15 @@ Feature: Concept Owns Annotations
     When connection open read transaction for database: typedb
     Then entity(person) get owns is empty
     Examples:
-      | value-type    | arg0                | arg1                |
-      | string        | 0                   | 10                  |
-      | boolean       | 0                   | 9223372036854775807 |
-      | double        | 1                   | 10                  |
-      | decimal       | 0                   |                     |
-      | date          | 1                   |                     |
-      | datetime-tz   | 1                   | 1                   |
-      | duration      | 9223372036854775807 | 9223372036854775807 |
-      | custom-struct | 9223372036854775807 |                     |
+      | value-type            | arg0                | arg1                |
+      | string                | 0                   | 10                  |
+      | boolean               | 0                   | 9223372036854775807 |
+      | double                | 1                   | 10                  |
+      | decimal               | 0                   |                     |
+      | date                  | 1                   |                     |
+      | datetime-tz           | 1                   | 1                   |
+      | duration              | 9223372036854775807 | 9223372036854775807 |
+      | struct(custom-struct) | 9223372036854775807 |                     |
 
   Scenario Outline: Ordered owns can set @card annotation for <value-type> value type with arguments in correct order and unset it
     When create attribute type: custom-attribute
@@ -3320,15 +3320,15 @@ Feature: Concept Owns Annotations
     When connection open read transaction for database: typedb
     Then entity(person) get owns is empty
     Examples:
-      | value-type    | arg0                | arg1                |
-      | integer          | 0                   | 1                   |
-      | string        | 0                   | 10                  |
-      | boolean       | 0                   | 9223372036854775807 |
-      | double        | 1                   | 10                  |
-      | date          | 1                   |                     |
-      | datetime-tz   | 1                   | 1                   |
-      | duration      | 9223372036854775807 | 9223372036854775807 |
-      | custom-struct | 9223372036854775807 |                     |
+      | value-type            | arg0                | arg1                |
+      | integer               | 0                   | 1                   |
+      | string                | 0                   | 10                  |
+      | boolean               | 0                   | 9223372036854775807 |
+      | double                | 1                   | 10                  |
+      | date                  | 1                   |                     |
+      | datetime-tz           | 1                   | 1                   |
+      | duration              | 9223372036854775807 | 9223372036854775807 |
+      | struct(custom-struct) | 9223372036854775807 |                     |
 
   Scenario Outline: Owns can set @card annotation for <value-type> value type with duplicate args (exactly N ownerships)
     When create attribute type: custom-attribute
@@ -3341,18 +3341,18 @@ Feature: Concept Owns Annotations
     When connection open read transaction for database: typedb
     Then entity(person) get owns(custom-attribute) get constraints contain: @card(<arg>..<arg>)
     Examples:
-      | value-type    | arg  |
-      | integer          | 1    |
-      | integer          | 9999 |
-      | string        | 8888 |
-      | boolean       | 7777 |
-      | double        | 666  |
-      | decimal       | 555  |
-      | date          | 444  |
-      | datetime      | 444  |
-      | datetime-tz   | 33   |
-      | duration      | 22   |
-      | custom-struct | 11   |
+      | value-type            | arg  |
+      | integer               | 1    |
+      | integer               | 9999 |
+      | string                | 8888 |
+      | boolean               | 7777 |
+      | double                | 666  |
+      | decimal               | 555  |
+      | date                  | 444  |
+      | datetime              | 444  |
+      | datetime-tz           | 33   |
+      | duration              | 22   |
+      | struct(custom-struct) | 11   |
 
   Scenario Outline: Owns cannot have @card annotation for <value-type> value type with invalid arguments
     When create attribute type: custom-attribute
@@ -3366,7 +3366,7 @@ Feature: Concept Owns Annotations
     Then entity(person) get owns(custom-attribute) get declared annotation categories do not contain: @card
     Examples:
       | value-type |
-      | integer       |
+      | integer    |
 
   Scenario: Owns can have @card annotation for none value type
     When create attribute type: custom-attribute
@@ -3397,7 +3397,7 @@ Feature: Concept Owns Annotations
     Then entity(person) get owns(custom-attribute) get constraints contain: @card(<args>)
     Examples:
       | value-type | args |
-      | integer       | 1..2 |
+      | integer    | 1..2 |
       | duration   | 0..9 |
 
   Scenario Outline: Owns can reset @card annotations
@@ -3444,7 +3444,7 @@ Feature: Concept Owns Annotations
     Then entity(person) get owns(custom-attribute) get constraints contain: @card(<args>)
     Examples:
       | value-type  | args | reset-args |
-      | integer        | 2..5 | 7..9       |
+      | integer     | 2..5 | 7..9       |
       | double      | 2..5 | 0..1       |
       | decimal     | 2..5 | 0..        |
       | string      | 2..5 | 4..        |
@@ -3592,7 +3592,7 @@ Feature: Concept Owns Annotations
     Then relation(description) get owns(second-custom-attribute) get declared annotations do not contain: @card(<args-specialise>)
     Examples:
       | value-type  | args       | args-specialise |
-      | integer        | 0..        | 0..10000        |
+      | integer     | 0..        | 0..10000        |
       | double      | 0..10      | 0..2            |
       | decimal     | 0..2       | 1..2            |
       | string      | 1..        | 1..1            |
@@ -3677,7 +3677,7 @@ Feature: Concept Owns Annotations
     Then relation(description) get constraints for owned attribute(second-custom-attribute) do not contain: @card(<args-specialise>)
     Examples:
       | value-type  | args       | args-specialise |
-      | integer        | 0..10000   | 0..10001        |
+      | integer     | 0..10000   | 0..10001        |
       | double      | 0..10      | 1..11           |
       | string      | 1..        | 0..2            |
       | decimal     | 2..2       | 1..1            |
@@ -4617,7 +4617,7 @@ Feature: Concept Owns Annotations
     Then <root-type>(<type-name>) get constraints for owned attribute(custom-attribute-ordered) do not contain: @distinct
     Examples:
       | root-type | type-name   | value-type |
-      | entity    | person      | integer       |
+      | entity    | person      | integer    |
       | relation  | description | string     |
 
   Scenario Outline: Ordered owns for <root-type> can set @distinct annotation for <value-type> value type and unset it
@@ -4646,27 +4646,27 @@ Feature: Concept Owns Annotations
     When connection open read transaction for database: typedb
     Then <root-type>(<type-name>) get owns is empty
     Examples:
-      | root-type | type-name   | value-type    |
-      | entity    | person      | integer          |
-      | entity    | person      | string        |
-      | entity    | person      | boolean       |
-      | entity    | person      | double        |
-      | entity    | person      | decimal       |
-      | entity    | person      | date          |
-      | entity    | person      | datetime      |
-      | entity    | person      | datetime-tz   |
-      | entity    | person      | duration      |
-      | entity    | person      | custom-struct |
-      | relation  | description | integer          |
-      | relation  | description | string        |
-      | relation  | description | boolean       |
-      | relation  | description | double        |
-      | relation  | description | decimal       |
-      | relation  | description | date          |
-      | relation  | description | datetime      |
-      | relation  | description | datetime-tz   |
-      | relation  | description | duration      |
-      | relation  | description | custom-struct |
+      | root-type | type-name   | value-type            |
+      | entity    | person      | integer               |
+      | entity    | person      | string                |
+      | entity    | person      | boolean               |
+      | entity    | person      | double                |
+      | entity    | person      | decimal               |
+      | entity    | person      | date                  |
+      | entity    | person      | datetime              |
+      | entity    | person      | datetime-tz           |
+      | entity    | person      | duration              |
+      | entity    | person      | struct(custom-struct) |
+      | relation  | description | integer               |
+      | relation  | description | string                |
+      | relation  | description | boolean               |
+      | relation  | description | double                |
+      | relation  | description | decimal               |
+      | relation  | description | date                  |
+      | relation  | description | datetime              |
+      | relation  | description | datetime-tz           |
+      | relation  | description | duration              |
+      | relation  | description | struct(custom-struct) |
 
   Scenario: Owns can have @distinct annotation for none value type
     When create attribute type: custom-attribute
@@ -4698,7 +4698,7 @@ Feature: Concept Owns Annotations
     Then entity(person) get owns(custom-attribute) get constraints contain: @distinct
     Examples:
       | value-type |
-      | integer       |
+      | integer    |
       | decimal    |
 
   Scenario Outline: <root-type> types can redeclare owns as owns with @distinct
@@ -4747,7 +4747,7 @@ Feature: Concept Owns Annotations
     Examples:
       | root-type | type-name   | value-type |
       | entity    | person      | string     |
-      | entity    | person      | integer       |
+      | entity    | person      | integer    |
       | relation  | description | datetime   |
       | relation  | description | duration   |
 
@@ -4783,7 +4783,7 @@ Feature: Concept Owns Annotations
     Examples:
       | root-type | type-name   | value-type |
       | entity    | person      | string     |
-      | entity    | person      | integer       |
+      | entity    | person      | integer    |
       | relation  | description | datetime   |
       | relation  | description | duration   |
 
@@ -4909,16 +4909,16 @@ Feature: Concept Owns Annotations
     When connection open read transaction for database: typedb
     Then entity(person) get owns(custom-attribute) get constraint categories do not contain: @regex
     Examples:
-      | value-type    |
-      | integer          |
-      | boolean       |
-      | double        |
-      | decimal       |
-      | date          |
-      | datetime      |
-      | datetime-tz   |
-      | duration      |
-      | custom-struct |
+      | value-type            |
+      | integer               |
+      | boolean               |
+      | double                |
+      | decimal               |
+      | date                  |
+      | datetime              |
+      | datetime-tz           |
+      | duration              |
+      | struct(custom-struct) |
 
   Scenario: Owns can set @regex annotation if there is a different @regex annotation on the attribute
     When create attribute type: custom-attribute
@@ -5086,7 +5086,7 @@ Feature: Concept Owns Annotations
     Then attribute(custom-attribute) set value type: datetime; fails
     Then attribute(custom-attribute) set value type: datetime-tz; fails
     Then attribute(custom-attribute) set value type: duration; fails
-    Then attribute(custom-attribute) set value type: custom-struct; fails
+    Then attribute(custom-attribute) set value type: struct(custom-struct); fails
     When attribute(custom-attribute) set value type: string
     When entity(person) get owns(custom-attribute) unset annotation: @regex
     When attribute(custom-attribute) unset value type
@@ -5106,7 +5106,7 @@ Feature: Concept Owns Annotations
     Then attribute(custom-attribute) set value type: datetime; fails
     Then attribute(custom-attribute) set value type: datetime-tz; fails
     Then attribute(custom-attribute) set value type: duration; fails
-    Then attribute(custom-attribute) set value type: custom-struct; fails
+    Then attribute(custom-attribute) set value type: struct(custom-struct); fails
     When attribute(custom-attribute) set value type: string
     Then attribute(custom-attribute) get value type: string
     Then transaction commits
@@ -5162,7 +5162,7 @@ Feature: Concept Owns Annotations
 #      | subkey(L)                         | range(false..true) | subkey                | range                 | boolean     |
 #      | subkey(L)                         | card(0..1)         | subkey                | card                  | integer        |
 #      | subkey(L)                         | regex("s")         | subkey                | regex                 | string      |
-      | unique                        | values(1, 2)    | unique                | values                | integer        |
+      | unique                        | values(1, 2)    | unique                | values                | integer     |
       | unique                        | range(1.0..2.0) | unique                | range                 | decimal     |
       | unique                        | card(0..1)      | unique                | card                  | decimal     |
       | unique                        | regex("s")      | unique                | regex                 | string      |
@@ -5210,19 +5210,19 @@ Feature: Concept Owns Annotations
     Examples:
     # TODO: Move to "cannot" test if something is wrong here.
       | annotation-1                  | annotation-2    | annotation-category-1 | annotation-category-2 | value-type  |
-      | unique                        | values(1, 2)    | unique                | values                | integer        |
+      | unique                        | values(1, 2)    | unique                | values                | integer     |
       | unique                        | range(1.0..2.0) | unique                | range                 | decimal     |
-      | unique                        | card(0..1)      | unique                | card                  | integer        |
+      | unique                        | card(0..1)      | unique                | card                  | integer     |
       | unique                        | regex("s")      | unique                | regex                 | string      |
       | unique                        | distinct        | unique                | distinct              | string      |
       | values(2024-05-06+0100)       | card(0..1)      | values                | card                  | datetime-tz |
-      | values(1, 2)                  | distinct        | values                | distinct              | integer        |
+      | values(1, 2)                  | distinct        | values                | distinct              | integer     |
       | values(1.0, 2.0)              | range(1.0..2.0) | values                | range                 | decimal     |
       | values("str")                 | regex("s")      | values                | regex                 | string      |
       | range(2020-05-05..2025-05-05) | card(0..1)      | range                 | card                  | datetime    |
       | range(2020-05-05..2025-05-05) | distinct        | range                 | distinct              | date        |
       | card(0..1)                    | regex("s")      | card                  | regex                 | string      |
-      | card(0..1)                    | distinct        | card                  | distinct              | integer        |
+      | card(0..1)                    | distinct        | card                  | distinct              | integer     |
       | regex("s")                    | distinct        | regex                 | distinct              | string      |
       | range("1".."2")               | regex("s")      | range                 | regex                 | string      |
 
@@ -5245,11 +5245,11 @@ Feature: Concept Owns Annotations
     Then relation(description) get owns(custom-attribute) get declared annotations do not contain: @<annotation-1>
     Examples:
       | annotation-1 | annotation-2 | value-type |
-      | key          | unique       | integer       |
-      | key          | card(0..1)   | integer       |
-      | key          | card(0..)    | integer       |
-      | key          | card(1..1)   | integer       |
-      | key          | card(2..5)   | integer       |
+      | key          | unique       | integer    |
+      | key          | card(0..1)   | integer    |
+      | key          | card(0..)    | integer    |
+      | key          | card(1..1)   | integer    |
+      | key          | card(2..5)   | integer    |
 
   Scenario Outline: Ordered ownership cannot set @<annotation-1> and @<annotation-2> together for <value-type> value type
     When create attribute type: custom-attribute
@@ -5272,11 +5272,11 @@ Feature: Concept Owns Annotations
     Then relation(description) get owns(custom-attribute) get declared annotations do not contain: @<annotation-1>
     Examples:
       | annotation-1 | annotation-2 | value-type |
-      | key          | unique       | integer       |
-      | key          | card(0..1)   | integer       |
-      | key          | card(0..)    | integer       |
-      | key          | card(1..1)   | integer       |
-      | key          | card(2..5)   | integer       |
+      | key          | unique       | integer    |
+      | key          | card(0..1)   | integer    |
+      | key          | card(0..)    | integer    |
+      | key          | card(1..1)   | integer    |
+      | key          | card(2..5)   | integer    |
 
   Scenario Outline: Annotation @key can be set if type has inherited cardinality that can be narrowed
     When create attribute type: name

--- a/concept/type/owns.feature
+++ b/concept/type/owns.feature
@@ -85,16 +85,16 @@ Feature: Concept Owns
       | birthday |
     Then entity(person) get owns is empty
     Examples:
-      | value-type    | value-type-2 |
-      | integer       | string       |
-      | double        | datetime-tz  |
-      | decimal       | datetime     |
-      | string        | duration     |
-      | boolean       | integer      |
-      | date          | decimal      |
-      | datetime-tz   | double       |
-      | duration      | boolean      |
-      | custom-struct | integer      |
+      | value-type            | value-type-2 |
+      | integer               | string       |
+      | double                | datetime-tz  |
+      | decimal               | datetime     |
+      | string                | duration     |
+      | boolean               | integer      |
+      | date                  | decimal      |
+      | datetime-tz           | double       |
+      | duration              | boolean      |
+      | struct(custom-struct) | integer      |
 
   Scenario Outline: Entity types can redeclare owning attributes with <value-type> value type
     When create attribute type: name
@@ -108,10 +108,10 @@ Feature: Concept Owns
     When connection open schema transaction for database: typedb
     Then entity(person) set owns: email
     Examples:
-      | value-type    |
-      | integer       |
-      | datetime      |
-      | custom-struct |
+      | value-type            |
+      | integer               |
+      | datetime              |
+      | struct(custom-struct) |
 
   Scenario: Non-abstract entity type can own abstract attribute with and without value type
     When create entity type: player
@@ -240,16 +240,16 @@ Feature: Concept Owns
       | comment       |
     Then relation(marriage) get owns is empty
     Examples:
-      | value-type    | value-type-2 |
-      | integer       | string       |
-      | double        | datetime-tz  |
-      | decimal       | datetime     |
-      | string        | duration     |
-      | boolean       | integer      |
-      | date          | decimal      |
-      | datetime-tz   | double       |
-      | duration      | boolean      |
-      | custom-struct | integer      |
+      | value-type            | value-type-2 |
+      | integer               | string       |
+      | double                | datetime-tz  |
+      | decimal               | datetime     |
+      | string                | duration     |
+      | boolean               | integer      |
+      | date                  | decimal      |
+      | datetime-tz           | double       |
+      | duration              | boolean      |
+      | struct(custom-struct) | integer      |
 
   Scenario: The schema does not contain redundant owns declarations
     When create attribute type: attr0
@@ -540,11 +540,11 @@ Feature: Concept Owns
     Then <root-type>(<subtype-name-2>) set owns: name
     Then transaction commits; fails
     Examples:
-      | root-type | supertype-name | subtype-name | subtype-name-2 | value-type    |
-      | entity    | person         | customer     | subscriber     | datetime-tz   |
-      | entity    | person         | customer     | subscriber     | custom-struct |
-      | relation  | description    | registration | profile        | decimal       |
-      | relation  | description    | registration | profile        | string        |
+      | root-type | supertype-name | subtype-name | subtype-name-2 | value-type            |
+      | entity    | person         | customer     | subscriber     | datetime-tz           |
+      | entity    | person         | customer     | subscriber     | struct(custom-struct) |
+      | relation  | description    | registration | profile        | decimal               |
+      | relation  | description    | registration | profile        | string                |
 
   Scenario Outline: <root-type> types cannot unset inherited ownership
     When create attribute type: username
@@ -683,16 +683,16 @@ Feature: Concept Owns
       | birthday |
     Then entity(person) get owns is empty
     Examples:
-      | value-type    | value-type-2 |
-      | integer       | string       |
-      | double        | datetime-tz  |
-      | decimal       | datetime     |
-      | string        | duration     |
-      | boolean       | integer      |
-      | date          | decimal      |
-      | datetime-tz   | double       |
-      | duration      | boolean      |
-      | custom-struct | integer      |
+      | value-type            | value-type-2 |
+      | integer               | string       |
+      | double                | datetime-tz  |
+      | decimal               | datetime     |
+      | string                | duration     |
+      | boolean               | integer      |
+      | date                  | decimal      |
+      | datetime-tz           | double       |
+      | duration              | boolean      |
+      | struct(custom-struct) | integer      |
 
   Scenario Outline: Entity types can redeclare ordered ownership
     When create attribute type: name
@@ -714,17 +714,17 @@ Feature: Concept Owns
     Then entity(person) get owns(email) get ordering: unordered
     Then transaction commits
     Examples:
-      | value-type    |
-      | integer       |
-      | double        |
-      | decimal       |
-      | string        |
-      | boolean       |
-      | date          |
-      | datetime      |
-      | datetime-tz   |
-      | duration      |
-      | custom-struct |
+      | value-type            |
+      | integer               |
+      | double                |
+      | decimal               |
+      | string                |
+      | boolean               |
+      | date                  |
+      | datetime              |
+      | datetime-tz           |
+      | duration              |
+      | struct(custom-struct) |
 
   Scenario: Abstract entity type can set ordered ownership
     When create entity type: player
@@ -808,10 +808,10 @@ Feature: Concept Owns
       | comment       |
     Then relation(marriage) get owns is empty
     Examples:
-      | value-type    | value-type-2 |
-      | integer       | string       |
-      | double        | datetime-tz  |
-      | custom-struct | decimal      |
+      | value-type            | value-type-2 |
+      | integer               | string       |
+      | double                | datetime-tz  |
+      | struct(custom-struct) | decimal      |
 
   Scenario Outline: Relation types can redeclare ordered ownership
     When create attribute type: name
@@ -835,17 +835,17 @@ Feature: Concept Owns
     Then relation(reference) get owns(email) get ordering: unordered
     Then transaction commits
     Examples:
-      | value-type    |
-      | integer       |
-      | double        |
-      | decimal       |
-      | string        |
-      | boolean       |
-      | date          |
-      | datetime      |
-      | datetime-tz   |
-      | duration      |
-      | custom-struct |
+      | value-type            |
+      | integer               |
+      | double                |
+      | decimal               |
+      | string                |
+      | boolean               |
+      | date                  |
+      | datetime              |
+      | datetime-tz           |
+      | duration              |
+      | struct(custom-struct) |
 
   Scenario: Abstract relation type can set ordered ownership of abstract attribute
     When create relation type: reference
@@ -970,11 +970,11 @@ Feature: Concept Owns
     When <root-type>(<subtype-name-2>) set owns: name[]
     Then transaction commits; fails
     Examples:
-      | root-type | supertype-name | subtype-name | subtype-name-2 | value-type    |
-      | entity    | person         | customer     | subscriber     | datetime-tz   |
-      | entity    | person         | customer     | subscriber     | custom-struct |
-      | relation  | description    | registration | profile        | decimal       |
-      | relation  | description    | registration | profile        | string        |
+      | root-type | supertype-name | subtype-name | subtype-name-2 | value-type            |
+      | entity    | person         | customer     | subscriber     | datetime-tz           |
+      | entity    | person         | customer     | subscriber     | struct(custom-struct) |
+      | relation  | description    | registration | profile        | decimal               |
+      | relation  | description    | registration | profile        | string                |
 
   Scenario Outline: <root-type> types cannot own super and sub attribute types of different orderings
     When create attribute type: name
@@ -1093,9 +1093,9 @@ Feature: Concept Owns
     Then <root-type>(<subtype-name>) get owns(name) get ordering: unordered
     Then <root-type>(<subtype-name-2>) get owns(surname) get ordering: unordered
     Examples:
-      | root-type | supertype-name | subtype-name | subtype-name-2 | value-type    |
-      | entity    | person         | customer     | subscriber     | decimal       |
-      | relation  | description    | registration | profile        | custom-struct |
+      | root-type | supertype-name | subtype-name | subtype-name-2 | value-type            |
+      | entity    | person         | customer     | subscriber     | decimal               |
+      | relation  | description    | registration | profile        | struct(custom-struct) |
 
   Scenario Outline: <root-type> type can only redeclare ownership if it specialises the inherited one with an annotation
     When create attribute type: literal

--- a/driver/driver.feature
+++ b/driver/driver.feature
@@ -319,6 +319,7 @@ Feature: TypeDB Driver
     Then transaction is open: false
 
 
+  @ignore-typedb-driver
   Scenario Outline: Driver can open <type> transactions with different transaction timeouts
     When set transaction option transaction_timeout_millis to: 6000
     Then transaction is open: false
@@ -345,6 +346,7 @@ Feature: TypeDB Driver
       | read   |
 
 
+  @ignore-typedb-driver
   Scenario: Driver can open a schema transaction when a parallel schema lock is released
     When set transaction option transaction_timeout_millis to: 5000
     When set transaction option schema_lock_acquire_timeout_millis to: 1000

--- a/driver/driver.feature
+++ b/driver/driver.feature
@@ -319,7 +319,51 @@ Feature: TypeDB Driver
     Then transaction is open: false
 
 
-  # TODO: Check options setting and retrieval
+  Scenario Outline: Driver can open <type> transactions with different transaction timeouts
+    When set transaction option transaction_timeout_millis to: 6000
+    Then transaction is open: false
+    When connection open <type> transaction for database: typedb
+    Then transaction is open: true
+    Then transaction has type: <type>
+    When wait 3 seconds
+    Then transaction is open: true
+    Then transaction has type: <type>
+    Then typeql schema query
+      """
+      match entity $x;
+      """
+    When wait 4 seconds
+    Then transaction is open: false
+    Then typeql schema query; fails with a message containing: "no open transaction"
+      """
+      match entity $x;
+      """
+    Examples:
+      | type   |
+      | schema |
+      | write  |
+      | read   |
+
+
+  Scenario: Driver can open a schema transaction when a parallel schema lock is released
+    When set transaction option transaction_timeout_millis to: 5000
+    When set transaction option schema_lock_acquire_timeout_millis to: 1000
+    When in background, connection open schema transaction for database: typedb
+    Then transaction is open: false
+    Then connection open schema transaction for database: typedb; fails with a message containing: "timeout"
+    Then transaction is open: false
+    When wait 5 seconds
+    When set transaction option transaction_timeout_millis to: 1000
+    When set transaction option schema_lock_acquire_timeout_millis to: 5000
+    When in background, connection open schema transaction for database: typedb
+    Then transaction is open: false
+    When connection open schema transaction for database: typedb
+    Then transaction is open: true
+    Then transaction has type: schema
+    Then typeql schema query
+      """
+      match entity $x;
+      """
 
 
   # TODO: Fix on_close

--- a/driver/driver.feature
+++ b/driver/driver.feature
@@ -778,7 +778,7 @@ Feature: TypeDB Driver
         "single attribute type": {
             "kind": "attribute",
             "label": "name",
-            "value_type": "string"
+            "valueType": "string"
         }
     }
     """
@@ -789,7 +789,7 @@ Feature: TypeDB Driver
         "single attribute type": {
             "kind": "attribute",
             "label": "id",
-            "value_type": "integer"
+            "valueType": "integer"
         }
     }
     """

--- a/driver/user.feature
+++ b/driver/user.feature
@@ -125,10 +125,10 @@ Feature: Driver User
     Given typedb starts
     Given connection opens with username 'admin', password 'password'
     When create user with username 'user', password 'password'
-    Then create user with username 'user', password 'password'; fails with a message containing: "Invalid credential supplied"
-    Then create user with username 'user', password 'new-password'; fails with a message containing: "Invalid credential supplied"
-    Then create user with username 'admin', password 'password'; fails with a message containing: "Invalid credential supplied"
-    Then create user with username 'admin', password 'new-password'; fails with a message containing: "Invalid credential supplied"
+    Then create user with username 'user', password 'password'; fails with a message containing: "User already exists"
+    Then create user with username 'user', password 'new-password'; fails with a message containing: "User already exists"
+    Then create user with username 'admin', password 'password'; fails with a message containing: "User already exists"
+    Then create user with username 'admin', password 'new-password'; fails with a message containing: "User already exists"
 
 
   Scenario: User can be created after deletion


### PR DESCRIPTION
## Usage and product changes
Update BDDs with the introduction of the HTTP client and driver steps for it:
* concept tests expect custom value types to be specified inside a `struct(xxxx)` wrapper to avoid errors (it's generally more explicit and it does not have conflicts with driver BDD steps).
* add tests for transaction options (currently works only for HTTP).

## Implementation

