### PR TITLE
Add tests for variable visibility

### DIFF
--- a/query/language/fetch.feature
+++ b/query/language/fetch.feature
@@ -2997,3 +2997,29 @@ Feature: TypeQL Fetch Query
         "also known as": "Jon"
       }
       """
+
+  ###############
+  # VALIDATION  #
+  ###############
+
+  Scenario: Fetch clauses cannot access unavailable variables
+    # See: https://github.com/typedb/typedb/issues/7462
+    Then typeql read query; fails with a message containing: "The variable 'p' is not available."
+      """
+      match {$p isa person;} or {$k isa person;}; fetch {"p": $p.name};
+      """
+
+    Then typeql read query; fails with a message containing: "The variable 'p' is required to be bound to a value before it's used"
+    """
+    with fun name($p: person) -> name:
+    match $p has name $n;
+    return first $n;
+
+    match {$p isa person;} or {$k isa person;}; fetch {"name": name($p)};
+
+    """
+
+    Then typeql read query; fails with a message containing: "The variable 'p' is not available."
+    """
+    match {$p isa person;} or {$k isa person;}; fetch {$p.*};
+    """

--- a/query/language/validation.feature
+++ b/query/language/validation.feature
@@ -22,7 +22,6 @@ Feature: TypeQL Validation
       """
     Given transaction commits
 
-  Scenario: Disjunction local variables are not visible in downstream stages
 
   Scenario: Disjunction local variables are not visible in subsequent stages
     Given connection open read transaction for database: typedb
@@ -56,5 +55,16 @@ Feature: TypeQL Validation
        $p isa person;
       reduce $c = count($p);
       select $p;
+      """
+    Given transaction closes
+
+    Given connection open read transaction for database: typedb
+    Then typeql read query
+      """
+      match
+       $p1 isa person;
+       $p2 isa person;
+      reduce $c = count($p1) groupby $p2;
+      select $p2, $c;
       """
     Given transaction closes

--- a/query/language/validation.feature
+++ b/query/language/validation.feature
@@ -1,0 +1,60 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#noinspection CucumberUndefinedStep
+Feature: TypeQL Validation
+
+  Background: Open connection and create a simple extensible schema
+    Given typedb starts
+    Given connection opens with default authentication
+    Given connection is open: true
+    Given connection has 0 databases
+    Given connection create database: typedb
+
+    Given connection open schema transaction for database: typedb
+    Given typeql schema query
+      """
+      define
+      entity person
+        owns name @card(0..);
+      attribute name value string;
+      """
+    Given transaction commits
+
+  Scenario: Disjunction local variables are not visible in downstream stages
+
+  Scenario: Disjunction local variables are not visible in subsequent stages
+    Given connection open read transaction for database: typedb
+    Then typeql read query; fails with a message containing: "The variable 'p' was not available in the stage"
+      """
+      match
+       { $p isa person; } or { $k isa person; };
+      select $p;
+      """
+    Given transaction closes
+
+
+  Scenario: Deleted variables are not visible in subsequent stages
+    Given connection open read transaction for database: typedb
+    Then typeql read query; fails with a message containing: "The variable 'p' was not available in the stage"
+      """
+      match
+       $p isa person;
+      delete
+       $p;
+      select $p;
+      """
+    Given transaction closes
+
+
+  Scenario: Reduced variables are not visible in subsequent stages
+    Given connection open read transaction for database: typedb
+    Then typeql read query; fails with a message containing: "The variable 'p' was not available in the stage"
+      """
+      match
+       $p isa person;
+      reduce $c = count($p);
+      select $p;
+      """
+    Given transaction closes


### PR DESCRIPTION
## Usage and product changes
Add tests for variable visibility to ensure subsequent stages do not see visibles which are disjunction local, deleted, or (3) reduced away.

## Implementation
Introduces tests in a newly introduced `validation.feature`
