### PR TITLE
Update BDD for empty define

### DIFF
--- a/driver/connection.feature
+++ b/driver/connection.feature
@@ -130,6 +130,7 @@ Feature: Driver Connection
     Given connection has database: typedb
     Then connection get database(typedb) has schema:
     """
+    define
     """
     Then connection get database(typedb) has type schema:
     """
@@ -154,9 +155,11 @@ Feature: Driver Connection
     """
     Then connection get database(typedb) has schema:
     """
+    define
     """
     Then connection get database(typedb) has type schema:
     """
+    define
     """
     When transaction commits
     Then connection get database(typedb) has schema:

--- a/driver/migration.feature
+++ b/driver/migration.feature
@@ -1107,7 +1107,10 @@ Feature: Driver Migration
     When connection get database(typedb) export to schema file(schema.tql), data file(data.typedb)
     Then file(schema.tql) exists
     Then file(data.typedb) exists
-    Then file(schema.tql) is empty
+    Then file(schema.tql) has schema:
+    """
+    define
+    """
     # Metadata still exists!
     Then file(data.typedb) is not empty
     Then connection import database(typedb-clone) from schema file(schema.tql), data file(data.typedb)


### PR DESCRIPTION
## Usage and product changes
Update connection & migration BDD to reflect empty `define` statements being valid (and used) TypeQL (typedb/typeql#412)

