### PR TITLE
Implement optional scenarios

### DIFF
--- a/query/functions/usage.feature
+++ b/query/functions/usage.feature
@@ -41,7 +41,7 @@ Feature: Function Usage
       let $six = five() + 1;
     """
     Then uniquely identify answer concepts
-      | six          |
+      | six             |
       | value:integer:6 |
     Given transaction closes
 
@@ -107,7 +107,7 @@ Feature: Function Usage
       let $ten = five() + five();
     """
     Then uniquely identify answer concepts
-      | ten           |
+      | ten              |
       | value:integer:10 |
     Given transaction closes
 
@@ -184,8 +184,8 @@ Feature: Function Usage
     """
     Then answer size is: 1
     Then uniquely identify answer concepts
-      | z                |
-      | value:integer:1  |
+      | x               | y               | z               |
+      | value:integer:2 | value:integer:1 | value:integer:1 |
 
 
   Scenario: A variable that is input from a previous stage may not be assigned to

--- a/query/language/disjunction.feature
+++ b/query/language/disjunction.feature
@@ -100,6 +100,61 @@ Feature: TypeQL Disjunction
       | key:ref:1 |
 
 
+  Scenario: a variable reused across all nested branches of a nested disjunction is returned
+    Given transaction commits
+
+    Given connection open write transaction for database: typedb
+    Given typeql write query
+      """
+      insert
+        $p1 isa person, has ref 10, has name "Alice";
+        $p2 isa person, has ref 11, has name "Bob";
+        $p3 isa person, has ref 12, has name "Charlie";
+      """
+    Given transaction commits
+
+    Given connection open read transaction for database: typedb
+    When get answers of typeql read query
+      """
+      match 
+      {
+        { $p has ref 10; } or { $p has ref 11; };
+      } or {
+        { $p has ref 11; } or { $p has ref 12; };
+      };
+      """
+    Then uniquely identify answer concepts
+      | p          |
+      | key:ref:10 |
+      | key:ref:11 |
+      | key:ref:12 |
+
+
+  Scenario: a variable only used in one branch is not returned
+    Given transaction commits
+
+    Given connection open write transaction for database: typedb
+    Given typeql write query
+      """
+      insert
+        $p1 isa person, has ref 1, has name "Dave";
+        $p2 isa person, has ref 2, has name "Eve";
+      """
+    Given transaction commits
+
+    Given connection open read transaction for database: typedb
+    When get answers of typeql read query
+      """
+      match 
+      { $p isa person, has ref 1; $other isa person, has ref 2; } or { $p isa person, has ref 2; };
+      """
+    Then answers do not contain variable: other
+    Then uniquely identify answer concepts
+      | p          |
+      | key:ref:1 |
+      | key:ref:2 |
+
+
   Scenario: a conjunction where one disjunction produces a variable, and the other only references it can be planned.
     Given transaction closes
     Given connection open read transaction for database: typedb

--- a/query/language/disjunction.feature
+++ b/query/language/disjunction.feature
@@ -53,9 +53,9 @@ Feature: TypeQL Disjunction
       match $x isa $t; { $t label person; } or { $t label company; };
       """
     Then uniquely identify answer concepts
-      | x         |
-      | key:ref:0 |
-      | key:ref:1 |
+      | x         | t             |
+      | key:ref:0 | label:person  |
+      | key:ref:1 | label:company |
     When get answers of typeql read query
       """
       match $x isa $_; { $x has name "Jeff"; } or { $x has name "Amazon"; };
@@ -150,7 +150,7 @@ Feature: TypeQL Disjunction
       """
     Then answers do not contain variable: other
     Then uniquely identify answer concepts
-      | p          |
+      | p         |
       | key:ref:1 |
       | key:ref:2 |
 

--- a/query/language/expression.feature
+++ b/query/language/expression.feature
@@ -195,7 +195,7 @@ Feature: TypeQL Query with Expressions
       """
     Then uniquely identify answer concepts
       | x               | y                |
-      | attr:name:Lisa  | attribute:age:16 |
+      | attr:name:Lisa  | attr:age:16 |
 
 
   Scenario: Value variables and concept variables may not share name

--- a/query/language/expression.feature
+++ b/query/language/expression.feature
@@ -75,7 +75,6 @@ Feature: TypeQL Query with Expressions
     """
       match
         $x isa person, has age $a, has height $h;
-        let $v0 = $v; # TODO: Remove. once rebased on Dmitrii's changes
         { let $v = $a * 2; } or { let $v = 0; };
         { let $v = $h * 2; } or { let $v = 1; };
       select
@@ -85,7 +84,6 @@ Feature: TypeQL Query with Expressions
     """
       match
         $x isa person, has age $a, has height $h;
-        let $v0 = $v; # TODO: Remove. once rebased on Dmitrii's changes
         { let $v = $a * 2; } or { let $v = 1; };
       match
         { let $v = $h * 2; } or { let $v = 2; };
@@ -96,7 +94,6 @@ Feature: TypeQL Query with Expressions
     """
       match
         $x isa person, has age $a, has height $h;
-        let $v0 = $v; # TODO: Remove. once rebased on Dmitrii's changes
         { let $v = $a * 2; } or { let $v = $h * 2; };
       select
         $v;
@@ -110,7 +107,6 @@ Feature: TypeQL Query with Expressions
     """
       match
         $x isa person, has age $a, has height $h;
-        let $v0 = $v; # TODO: Remove. once rebased on Dmitrii's changes
         { let $v = 12; } or {
           let $v1 = $v;
           { let $v = $a * 2; } or { let $v = $h * 2; };
@@ -243,7 +239,6 @@ Feature: TypeQL Query with Expressions
       """
       match
       $p isa person;
-      let $v0 = $v; # TODO: Remove. once rebased on Dmitrii's changes
       { $p has age $a; let $v = $a; } or
       { $p has name $n; let $v = $n; };
       """
@@ -251,7 +246,6 @@ Feature: TypeQL Query with Expressions
       """
       match
       $p isa person, has age $a;
-      let $v0 = $v; # TODO: Remove. once rebased on Dmitrii's changes
       { let $v = $a * 2; } or
       { let $v = $a / 2.0; };
       """

--- a/query/language/expression.feature
+++ b/query/language/expression.feature
@@ -194,8 +194,8 @@ Feature: TypeQL Query with Expressions
       select $x, $y;
       """
     Then uniquely identify answer concepts
-      | x               |
-      | attr:name:Lisa  |
+      | x               | y                |
+      | attr:name:Lisa  | attribute:age:16 |
 
 
   Scenario: Value variables and concept variables may not share name

--- a/query/language/fetch.feature
+++ b/query/language/fetch.feature
@@ -1596,10 +1596,10 @@ Feature: TypeQL Fetch Query
       """
     Given answer size is: 3
     Given uniquely identify answer concepts
-      | z                      |
-      | attr:person-name:Alice |
-      | attr:person-name:Allie |
-      | attr:person-name:Bob   |
+      | p         | z                      |
+      | key:ref:0 | attr:person-name:Alice |
+      | key:ref:0 | attr:person-name:Allie |
+      | key:ref:1 | attr:person-name:Bob   |
 
     Given get answers of typeql read query
       """
@@ -1615,8 +1615,8 @@ Feature: TypeQL Fetch Query
       """
     Given answer size is: 1
     Given uniquely identify answer concepts
-      | z           |
-      | attr:age:10 |
+      | p         | z           |
+      | key:ref:0 | attr:age:10 |
 
     When get answers of typeql read query
       """
@@ -1731,10 +1731,10 @@ Feature: TypeQL Fetch Query
       """
     Given answer size is: 3
     Given uniquely identify answer concepts
-      | z                  |
-      | value:string:Alice |
-      | value:string:Allie |
-      | value:string:Bob   |
+      | p         | z                  |
+      | key:ref:0 | value:string:Alice |
+      | key:ref:0 | value:string:Allie |
+      | key:ref:1 | value:string:Bob   |
 
     Given get answers of typeql read query
       """
@@ -1751,8 +1751,8 @@ Feature: TypeQL Fetch Query
       """
     Given answer size is: 1
     Given uniquely identify answer concepts
-      | z                |
-      | value:integer:10 |
+      | p         | z                |
+      | key:ref:0 | value:integer:10 |
 
     When get answers of typeql read query
       """
@@ -2113,9 +2113,9 @@ Feature: TypeQL Fetch Query
       """
     Given answer size is: 2
     Given uniquely identify answer concepts
-      | x               | y                | z               |
-      | value:integer:2 | value:integer:20 | value:integer:2 |
-      | value:integer:0 | value:integer:0  | value:integer:0 |
+      | p         | x               | y                | z               |
+      | key:ref:0 | value:integer:2 | value:integer:20 | value:integer:2 |
+      | key:ref:1 | value:integer:0 | value:integer:0  | value:integer:0 |
     When get answers of typeql read query
       """
         match
@@ -2357,10 +2357,10 @@ Feature: TypeQL Fetch Query
       """
     Given answer size is: 3
     Given uniquely identify answer concepts
-      | z                      |
-      | attr:person-name:Alice |
-      | attr:person-name:Allie |
-      | attr:person-name:Bob   |
+      | p         | z                      |
+      | key:ref:0 | attr:person-name:Alice |
+      | key:ref:0 | attr:person-name:Allie |
+      | key:ref:1 | attr:person-name:Bob   |
 
     Given get answers of typeql read query
       """
@@ -2452,10 +2452,10 @@ Feature: TypeQL Fetch Query
       """
     Given answer size is: 3
     Given uniquely identify answer concepts
-      | z                  |
-      | value:string:Alice |
-      | value:string:Allie |
-      | value:string:Bob   |
+      | p         | z                  |
+      | key:ref:0 | value:string:Alice |
+      | key:ref:0 | value:string:Allie |
+      | key:ref:1 | value:string:Bob   |
 
     Given get answers of typeql read query
       """
@@ -2472,8 +2472,8 @@ Feature: TypeQL Fetch Query
       """
     Given answer size is: 1
     Given uniquely identify answer concepts
-      | z                |
-      | value:integer:10 |
+      | p         | z                |
+      | key:ref:0 | value:integer:10 |
 
     When get answers of typeql read query
       """

--- a/query/language/fetch.feature
+++ b/query/language/fetch.feature
@@ -2376,8 +2376,8 @@ Feature: TypeQL Fetch Query
       """
     Given answer size is: 1
     Given uniquely identify answer concepts
-      | z           |
-      | attr:age:10 |
+      | p         | z           |
+      | key:ref:0 | attr:age:10 |
 
     When get answers of typeql read query
       """

--- a/query/language/insert.feature
+++ b/query/language/insert.feature
@@ -1142,8 +1142,8 @@ Parker";
       match $r isa $rt; relation $rt;
       """
     Then uniquely identify answer concepts
-      | r         |
-      | key:ref:1 |
+      | r         | rt               |
+      | key:ref:1 | label:loneliness |
     Then transaction commits; fails with a message containing: "at least one role"
 
   Scenario: relations of relation types without role types can be inserted, then updated to have role players
@@ -1173,9 +1173,9 @@ Parker";
       match $r isa $rt; relation $rt;
       """
     Then uniquely identify answer concepts
-      | r         |
-      | key:ref:1 |
-      | key:ref:2 |
+      | r         | rt               |
+      | key:ref:1 | label:loneliness |
+      | key:ref:2 | label:loneliness |
 
     When typeql schema query
       """
@@ -1204,9 +1204,9 @@ Parker";
       match $r isa $rt; relation $rt;
       """
     Then uniquely identify answer concepts
-      | r         |
-      | key:ref:1 |
-      | key:ref:2 |
+      | r         | rt               |
+      | key:ref:1 | label:loneliness |
+      | key:ref:2 | label:loneliness |
     When transaction commits
 
     When connection open read transaction for database: typedb
@@ -1222,8 +1222,8 @@ Parker";
       match $r isa $rt; relation $rt;
       """
     Then uniquely identify answer concepts
-      | r         |
-      | key:ref:2 |
+      | r         | rt               |
+      | key:ref:2 | label:loneliness |
 
   #######################
   # ATTRIBUTE INSERTION #
@@ -1899,6 +1899,7 @@ Parker";
         $y isa person, has name "Tarja";
       insert
         (employer: $x, employee: $y) isa employment, has ref 10;
+      select $x, $y;
       """
 
     # Should only contain variables mentioned in the insert (so excludes '$z')

--- a/query/language/match.feature
+++ b/query/language/match.feature
@@ -1412,10 +1412,10 @@ Feature: TypeQL Match Clause
        match relation $t; $r isa $t;
        """
     Given uniquely identify answer concepts
-      | r         |
-      | key:ref:1 |
-      | key:ref:2 |
-      | key:ref:3 |
+      | r         | t                |
+      | key:ref:1 | label:employment |
+      | key:ref:2 | label:friendship |
+      | key:ref:3 | label:residency  |
     When get answers of typeql read query
        """
        match ($x) isa $_;
@@ -2536,9 +2536,9 @@ Feature: TypeQL Match Clause
       match $x has name $y;
       """
     Then uniquely identify answer concepts
-      | x         |
-      | key:ref:0 |
-      | key:ref:2 |
+      | x         | y                  |
+      | key:ref:0 | attr:name:"Leila"  |
+      | key:ref:2 | attr:name:"TypeDB" |
 
 
   Scenario: using the 'attribute' meta label, 'has' can match things that own any attribute with a specified value
@@ -3012,9 +3012,9 @@ Feature: TypeQL Match Clause
         $z isa age;
       """
     Then uniquely identify answer concepts
-      | x         |
-      | key:ref:1 |
-      | key:ref:2 |
+      | x         | z           |
+      | key:ref:1 | attr:age:25 |
+      | key:ref:2 | attr:age:18 |
 
 
   Scenario: when the answers of a value comparison include both a 'double' and a 'integer', both answers are returned
@@ -3423,9 +3423,9 @@ Feature: TypeQL Match Clause
       match $x isa! $t; $x has name $_;
       """
     Then uniquely identify answer concepts
-      | t         |
-      | label:人   |
-      | label:אדם |
+      | x         | t         |
+      | key:ref:0 | label:人   |
+      | key:ref:1 | label:אדם |
 
     Given get answers of typeql read query
       """

--- a/query/language/modifiers.feature
+++ b/query/language/modifiers.feature
@@ -79,10 +79,10 @@ Feature: TypeQL Query Modifiers
       | attr:<attr>:<val1> |
 
     Examples:
-      | attr          | type     | val4       | val2             | val3             | val1       |
-      | colour        | string   | "blue"     | "green"          | "red"            | "yellow"   |
-      | score         | integer     | -38        | -4               | 18               | 152        |
-      | correlation   | double   | -29.7      | -0.9             | 0.01             | 100.0      |
+      | attr        | type    | val4   | val2    | val3  | val1     |
+      | colour      | string  | "blue" | "green" | "red" | "yellow" |
+      | score       | integer | -38    | -4      | 18    | 152      |
+      | correlation | double  | -29.7  | -0.9    | 0.01  | 100.0    |
 #      | date-of-birth | datetime | 1970-01-01 | 1999-12-31T23:00 | 1999-12-31T23:01 | 2020-02-29 |
 
 
@@ -105,22 +105,22 @@ Feature: TypeQL Query Modifiers
       sort $y asc;
       """
     Then order of answer concepts is
-      | x         | y                    |
-      | key:ref:3 | attr:name:Brenda     |
-      | key:ref:2 | attr:name:Frederick  |
-      | key:ref:0 | attr:name:Gary       |
-      | key:ref:1 | attr:name:Jemima     |
+      | x         | y                   |
+      | key:ref:3 | attr:name:Brenda    |
+      | key:ref:2 | attr:name:Frederick |
+      | key:ref:0 | attr:name:Gary      |
+      | key:ref:1 | attr:name:Jemima    |
     When get answers of typeql read query
       """
       match $x isa person, has name $y;
       sort $y desc;
       """
     Then order of answer concepts is
-      | x         | y                    |
-      | key:ref:1 | attr:name:Jemima     |
-      | key:ref:0 | attr:name:Gary       |
-      | key:ref:2 | attr:name:Frederick  |
-      | key:ref:3 | attr:name:Brenda     |
+      | x         | y                   |
+      | key:ref:1 | attr:name:Jemima    |
+      | key:ref:0 | attr:name:Gary      |
+      | key:ref:2 | attr:name:Frederick |
+      | key:ref:3 | attr:name:Brenda    |
 
 
   Scenario: the default sort order is ascending
@@ -142,11 +142,11 @@ Feature: TypeQL Query Modifiers
       sort $y;
       """
     Then order of answer concepts is
-      | x         | y                    |
-      | key:ref:3 | attr:name:Brenda     |
-      | key:ref:2 | attr:name:Frederick  |
-      | key:ref:0 | attr:name:Gary       |
-      | key:ref:1 | attr:name:Jemima     |
+      | x         | y                   |
+      | key:ref:3 | attr:name:Brenda    |
+      | key:ref:2 | attr:name:Frederick |
+      | key:ref:0 | attr:name:Gary      |
+      | key:ref:1 | attr:name:Jemima    |
 
 
   Scenario: Sorting on value variables is supported
@@ -171,7 +171,7 @@ Feature: TypeQL Query Modifiers
         $to20 desc;
       """
     Then order of answer concepts is
-      | x         | to20         |
+      | x         | to20            |
       | key:ref:1 | value:integer:6 |
       | key:ref:3 | value:integer:4 |
       | key:ref:0 | value:integer:2 |
@@ -197,11 +197,11 @@ Feature: TypeQL Query Modifiers
       sort $y, $a, $r asc;
       """
     Then order of answer concepts is
-      | y                 |  a           | x         |
-      | attr:name:Brenda  | attr:age:12  | key:ref:3 |
-      | attr:name:Gary    | attr:age:5   | key:ref:1 |
-      | attr:name:Gary    | attr:age:15  | key:ref:0 |
-      | attr:name:Gary    | attr:age:25  | key:ref:2 |
+      | y                | a           | x         |
+      | attr:name:Brenda | attr:age:12 | key:ref:3 |
+      | attr:name:Gary   | attr:age:5  | key:ref:1 |
+      | attr:name:Gary   | attr:age:15 | key:ref:0 |
+      | attr:name:Gary   | attr:age:25 | key:ref:2 |
 
 
   Scenario: multiple sort variables may be used to sort ascending or descending
@@ -223,11 +223,11 @@ Feature: TypeQL Query Modifiers
       sort $y asc, $a desc, $r desc;
       """
     Then order of answer concepts is
-      | y                 |  a           | x         |
-      | attr:name:Brenda  | attr:age:12  | key:ref:3 |
-      | attr:name:Gary    | attr:age:25  | key:ref:2 |
-      | attr:name:Gary    | attr:age:15  | key:ref:0 |
-      | attr:name:Gary    | attr:age:5   | key:ref:1 |
+      | y                | a           | x         |
+      | attr:name:Brenda | attr:age:12 | key:ref:3 |
+      | attr:name:Gary   | attr:age:25 | key:ref:2 |
+      | attr:name:Gary   | attr:age:15 | key:ref:0 |
+      | attr:name:Gary   | attr:age:5  | key:ref:1 |
 
 
   Scenario: a sorted result set can be limited to a specific size
@@ -250,10 +250,10 @@ Feature: TypeQL Query Modifiers
       limit 3;
       """
     Then order of answer concepts is
-      | x         | y                    |
-      | key:ref:3 | attr:name:Brenda     |
-      | key:ref:2 | attr:name:Frederick  |
-      | key:ref:0 | attr:name:Gary       |
+      | x         | y                   |
+      | key:ref:3 | attr:name:Brenda    |
+      | key:ref:2 | attr:name:Frederick |
+      | key:ref:0 | attr:name:Gary      |
 
 
   Scenario: sorted results can be retrieved starting from a specific offset
@@ -276,9 +276,9 @@ Feature: TypeQL Query Modifiers
       offset 2;
       """
     Then order of answer concepts is
-      | x         | y                 |
-      | key:ref:0 | attr:name:Gary    |
-      | key:ref:1 | attr:name:Jemima  |
+      | x         | y                |
+      | key:ref:0 | attr:name:Gary   |
+      | key:ref:1 | attr:name:Jemima |
 
 
   Scenario: 'offset' and 'limit' can be used together to restrict the answer set
@@ -302,9 +302,9 @@ Feature: TypeQL Query Modifiers
       limit 2;
       """
     Then order of answer concepts is
-      | x         | y                    |
-      | key:ref:2 | attr:name:Frederick  |
-      | key:ref:0 | attr:name:Gary       |
+      | x         | y                   |
+      | key:ref:2 | attr:name:Frederick |
+      | key:ref:0 | attr:name:Gary      |
 
 
   Scenario: when the answer size is limited to 0, an empty answer set is returned
@@ -371,12 +371,12 @@ Feature: TypeQL Query Modifiers
       sort $x asc;
       """
     Then order of answer concepts is
-      | x                       |
-      | attr:name:007           |
-      | attr:name:Bond          |
-      | attr:name:James Bond    |
-      | attr:name:agent         |
-      | attr:name:secret agent  |
+      | x                      |
+      | attr:name:007          |
+      | attr:name:Bond         |
+      | attr:name:James Bond   |
+      | attr:name:agent        |
+      | attr:name:secret agent |
 
 
   Scenario: sort is able to correctly handle duplicates in the value set
@@ -400,9 +400,9 @@ Feature: TypeQL Query Modifiers
       limit 2;
       """
     Then order of answer concepts is
-      | x         | y           |
-      | key:ref:0 | attr:age:2  |
-      | key:ref:4 | attr:age:2  |
+      | x         | y          |
+      | key:ref:0 | attr:age:2 |
+      | key:ref:4 | attr:age:2 |
     When get answers of typeql read query
       """
       match $x isa person, has age $y;
@@ -411,9 +411,9 @@ Feature: TypeQL Query Modifiers
       limit 2;
       """
     Then order of answer concepts is
-      | x         | y           |
-      | key:ref:1 | attr:age:6  |
-      | key:ref:3 | attr:age:6  |
+      | x         | y          |
+      | key:ref:1 | attr:age:6 |
+      | key:ref:3 | attr:age:6 |
 
 
   Scenario: when sorting by a variable not contained in the answer set, an error is thrown
@@ -555,11 +555,11 @@ Feature: TypeQL Query Modifiers
       | attr:<attr>:<pivot>   |
 
     Examples:
-      | attr          | type     | pivot      | lesser       | greater          |
-      | colour        | string   | "green"    | "blue"       | "red"            |
-      | score         | integer     | -4         | -38          | 18               |
-      | correlation   | double   | -0.9       | -1.2         | 0.01             |
-      | date-of-birth | datetime | 1970-02-01 |  1970-01-01  | 1999-12-31T23:01 |
+      | attr          | type     | pivot      | lesser     | greater          |
+      | colour        | string   | "green"    | "blue"     | "red"            |
+      | score         | integer  | -4         | -38        | 18               |
+      | correlation   | double   | -0.9       | -1.2       | 0.01             |
+      | date-of-birth | datetime | 1970-02-01 | 1970-01-01 | 1999-12-31T23:01 |
 
 
   Scenario Outline: sorting and query predicates produce order ignoring types
@@ -721,10 +721,10 @@ Feature: TypeQL Query Modifiers
       # NOTE: fourthValuePivot is expected to be the middle of the sort order (pivot)
       | firstAttr   | firstType | firstValue1 | firstValue2 | secondAttr | secondType | secondValue | thirdAttr | thirdType | thirdValue | fourthAttr | fourthType | fourthValuePivot |
       | colour      | string    | "green"     | "blue"      | name       | string     | "alice"     | shape     | string    | "square"   | street     | string     | "carnaby"        |
-      | score       | integer      | 4           | -38         | quantity   | integer       | -50         | area      | integer      | 100        | length     | integer       | 0                |
+      | score       | integer   | 4           | -38         | quantity   | integer    | -50         | area      | integer   | 100        | length     | integer    | 0                |
       | correlation | double    | 4.1         | -38.999     | quantity   | double     | -101.4      | area      | double    | 110.0555   | length     | double     | 0.5              |
-      | dob         | datetime  | 2970-01-01   | 1970-02-01 | start-date | datetime   | 1970-01-01  | end-date  | datetime  | 3100-11-20 | last-date  | datetime   | 2000-08-03       |
-      | score       | integer      | 4           | -38         | quantity   | double     | -55.123     | area      | integer      | 100        | length     | double     | 0.5              |
+      | dob         | datetime  | 2970-01-01  | 1970-02-01  | start-date | datetime   | 1970-01-01  | end-date  | datetime  | 3100-11-20 | last-date  | datetime   | 2000-08-03       |
+      | score       | integer   | 4           | -38         | quantity   | double     | -55.123     | area      | integer   | 100        | length     | double     | 0.5              |
 
 
   Scenario: Fetch queries can use sort, offset, limit
@@ -796,9 +796,9 @@ Feature: TypeQL Query Modifiers
       sort $r; offset 1; limit 2;
       """
     Then uniquely identify answer concepts
-      | x         |
-      | key:ref:1 |
-      | key:ref:2 |
+      | x         | r          |
+      | key:ref:1 | attr:ref:1 |
+      | key:ref:2 | attr:ref:2 |
 
 
   Scenario: Match delete queries can use sort, offset, limit
@@ -832,10 +832,9 @@ Feature: TypeQL Query Modifiers
       sort $n;
       """
     Then uniquely identify answer concepts
-      | x         | n                   |
-      | key:ref:3 | attr:name:Brenda    |
-      | key:ref:0 | attr:name:Gary      |
-
+      | x         | n                |
+      | key:ref:3 | attr:name:Brenda |
+      | key:ref:0 | attr:name:Gary   |
 
 
   Scenario: Match update queries can use sort, offset, limit
@@ -898,8 +897,8 @@ Feature: TypeQL Query Modifiers
       select $z, $x;
       """
     Then uniquely identify answer concepts
-      | z         | x               |
-      | key:ref:0 | attr:name:Lisa  |
+      | z         | x              |
+      | key:ref:0 | attr:name:Lisa |
 
 
   Scenario: when a 'select' has unbound variables, an error is thrown
@@ -930,8 +929,8 @@ Feature: TypeQL Query Modifiers
       select $z, $x, $b;
       """
     Then uniquely identify answer concepts
-      | z         | x              | b                |
-      | key:ref:0 | attr:name:Lisa | value:integer:2001  |
+      | z         | x              | b                  |
+      | key:ref:0 | attr:name:Lisa | value:integer:2001 |
 
 
   # Guards against regression of #6967
@@ -955,8 +954,8 @@ Feature: TypeQL Query Modifiers
       select $n, $r;
       """
     Then uniquely identify answer concepts
-      | n               | r               |
-      | attr:name:Klaus | attr:ref:0      |
+      | n               | r          |
+      | attr:name:Klaus | attr:ref:0 |
 
     When get answers of typeql read query
       """
@@ -968,6 +967,6 @@ Feature: TypeQL Query Modifiers
       sort $r; # The sort triggered the bug
       """
     Then uniquely identify answer concepts
-      | n               | r               |
-      | attr:name:Klaus | attr:ref:0      |
+      | n               | r          |
+      | attr:name:Klaus | attr:ref:0 |
 

--- a/query/language/negation.feature
+++ b/query/language/negation.feature
@@ -645,6 +645,7 @@ Feature: TypeQL Negation
     When get answers of typeql read query
       """
       match $x isa person, has name $a; not { $a == "Jeff"; };
+      select $a;
       """
     Then answer size is: 1
     Then uniquely identify answer concepts

--- a/query/language/optional.feature
+++ b/query/language/optional.feature
@@ -153,7 +153,7 @@ Feature: TypeQL Optional
       | key:ref:12 | key:ref:13 | key:ref:14 |
 
 
-  Scenario: an optional cannot be nested within a disjunction
+  Scenario: an optional cannot be used within a disjunction
     When  typeql read query; fails with a message containing: "cannot be re-used elsewhere as a locally-scoped variable"
       """
       match $x isa person, has name "Frank";
@@ -174,10 +174,129 @@ Feature: TypeQL Optional
 
 
   Scenario: sibling optionals may share the same parent variables, but not overlap shared optional variables
+    Given typeql write query
+      """
+      insert
+      $x isa person, has name "Eve", has ref 1;
+      $y isa company, has name "Netflix", has ref 2;
+      $r isa employment, links (employee: $x, employer: $y), has ref 3;
+      """
+    Given transaction commits
+
+    Given connection open read transaction for database: typedb
+    When get answers of typeql read query
+    """
+      match
+      $x isa person, has name "Eve";
+      try { $r1 isa employment ($x); };
+      try { $r2 isa employment ($x); };
+      """
+    Then uniquely identify answer concepts
+      | x         | r1        | r2        |
+      | key:ref:1 | key:ref:3 | key:ref:3 |
     Then typeql read query; fails with a message containing: "cannot be re-used elsewhere as a locally-scoped variable"
     """
       match
-      $x isa person, has name "Grace";
+      $x isa person, has name "Eve";
       try { $y isa company; $r1 isa employment ($x, $y); };
       try { $y isa company; $r2 isa employment ($x, $y); };
       """
+
+
+  Scenario: an optional variable can be used non-optionally in the next match stage of the pipeline
+    Given typeql write query
+      """
+      insert
+      $p1 isa person, has name "Grace", has ref 30;
+      $p2 isa person, has name "Somebody", has ref 31;
+      $c1 isa company, has name "Uber", has ref 32;
+      $r1 isa employment, links (employee: $p1, employer: $c1), has ref 33;
+      """
+    Given transaction commits
+
+    # a None variable used in a subsequent match causes that row to be filtered out (in this case, the "Somebody" row)
+    Given connection open read transaction for database: typedb
+    When get answers of typeql read query
+      """
+      match
+      $p isa person;
+      try { $c isa company; $r isa employment ($p, $c); };
+      match
+      $p has name $name;
+      $c has name $company_name;
+      """
+    Then uniquely identify answer concepts
+      | p          | c          | r          | name            | company_name   |
+      | key:ref:30 | key:ref:32 | key:ref:33 | attr:name:Grace | attr:name:Uber |
+
+    # a None variable used in a subsequent match, even inside every branch of a Disjunction, causes that row to be filtered out (in this case, the "Somebody" row)
+    When get answers of typeql read query
+      """
+      match
+      $p isa person;
+      try { $c isa company; $r isa employment ($p, $c); };
+      match
+      $p has name $name;
+      { $c has name $attr; $attr == "Uber"; } or { $c has ref $attr; $attr == 32; };
+      """
+    Then uniquely identify answer concepts
+      | p          | c          | r          | name            | attr           |
+      | key:ref:30 | key:ref:32 | key:ref:33 | attr:name:Grace | attr:name:Uber |
+      | key:ref:30 | key:ref:32 | key:ref:33 | attr:name:Grace | attr:ref:32    |
+
+    # a None variable used in a subsequent match can cause only 1 branch of a disjunction to fail
+    When get answers of typeql read query
+      """
+      match
+      $p isa person;
+      try { $c isa company; $r isa employment ($p, $c); };
+      match
+      $p has name $name;
+      { $c has name $attr; $attr == "Uber"; } or { $p has ref 30; } or { $p has ref 31; };
+      """
+    Then uniquely identify answer concepts
+      | p          | c          | r          | name               |
+      | key:ref:30 | key:ref:32 | key:ref:33 | attr:name:Grace    |
+      | key:ref:31 | none       | none       | attr:name:Somebody |
+
+    # a None variable used in a subsequent match, even inside a Negation, causes that row to be filtered out (in this case, the "Somebody" row)
+    When get answers of typeql read query
+      """
+      match
+      $p isa person;
+      try { $c isa company; $r isa employment ($p, $c); };
+      match
+      $p has name $name;
+      not { $c has ref 100000; };
+      """
+    Then uniquely identify answer concepts
+      | p          | c          | r          | name               |
+      | key:ref:30 | key:ref:32 | key:ref:33 | attr:name:Grace    |
+      | key:ref:31 | none       | none       | attr:name:Somebody |
+
+
+  Scenario: an optional variable can be used optionally in the next match stage of the pipeline
+    Given typeql write query
+      """
+      insert
+      $p1 isa person, has name "Grace", has ref 30;
+      $p2 isa person, has name "Somebody", has ref 31;
+      $c1 isa company, has name "Uber", has ref 32;
+      $r1 isa employment, links (employee: $p1, employer: $c1), has ref 33;
+      """
+    Given transaction commits
+
+    Given connection open read transaction for database: typedb
+    When get answers of typeql read query
+      """
+      match
+      $p isa person;
+      try { $c isa company; $r isa employment ($p, $c); };
+      match
+      $p has name $name;
+      try { $c has name $company_name; };
+      """
+    Then uniquely identify answer concepts
+      | p          | c          | r          | name               | company_name   |
+      | key:ref:30 | key:ref:32 | key:ref:33 | attr:name:Grace    | attr:name:Uber |
+      | key:ref:31 | none       | none       | attr:name:Somebody | none           |

--- a/query/language/optional.feature
+++ b/query/language/optional.feature
@@ -300,3 +300,20 @@ Feature: TypeQL Optional
       | p          | c          | r          | name               | company_name   |
       | key:ref:30 | key:ref:32 | key:ref:33 | attr:name:Grace    | attr:name:Uber |
       | key:ref:31 | none       | none       | attr:name:Somebody | none           |
+
+    When get answers of typeql read query
+      """
+      match
+      $p isa person;
+      try { $c isa company; $r isa employment ($p, $c); };
+      match
+      try {
+        $p has name $name;
+        try { $c has name $company_name; };
+      };
+      """
+    Then uniquely identify answer concepts
+      | p          | c          | r          | name               | company_name   |
+      | key:ref:30 | key:ref:32 | key:ref:33 | attr:name:Grace    | attr:name:Uber |
+      | key:ref:31 | none       | none       | attr:name:Somebody | none           |
+

--- a/query/language/optional.feature
+++ b/query/language/optional.feature
@@ -317,3 +317,5 @@ Feature: TypeQL Optional
       | key:ref:30 | key:ref:32 | key:ref:33 | attr:name:Grace    | attr:name:Uber |
       | key:ref:31 | none       | none       | attr:name:Somebody | none           |
 
+  # TODO: Test out assigning to optionals  let $x? = f($y);
+  # TODO: Test out functions returning optionals: fun f(x) -> { person?, name };

--- a/query/language/pipelines.feature
+++ b/query/language/pipelines.feature
@@ -149,8 +149,8 @@ Feature: TypeQL pipelines
     limit 1;
     """
     Then uniquely identify answer concepts
-      | p         |
-      | key:ref:0 |
+      | p         | name            |
+      | key:ref:0 | attr:name:Alice |
 
     Given get answers of typeql read query
     """
@@ -160,8 +160,8 @@ Feature: TypeQL pipelines
     limit 1;
     """
     Then uniquely identify answer concepts
-      | p         |
-      | key:ref:1 |
+      | p         | name            |
+      | key:ref:1 | attr:name:Bob   |
 
 
   Scenario: Sort, offset, limit can be combined
@@ -264,6 +264,7 @@ Feature: TypeQL pipelines
       match
         $r isa naming (named: $p, name: $nc);
         $nc has name $n;
+      select $p, $n;
       """
     Then uniquely identify answer concepts
       | p         | n                 |

--- a/query/language/put.feature
+++ b/query/language/put.feature
@@ -355,6 +355,7 @@ Feature: TypeQL Put Query
     When get answers of typeql read query
     """
     match $p isa person, has name "bob", has email $email;
+    select $email;
     """
     Then uniquely identify answer concepts
       | email                     |
@@ -570,6 +571,7 @@ Feature: TypeQL Put Query
       $emp isa employment, links (employer: $company, employee: $person);
       $company has name $cname;
       $person has name $pname;
+    select $cname, $pname;
     """
     Then answer size is: 1
     Then uniquely identify answer concepts

--- a/query/language/put.feature
+++ b/query/language/put.feature
@@ -288,9 +288,9 @@ Feature: TypeQL Put Query
     put $p isa person, has $ref;
     """
     Then uniquely identify answer concepts
-      | p         |
-      | key:ref:0 |
-      | key:ref:1 |
+      | p         | ref        |
+      | key:ref:0 | attr:ref:0 |
+      | key:ref:1 | attr:ref:1 |
     When get answers of typeql read query
     """
     match $p isa person;
@@ -329,6 +329,7 @@ Feature: TypeQL Put Query
     When get answers of typeql read query
     """
     match $p isa person, has name "alice", has email $email;
+    select $email;
     """
     Then uniquely identify answer concepts
       | email                       |
@@ -503,7 +504,8 @@ Feature: TypeQL Put Query
     match
       $emp isa employment, links (employer: $company, employee: $person);
       $company isa company, has name $cname;
-      $person  isa person, has name $pname;
+      $person isa person, has name $pname;
+    select $cname, $pname;
     """
     Then uniquely identify answer concepts
       | cname            | pname           |
@@ -545,6 +547,7 @@ Feature: TypeQL Put Query
       $emp isa employment, links (employer: $company, employee: $person);
       $company has name $cname;
       $person has name $pname;
+    select $cname, $pname;
     """
     Then answer size is: 1
     Then uniquely identify answer concepts

--- a/query/language/reduce.feature
+++ b/query/language/reduce.feature
@@ -311,7 +311,7 @@ Feature: TypeQL Reduce Queries
       match $x isa person, has income $y;
       reduce $red_var? = <reduction>($y);
       """
-    Then result is a single row with variable 'red_var': empty
+    Then result is a single row with variable 'red_var': none
 
     Examples:
       | reduction |
@@ -642,5 +642,5 @@ Feature: TypeQL Reduce Queries
       """
     Then uniquely identify answer concepts
       | x         | std   |
-      | key:ref:0 | empty |
+      | key:ref:0 | none  |
 

--- a/query/language/update.feature
+++ b/query/language/update.feature
@@ -367,8 +367,8 @@ Feature: TypeQL Update Query
         $p has $n;
       """
     Then uniquely identify answer concepts
-      | p         |
-      | key:ref:0 |
+      | n                 | p         |
+      | attr:name:Charlie | key:ref:0 |
     When get answers of typeql read query
       """
       match $p isa person, has name $n;
@@ -1045,7 +1045,7 @@ Feature: TypeQL Update Query
       """
     Then uniquely identify answer concepts
       | sn                  | p         |
-      | attr:surname:Morgan | key:ref:0 |
+      | attr:surname:Marley | key:ref:0 |
     When get answers of typeql read query
       """
       match $p isa person, has name $n;

--- a/query/language/update.feature
+++ b/query/language/update.feature
@@ -329,8 +329,8 @@ Feature: TypeQL Update Query
         $p has $n;
       """
     Then uniquely identify answer concepts
-      | p              |
-      | key:name:Alice |
+      | p              | n               |
+      | key:name:Alice | attr:name:Alice |
     When get answers of typeql read query
       """
       match $p isa person, has name $n;
@@ -348,8 +348,8 @@ Feature: TypeQL Update Query
         $p has name == $n;
       """
     Then uniquely identify answer concepts
-      | p         |
-      | key:ref:0 |
+      | p         | n                |
+      | key:ref:0 | value:string:Bob |
     When get answers of typeql read query
       """
       match $p isa person, has name $n;
@@ -1044,8 +1044,8 @@ Feature: TypeQL Update Query
         $p has old-surname "Morgan";
       """
     Then uniquely identify answer concepts
-      | p         |
-      | key:ref:0 |
+      | sn                  | p         |
+      | attr:surname:Morgan | key:ref:0 |
     When get answers of typeql read query
       """
       match $p isa person, has name $n;


### PR DESCRIPTION
## Usage and product changes

We implement scenarios testing the functionality of optional reads, and add scenarios to verify the behaviour of disjunctions with regards to shared and non-shared variables in each branch.

Highlights:
 - Sibling optionals cannot share optional variables, though they can re-use any variables from parent scopes
 - Optionals can be nested
 - Optionals cannot be used in negations or disjunctions (at least until disjunctions can also return optional answers)
 - We call the value returned in a Variable when it is a failed optional `None`, instead of `empty`.

