### PR TITLE
Generalize error messages in migration tests

### DIFF
--- a/driver/migration.feature
+++ b/driver/migration.feature
@@ -1409,10 +1409,10 @@ Feature: Driver Migration
     When connection get database(typedb) export to schema file(typedb.tql), data file(typedb.typedb)
     When connection get database(untypedb) export to schema file(untypedb.tql), data file(untypedb.typedb)
     When connection get database(notypedb) export to schema file(notypedb.tql), data file(notypedb.typedb)
-    Then connection import database(newtypedb) from schema file(typedb.tql), data file(untypedb.typedb); fails with a message containing: "entity type 'name' does not exist"
-    Then connection import database(newtypedb) from schema file(untypedb.tql), data file(typedb.typedb); fails with a message containing: "entity type 'person' does not exist"
-    Then connection import database(newtypedb) from schema file(notypedb.tql), data file(typedb.typedb); fails with a message containing: "entity type 'person' does not exist"
-    Then connection import database(newtypedb) from schema file(notypedb.tql), data file(untypedb.typedb); fails with a message containing: "entity type 'name' does not exist"
+    Then connection import database(newtypedb) from schema file(typedb.tql), data file(untypedb.typedb); fails with a message containing: "'person' does not exist"
+    Then connection import database(newtypedb) from schema file(untypedb.tql), data file(typedb.typedb); fails with a message containing: "'name' does not exist"
+    Then connection import database(newtypedb) from schema file(notypedb.tql), data file(typedb.typedb); fails with a message containing: "'name' does not exist"
+    Then connection import database(newtypedb) from schema file(notypedb.tql), data file(untypedb.typedb); fails with a message containing: "'person' does not exist"
     Then connection import database(newtypedb) from schema file(typedb.tql), data file(typedb.typedb)
     Then connection import database(newuntypedb) from schema file(untypedb.tql), data file(untypedb.typedb)
     Then connection import database(newnotypedb) from schema file(notypedb.tql), data file(notypedb.typedb)

--- a/driver/migration.feature
+++ b/driver/migration.feature
@@ -1409,10 +1409,10 @@ Feature: Driver Migration
     When connection get database(typedb) export to schema file(typedb.tql), data file(typedb.typedb)
     When connection get database(untypedb) export to schema file(untypedb.tql), data file(untypedb.typedb)
     When connection get database(notypedb) export to schema file(notypedb.tql), data file(notypedb.typedb)
-    Then connection import database(newtypedb) from schema file(typedb.tql), data file(untypedb.typedb); fails with a message containing: "'person' does not exist"
-    Then connection import database(newtypedb) from schema file(untypedb.tql), data file(typedb.typedb); fails with a message containing: "'name' does not exist"
-    Then connection import database(newtypedb) from schema file(notypedb.tql), data file(typedb.typedb); fails with a message containing: "'name' does not exist"
-    Then connection import database(newtypedb) from schema file(notypedb.tql), data file(untypedb.typedb); fails with a message containing: "'person' does not exist"
+    Then connection import database(newtypedb) from schema file(typedb.tql), data file(untypedb.typedb); fails with a message containing: "' does not exist"
+    Then connection import database(newtypedb) from schema file(untypedb.tql), data file(typedb.typedb); fails with a message containing: "' does not exist"
+    Then connection import database(newtypedb) from schema file(notypedb.tql), data file(typedb.typedb); fails with a message containing: "' does not exist"
+    Then connection import database(newtypedb) from schema file(notypedb.tql), data file(untypedb.typedb); fails with a message containing: "' does not exist"
     Then connection import database(newtypedb) from schema file(typedb.tql), data file(typedb.typedb)
     Then connection import database(newuntypedb) from schema file(untypedb.tql), data file(untypedb.typedb)
     Then connection import database(newnotypedb) from schema file(notypedb.tql), data file(notypedb.typedb)


### PR DESCRIPTION
## Usage and product changes
Adopt error message assertions in migration tests to accommodate any order of server's type checks. This is required by a pull request that changes the order of item processing in core (https://github.com/typedb/typedb/pull/7955).

## Implementation

